### PR TITLE
Test branch

### DIFF
--- a/opus/application/apps/search/forms.py
+++ b/opus/application/apps/search/forms.py
@@ -150,12 +150,20 @@ class SearchForm(forms.Form):
                 else:
                     choices = [(mult.label, mult.label) for mult in model.objects.filter(display='Y').order_by('disp_order')]
 
-                self.fields[slug] = forms.MultipleChoiceField(
-                        # label = ParamInfo.objects.get(slug=slug).label,
-                        label = '',
-                        choices = choices,
-                        widget = forms.CheckboxSelectMultiple(attrs={'class':'multichoice'}),
-                        required=False)
+                if param_name == 'obs_surface_geometry.target_name':
+                    self.fields[slug] = forms.ChoiceField(
+                            # label = ParamInfo.objects.get(slug=slug).label,
+                            label = '',
+                            choices = choices,
+                            widget = forms.RadioSelect(attrs={'class':'multichoice'}),
+                            required=False)
+                else:
+                    self.fields[slug] = forms.MultipleChoiceField(
+                            # label = ParamInfo.objects.get(slug=slug).label,
+                            label = '',
+                            choices = choices,
+                            widget = forms.CheckboxSelectMultiple(attrs={'class':'multichoice'}),
+                            required=False)
 
         # XXX RF - This is awful. It takes the last form_type from the above loop, but
         # is it possible the loop went more than once??

--- a/opus/application/apps/search/forms.py
+++ b/opus/application/apps/search/forms.py
@@ -155,7 +155,7 @@ class SearchForm(forms.Form):
                             # label = ParamInfo.objects.get(slug=slug).label,
                             label = '',
                             choices = choices,
-                            widget = forms.RadioSelect(attrs={'class':'multichoice'}),
+                            widget = forms.RadioSelect(attrs={'class':'singlechoice'}),
                             required=False)
                 else:
                     self.fields[slug] = forms.MultipleChoiceField(

--- a/opus/application/apps/tools/app_utils.py
+++ b/opus/application/apps/tools/app_utils.py
@@ -265,7 +265,7 @@ def get_mult_name(param_name):
 def format_metadata_number(val, form_type_format):
     if form_type_format is None:
         return val
-    if abs(val) > settings.THRESHOLD_FOR_EXPONENTIAL:
+    if val is not None and abs(val) > settings.THRESHOLD_FOR_EXPONENTIAL:
         form_type_format = form_type_format.replace('f', 'e')
     try:
         return format(val, form_type_format)

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -94,7 +94,7 @@ var o_widgets = {
                   opus.selections[id] = [value];
                } else {
                   // add the new value to the array of values
-                  values[values.length] = value;
+                  values.push(value);
                   // add the array of values to selections
                   opus.selections[id] = values;
                }

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -57,7 +57,6 @@ var o_widgets = {
             }
         });
 
-
         // mult widget behaviors - user clicks a multi-select checkbox
 
         /***********************************************************/
@@ -65,7 +64,7 @@ var o_widgets = {
         /**** OR move all those behaviors into here because wtf ****/
         /***********************************************************/
 
-        $('#search').on('change', 'input.multichoice', function() {
+        $('#search').on('change', 'input.multichoice, input.singlechoice', function() {
            // mult widget gets changed
            var id = $(this).attr("id").split('_')[0];
            var value = $(this).attr("value").replace(/\+/g, '%2B');
@@ -76,8 +75,15 @@ var o_widgets = {
                    var values = opus.selections[id]; // this param already has been constrained
                }
 
-               values[values.length] = value;    // add the new value to the array of values
-               opus.selections[id] = values;     // add the array of values to selections
+               // for surfacegeometry we only want a target selected
+               if (id === 'surfacegeometrytargetname') {
+                  opus.selections[id] = [value];
+               } else {
+                  // add the new value to the array of values
+                  values[values.length] = value;
+                  // add the array of values to selections
+                  opus.selections[id] = values;
+               }
 
                // special menu behavior for surface geo, slide in a loading indicator..
                if (id == 'surfacetarget') {

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -57,6 +57,20 @@ var o_widgets = {
             }
         });
 
+        // close opened surfacegeo widget if user select another surfacegeo target
+        $('#search').on('change', 'input.singlechoice', function() {
+          $('a[data-slug^="SURFACEGEO"]').each( function (index) {
+            let slug = $(this).data('slug');
+            o_widgets.closeWidget(slug);
+            try {
+              var id = "#widget__"+slug;
+              $(id).remove();
+            } catch (e) {
+              console.log("error on close widget, id="+id);
+            }
+          });
+        });
+
         // mult widget behaviors - user clicks a multi-select checkbox
 
         /***********************************************************/


### PR DESCRIPTION
# Modifications related to Issue #303:
# search/forms.py
  * Use RadioSelect widget when we are selecting surfacegeometry target so that only one surfacegeometry target can be selected at a time.
# widgets.js
  * Attached event handler to radio button selection for surfacegeometry target 
    * Modify the logic a little bit so that only one value is passed in for surfacegeometrytargetname when running api call on /opus/__api/meta/result_count.json (previously multiple target names can be assigned to the slug and it would fail to query the database since only one is allowed)
  * Add another on change event handler to close all opened surfacegeometry widgets when user changes to another surfacegeo target (previously we have to manually close all related surfacegeometry widgets)
# tools/app_utils.py
  * Add a check to make sure val is not None before passing it into abs() so that we don't get error sometimes when val is None