### PR TITLE
fixes clicking on planet wasn't opening corresponding targets group

### DIFF
--- a/static_media/js/widgets.js
+++ b/static_media/js/widgets.js
@@ -243,8 +243,6 @@ var o_widgets = {
 
     // this is called after a widge is drawn
     customWidgetBehaviors: function(slug) {
-        var mult_id = '#mult_group_' + $(this).attr('value');
-
         switch(slug) {
 
             // planet checkboxes open target groupings:
@@ -252,10 +250,11 @@ var o_widgets = {
                 // user checks a planet box - open the corresponding target group
                 // adding a behavior: checking a planet box opens the corresponding targets
                 $('#search').on('change', '#widget__planet input:checkbox:checked', function() {
-                    // a planet is .chosen_columns, and its corresponding target is not already open
-                    $(mult_id).find('.indicator').addClass('fa-plus');
-                    $(mult_id).find('.indicator').removeClass('fa-minus');
-                    $(mult_id).next().slideDown("fast");
+                      // a planet is .chosen_columns, and its corresponding target is not already open
+                      var mult_id = '#mult_group_' + $(this).attr('value');
+                      $(mult_id).find('.indicator').addClass('fa-plus');
+                      $(mult_id).find('.indicator').removeClass('fa-minus');
+                      $(mult_id).next().slideDown("fast");
                 });
                 break;
 
@@ -264,6 +263,7 @@ var o_widgets = {
                 // usually for when a planet checkbox is checked on page load
                 $('#widget__planet input:checkbox:checked', '#search').each(function() {
                     if ($(this).attr('id') && $(this).attr('id').split('_')[0] == 'planet') { // confine to param/vals - not other input controls
+                        var mult_id = '#mult_group_' + $(this).attr('value');
                         $(mult_id).find('.indicator').addClass('fa-plus');
                         $(mult_id).find('.indicator').removeClass('fa-minus');
                         $(mult_id).next().slideDown("fast");
@@ -276,6 +276,7 @@ var o_widgets = {
                // usually for when a planet checkbox is checked on page load
                $('#widget__planet input:checkbox:checked', '#search').each(function() {
                    if ($(this).attr('id') && $(this).attr('id').split('_')[0] == 'planet') { // confine to param/vals - not other input controls
+                       var mult_id = '#mult_group_' + $(this).attr('value');
                        $(mult_id).find('.indicator').addClass('fa-plus');
                        $(mult_id).find('.indicator').removeClass('fa-minus');
                        $(mult_id).next().slideDown("fast");


### PR DESCRIPTION
Hello I noticed the targets were no longer opening when a planet is clicked so here is a fix for that. 