### PR TITLE
Getting sent back to top #454

### DIFF
--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -86,7 +86,7 @@ var o_browse = {
             }
 
             // reset scroll position
-            window.scroll(0,opus.browse_view_scrolls[showing]); // restore previous scroll position
+            window.scrollTo(0,opus.browse_view_scrolls[showing]); // restore previous scroll position
 
             return false;
         });
@@ -868,7 +868,7 @@ var o_browse = {
             }
             // total pages indicator
             $('#' + prefix + 'pages', namespace).html(opus[prefix + 'pages']);
-            window.scroll(0,0);  // sometimes you have scrolled down the search tab
+            window.scrollTo(0,opus.browse_view_scrolls[prefix + view_var]);  // sometimes you have scrolled down the search tab
           });
         }
 
@@ -878,13 +878,11 @@ var o_browse = {
 
             // get table headers for table view
             if (!opus.table_headers_drawn) {
-                window.scroll(0,0);  // sometimes you have scrolled down in the search tab
+                window.scrollTo(0,0);  // sometimes you have scrolled down in the search tab
                 o_browse.startDataTable(namespace);
                 return; // startDataTable() starts data table and then calls getBrowseTab again
             }
         }
-        var url = o_hash.getHash() + '&reqno=' + opus.lastRequestNo + add_to_url;
-
         var footer_clicks = opus.browse_footer_clicks[prefix + view_var]; // default: {'gallery':0, 'data':0, 'colls_gallery':0, 'colls_data':0 };
 
         // figure out the page
@@ -921,6 +919,13 @@ var o_browse = {
                 }
             }
         }
+
+        var url = o_hash.getHash() + '&reqno=' + opus.lastRequestNo + add_to_url;
+
+        // remove any existing page= slug before adding in the current page= slug w/new page number
+        url = $.grep(url.split('&'), function(pair, index) {
+          return !pair.startsWith("page");
+        }).join('&');
 
         url += '&page=' + page;
 
@@ -1259,7 +1264,7 @@ var o_browse = {
     // if they match, it triggers refresh, if not then the user is still typing so moves on
     textInputMonitor: function() {
         // which field are we working on? defines which global monitor list we use
-        var ms = 1500;
+        var ms = 750; // original value of 1.5 sec too long
 
         var view_info = o_browse.getViewInfo();
         var namespace = view_info['namespace']; // either '#collection' or '#browse'

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -338,7 +338,7 @@ var opus = {
         switch(opus.prefs.view) {
 
             case 'search':
-                window.scroll(0,0);
+                window.scrollTo(0,0);
                 $('#search').fadeIn();
                 o_search.getSearchTab();
                 break;


### PR DESCRIPTION
Instead of setting the scrollbar to the 0 position, reset the scrollbar to the saved position in the opus global to preserve the current scroll.  Also updated deprecated method window.scroll(..) to window.scrollTo(..) to avoid using deprecated functions.  Lastly, changed the prev/next timeout to wait for data retrieve from 1.5 sec to 750ms because 1.5 sec seemed too long.  The blinking of the page number is still happening but that will likely go away w/rewrite and is fairly benign, although annoying.