### PR TITLE
Api guide fix

### DIFF
--- a/apps/guide/examples.yaml
+++ b/apps/guide/examples.yaml
@@ -28,8 +28,8 @@ sections:
                 fmt: json,html,zip,csv
                 GET params: search params, limit, page
             examples:
-                - desc: planet = Jupiter, medium images, in html
-                  url: https://tools.pds-rings.seti.org/opus/api/images/med.html?planet=Jupiter
+                - desc: planet = Jupiter, medium images, in json
+                  url: https://tools.pds-rings.seti.org/opus/api/images/med.json?planet=Jupiter
 
           - title: api/image/[size]/[ring_obs_id]
             desc: get images for a single observation
@@ -37,8 +37,8 @@ sections:
                 size: thumb,small,med,full
                 ring_obs_id: valid ring_obs_id
             examples:
-                - desc: jupiter observation, full size, in html
-                  url: https://tools.pds-rings.seti.org/opus/api/image/full/J_IMG_GO_SSI_0520821213.html
+                - desc: jupiter observation, full size, in json
+                  url: https://tools.pds-rings.seti.org/opus/api/image/full/J_IMG_GO_SSI_0520821213.json
 
           - title: api/files/[ring_obs_id].[fmt]
             desc: get files for a single observation
@@ -55,8 +55,8 @@ sections:
                 fmt: json,html,zip,csv
                 GET params: search params, limit, page
             examples:
-                - desc: target Pan, in html
-                  url: https://tools.pds-rings.seti.org/opus/api/files.html?&target=pan
+                - desc: target Pan, in json
+                  url: https://tools.pds-rings.seti.org/opus/api/files.json?&target=pan
 
     - title: Getting Information about Data
       endpoints:
@@ -90,14 +90,14 @@ sections:
                 - desc: get ring radius endpoints for target Saturn
                   url: https://tools.pds-rings.seti.org/opus/api/meta/range/endpoints/ringradius1.json?target=Saturn
 
-          - title: api/fields/[field].[fmt]
-            desc: get information about a particular field
-            info:
-                field: field name or no
-                fmt: json,html,zip
-            examples:
-                - desc: get information about the planet field
-                  url: https://tools.pds-rings.seti.org/opus/api/fields/planet.json
+          # - title: api/fields/[field].[fmt]
+          #   desc: get information about a particular field
+          #   info:
+          #       field: field name or no
+          #       fmt: json,html,zip
+          #   examples:
+          #       - desc: get information about the planet field
+          #         url: https://tools.pds-rings.seti.org/opus/api/fields/planet.json
 
           - title: api/fields.[fmt]
             desc: get list of all fields
@@ -107,13 +107,13 @@ sections:
                 - desc: list of all fields in json
                   url: https://tools.pds-rings.seti.org/opus/api/fields.json
 
-          - title: api/category/[cat_name]
-            desc: get all fields in a category
-            info:
-                cat_name: category name
-            examples:
-                - desc: field names in Hubble Mission in json
-                  url: https://tools.pds-rings.seti.org/opus/api/category/hubble_mission.json
+          # - title: api/category/[cat_name]
+          #   desc: get all fields in a category
+          #   info:
+          #       cat_name: category name
+          #   examples:
+          #       - desc: field names in Hubble Mission in json
+          #         url: https://tools.pds-rings.seti.org/opus/api/category/hubble_mission.json
 
           - title: api/categories.[fmt]
             desc: list category names

--- a/static_media/js/widgets.js
+++ b/static_media/js/widgets.js
@@ -243,8 +243,6 @@ var o_widgets = {
 
     // this is called after a widge is drawn
     customWidgetBehaviors: function(slug) {
-        var mult_id = '#mult_group_' + $(this).attr('value');
-
         switch(slug) {
 
             // planet checkboxes open target groupings:
@@ -252,10 +250,11 @@ var o_widgets = {
                 // user checks a planet box - open the corresponding target group
                 // adding a behavior: checking a planet box opens the corresponding targets
                 $('#search').on('change', '#widget__planet input:checkbox:checked', function() {
-                    // a planet is .chosen_columns, and its corresponding target is not already open
-                    $(mult_id).find('.indicator').addClass('fa-plus');
-                    $(mult_id).find('.indicator').removeClass('fa-minus');
-                    $(mult_id).next().slideDown("fast");
+                      // a planet is .chosen_columns, and its corresponding target is not already open
+                      var mult_id = '#mult_group_' + $(this).attr('value');
+                      $(mult_id).find('.indicator').addClass('fa-plus');
+                      $(mult_id).find('.indicator').removeClass('fa-minus');
+                      $(mult_id).next().slideDown("fast");
                 });
                 break;
 
@@ -264,6 +263,7 @@ var o_widgets = {
                 // usually for when a planet checkbox is checked on page load
                 $('#widget__planet input:checkbox:checked', '#search').each(function() {
                     if ($(this).attr('id') && $(this).attr('id').split('_')[0] == 'planet') { // confine to param/vals - not other input controls
+                        var mult_id = '#mult_group_' + $(this).attr('value');
                         $(mult_id).find('.indicator').addClass('fa-plus');
                         $(mult_id).find('.indicator').removeClass('fa-minus');
                         $(mult_id).next().slideDown("fast");
@@ -276,6 +276,7 @@ var o_widgets = {
                // usually for when a planet checkbox is checked on page load
                $('#widget__planet input:checkbox:checked', '#search').each(function() {
                    if ($(this).attr('id') && $(this).attr('id').split('_')[0] == 'planet') { // confine to param/vals - not other input controls
+                       var mult_id = '#mult_group_' + $(this).attr('value');
                        $(mult_id).find('.indicator').addClass('fa-plus');
                        $(mult_id).find('.indicator').removeClass('fa-minus');
                        $(mult_id).next().slideDown("fast");


### PR DESCRIPTION
this is more or less a copyedit of the [API guide page](https://tools.pds-rings.seti.org/opus/api/) : 

- commented out 2 examples for having broken links, but I think they were rather obscure examples so not sure it's worth filing an issue for them.

- changes any html examples to json instead because it looks like in html endpoints the link urls are not getting the base path, so they aren't displaying in the browser, but pretty sure no one (including opus) uses those endpoints (except maybe me in some past keynote slide!) 