### PR TITLE
Bug569 empty string issue

### DIFF
--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -8,13 +8,14 @@ var o_search = {
     searchMsg: "",
     truncatedResults: false,
     truncatedResultsMsg: "&ltMore choices available&gt",
+    slugStringSearchChoicesReqno: {},
     slugNormalizeReqno: {},
     slugRangeInputValidValueFromLastSearch: {},
     allNormalizedApiCall: function() {
         let newHash = o_hash.updateHash(false);
         /*
         We are relying on URL order now to parse and get slugs before "&view" in the URL
-        Opus would rewrite the URL when a URL is pasted, all the search related slugs would be moved ahead of "&view"
+        Opus will rewrite the URL when a URL is pasted, all the search related slugs would be moved ahead of "&view"
         Refer to hash.js getSelectionsFromHash and updateHash functions
         */
         let regexForHashWithSearchParams = /(.*)&view/;
@@ -75,15 +76,20 @@ var o_search = {
             }
         }
     },
-    parseFinalNormalizedInputDataAndUpdateHash: function(event, slug, url) {
+    parseFinalNormalizedInputDataAndUpdateHash: function(slug, url) {
         $.getJSON(url, function(normalizedInputData) {
             // Make sure it's the final call before parsing normalizedInputData
+            console.log("RETURN")
+            console.log(o_search.slugNormalizeReqno)
+            console.log(o_search.slugNormalizeReqno[slug])
+            console.log(normalizedInputData);
             if(normalizedInputData["reqno"] < o_search.slugNormalizeReqno[slug]) {
                 return;
             }
 
             // check each range input, if it's not valid, change its background to red
             o_search.validateRangeInput(normalizedInputData);
+            console.log("OPUS ALL INPUT VALID: " + opus.allInputsValid);
             if(!opus.allInputsValid) {
                 return;
             }
@@ -260,7 +266,7 @@ var o_search = {
             let newHash = o_hash.updateHash(false);
             /*
             We are relying on URL order now to parse and get slugs before "&view" in the URL
-            Opus would rewrite the URL when a URL is pasted, all the search related slugs would be moved ahead of "&view"
+            Opus will rewrite the URL when a URL is pasted, all the search related slugs would be moved ahead of "&view"
             Refer to hash.js getSelectionsFromHash and updateHash functions
             */
             let regexForHashWithSearchParams = /(.*)&view/;
@@ -274,12 +280,13 @@ var o_search = {
             if($(event.target).hasClass("input_currently_focused")) {
                 $(event.target).removeClass("input_currently_focused");
             }
-            o_search.parseFinalNormalizedInputDataAndUpdateHash(event, slug, url);
+            o_search.parseFinalNormalizedInputDataAndUpdateHash(slug, url);
         });
 
         // filling in a range or string search field = update the hash
         // range behaviors and string behaviors for search widgets - input box
-        $('#search').on('change', 'input.STRING', function() {
+        $('#search').on('change', 'input.STRING', function(event) {
+            console.log("CURRENT CHANGE EVENT STRING VAL: " + $(this).val());
             let slug = $(this).attr("name");
             let css_class = $(this).attr("class").split(' ')[0]; // class will be STRING, min or max
 
@@ -320,7 +327,7 @@ var o_search = {
             let newHash = o_hash.updateHash(false);
             /*
             We are relying on URL order now to parse and get slugs before "&view" in the URL
-            Opus would rewrite the URL when a URL is pasted, all the search related slugs would be moved ahead of "&view"
+            Opus will rewrite the URL when a URL is pasted, all the search related slugs would be moved ahead of "&view"
             Refer to hash.js getSelectionsFromHash and updateHash functions
             */
             let regexForHashWithSearchParams = /(.*)&view/;
@@ -330,8 +337,11 @@ var o_search = {
             opus.lastSlugNormalizeRequestNo++;
             o_search.slugNormalizeReqno[slug] = opus.lastSlugNormalizeRequestNo;
             let url = "/opus/__api/normalizeinput.json?" + newHash + "&reqno=" + opus.lastSlugNormalizeRequestNo;
-
-            o_search.parseFinalNormalizedInputDataAndUpdateHash(event, slug, url);
+            console.log("CHANGE BEFORE CALLING API")
+            console.log(o_search.slugNormalizeReqno)
+            console.log(o_search.slugNormalizeReqno[slug])
+            console.log("CHANGE EVENT API URL: " + url);
+            o_search.parseFinalNormalizedInputDataAndUpdateHash(slug, url);
         });
 
         // range behaviors and string behaviors for search widgets - qtype select dropdown

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -79,17 +79,12 @@ var o_search = {
     parseFinalNormalizedInputDataAndUpdateHash: function(slug, url) {
         $.getJSON(url, function(normalizedInputData) {
             // Make sure it's the final call before parsing normalizedInputData
-            console.log("RETURN")
-            console.log(o_search.slugNormalizeReqno)
-            console.log(o_search.slugNormalizeReqno[slug])
-            console.log(normalizedInputData);
             if(normalizedInputData["reqno"] < o_search.slugNormalizeReqno[slug]) {
                 return;
             }
 
             // check each range input, if it's not valid, change its background to red
             o_search.validateRangeInput(normalizedInputData);
-            console.log("OPUS ALL INPUT VALID: " + opus.allInputsValid);
             if(!opus.allInputsValid) {
                 return;
             }
@@ -286,7 +281,6 @@ var o_search = {
         // filling in a range or string search field = update the hash
         // range behaviors and string behaviors for search widgets - input box
         $('#search').on('change', 'input.STRING', function(event) {
-            console.log("CURRENT CHANGE EVENT STRING VAL: " + $(this).val());
             let slug = $(this).attr("name");
             let css_class = $(this).attr("class").split(' ')[0]; // class will be STRING, min or max
 
@@ -323,6 +317,12 @@ var o_search = {
                 }
                 opus.selections[slug_no_num + '2'] = values;
             }
+
+            if(opus.last_selections && opus.last_selections[slug]) {
+                if(opus.last_selections[slug][0] === $(this).val().trim()) {
+                    return;
+                }
+            }
             // make a normalized call to avoid changing url whenever there is an invalid range input value
             let newHash = o_hash.updateHash(false);
             /*
@@ -337,10 +337,6 @@ var o_search = {
             opus.lastSlugNormalizeRequestNo++;
             o_search.slugNormalizeReqno[slug] = opus.lastSlugNormalizeRequestNo;
             let url = "/opus/__api/normalizeinput.json?" + newHash + "&reqno=" + opus.lastSlugNormalizeRequestNo;
-            console.log("CHANGE BEFORE CALLING API")
-            console.log(o_search.slugNormalizeReqno)
-            console.log(o_search.slugNormalizeReqno[slug])
-            console.log("CHANGE EVENT API URL: " + url);
             o_search.parseFinalNormalizedInputDataAndUpdateHash(slug, url);
         });
 

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -644,19 +644,24 @@ var o_widgets = {
                      return false;
                  },
              })
-             .change(function(blurEvent) {
-                 console.log("AUTOCOMPLETE change");
-             })
              .keyup(function(keyupEvent) {
-                 // Make sure autocomplete dropdown list is closed when enter key is pressed
+                 /*
+                 When "enter" key is pressed:
+                 (1) autocomplete dropdown list is closed
+                 (2) change event is triggered if input is an empty string
+                 */
                  if(keyupEvent.which === 13) {
                      $(`input[name="${slug}"]`).autocomplete("close");
                      let currentStringInputValue = $(`input[name="${slug}"]`).val().trim();
-                     // if(currentStringInputValue === "") {
-                     //   $(`input[name="${slug}"]`).trigger("change");
-                     //   // opus.selections[slug] = [currentStringInputValue];
-                     //   // o_hash.updateHash();
-                     // }
+                     if(currentStringInputValue === "") {
+                         $(`input[name="${slug}"]`).trigger("change");
+                     }
+                 }
+             })
+             .focusout(function(focusoutEvent) {
+                 let currentStringInputValue = $(`input[name="${slug}"]`).val().trim();
+                 if(currentStringInputValue === "") {
+                     $(`input[name="${slug}"]`).trigger("change");
                  }
              })
              .data( "ui-autocomplete" );

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -596,14 +596,14 @@ var o_widgets = {
                      let values = [];
 
                      opus.lastRequestNo++;
-                     o_search.slugNormalizeReqno[slug] = opus.lastRequestNo;
+                     o_search.slugStringSearchChoicesReqno[slug] = opus.lastRequestNo;
 
                      values.push(currentValue)
                      opus.selections[slug] = values;
                      let newHash = o_hash.updateHash(false);
                      /*
                      We are relying on URL order now to parse and get slugs before "&view" in the URL
-                     Opus would rewrite the URL when a URL is pasted, all the search related slugs would be moved ahead of "&view"
+                     Opus will rewrite the URL when a URL is pasted, all the search related slugs would be moved ahead of "&view"
                      Refer to hash.js getSelectionsFromHash and updateHash functions
                      */
                      let regexForHashWithSearchParams = /(.*)&view/;
@@ -616,7 +616,7 @@ var o_widgets = {
                      }
                      let url = `/opus/__api/stringsearchchoices/${slug}.json?` + newHash + "&reqno=" + opus.lastRequestNo;
                      $.getJSON(url, function(stringSearchChoicesData) {
-                         if(stringSearchChoicesData["reqno"] < o_search.slugNormalizeReqno[slug]) {
+                         if(stringSearchChoicesData["reqno"] < o_search.slugStringSearchChoicesReqno[slug]) {
                              return;
                          }
 
@@ -637,16 +637,26 @@ var o_widgets = {
                  select: function(selectEvent, ui) {
                      let displayValue = o_search.extractHtmlContent(ui.item.label);
                      $(`input[name="${slug}"]`).val(displayValue);
+                     $(`input[name="${slug}"]`).trigger("change");
                      // If an item in the list is selected, we update the hash with selected value
-                     opus.selections[slug] = [displayValue];
-                     o_hash.updateHash();
+                     // opus.selections[slug] = [displayValue];
+                     // o_hash.updateHash();
                      return false;
                  },
+             })
+             .change(function(blurEvent) {
+                 console.log("AUTOCOMPLETE change");
              })
              .keyup(function(keyupEvent) {
                  // Make sure autocomplete dropdown list is closed when enter key is pressed
                  if(keyupEvent.which === 13) {
                      $(`input[name="${slug}"]`).autocomplete("close");
+                     let currentStringInputValue = $(`input[name="${slug}"]`).val().trim();
+                     // if(currentStringInputValue === "") {
+                     //   $(`input[name="${slug}"]`).trigger("change");
+                     //   // opus.selections[slug] = [currentStringInputValue];
+                     //   // o_hash.updateHash();
+                     // }
                  }
              })
              .data( "ui-autocomplete" );


### PR DESCRIPTION
* Modification
  * Fixed Issue #569. Now search can be performed with empty string. 
    * Previously if user has some valid value in string inputs, the following steps can reproduce the issue: 
      * Holds backspace to delete all valid values
      * Hits enter or leaves focus quickly
      * Sometimes search will not run
    * Now the issue is fixed, verified on both Firefox and Chrome
  * Firefox string input search issue is also fixed. 