### PR TITLE
String hints issues

### DIFF
--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -278,6 +278,10 @@ var o_search = {
             o_search.parseFinalNormalizedInputDataAndUpdateHash(slug, url);
         });
 
+        // $("input.STRING").on("scroll", "#mCSB_1_container", function() {
+        //     console.log("scrolling");
+        // });
+
         // filling in a range or string search field = update the hash
         // range behaviors and string behaviors for search widgets - input box
         $('#search').on('change', 'input.STRING', function(event) {

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -41,21 +41,27 @@ var o_search = {
                     currentInput.val(opus.selections[eachSlug]);
                     opus.allInputsValid = false;
                 }
+                if(currentInput.hasClass("input_currently_focused")) {
+                    delete opus.selections[eachSlug];
+                }
             } else {
-                if(currentInput.hasClass("RANGE") && !currentInput.hasClass("input_currently_focused")) {
-                    currentInput.val(value);
-                    o_search.slugRangeInputValidValueFromLastSearch[eachSlug] = value;
-                    // No color border if the input value is valid
-                    currentInput.addClass("search_input_original");
-                    currentInput.removeClass("search_input_invalid_no_focus");
-                    currentInput.removeClass("search_input_invalid");
-                    currentInput.removeClass("search_input_valid");
+                if(currentInput.hasClass("RANGE")) {
+                    if(currentInput.hasClass("input_currently_focused") && currentInput.val() !== value) {
+                        delete opus.selections[eachSlug];
+                    } else {
+                        currentInput.val(value);
+                        o_search.slugRangeInputValidValueFromLastSearch[eachSlug] = value;
+                        // No color border if the input value is valid
+                        currentInput.addClass("search_input_original");
+                        currentInput.removeClass("search_input_invalid_no_focus");
+                        currentInput.removeClass("search_input_invalid");
+                        currentInput.removeClass("search_input_valid");
+                    }
                 }
             }
-            if(currentInput.hasClass("input_currently_focused")) {
-                delete opus.selections[eachSlug];
-            }
+
         });
+
         if(!opus.allInputsValid) {
             $("#result_count").text("?");
             // set hinting info to ? when any range input has invalid value

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -63,7 +63,6 @@ var o_search = {
                     }
                 }
             }
-
         });
 
         if(!opus.allInputsValid) {

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -287,10 +287,6 @@ var o_search = {
             o_search.parseFinalNormalizedInputDataAndUpdateHash(slug, url);
         });
 
-        // $("input.STRING").on("scroll", "#mCSB_1_container", function() {
-        //     console.log("scrolling");
-        // });
-
         // filling in a range or string search field = update the hash
         // range behaviors and string behaviors for search widgets - input box
         $('#search').on('change', 'input.STRING', function(event) {

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -41,12 +41,8 @@ var o_search = {
                     currentInput.val(opus.selections[eachSlug]);
                     opus.allInputsValid = false;
                 }
-
-                if(currentInput.hasClass("input_currently_focused")) {
-                    delete opus.selections[eachSlug];
-                }
             } else {
-                if(currentInput.hasClass("RANGE")) {
+                if(currentInput.hasClass("RANGE") && !currentInput.hasClass("input_currently_focused")) {
                     currentInput.val(value);
                     o_search.slugRangeInputValidValueFromLastSearch[eachSlug] = value;
                     // No color border if the input value is valid
@@ -55,6 +51,9 @@ var o_search = {
                     currentInput.removeClass("search_input_invalid");
                     currentInput.removeClass("search_input_valid");
                 }
+            }
+            if(currentInput.hasClass("input_currently_focused")) {
+                delete opus.selections[eachSlug];
             }
         });
         if(!opus.allInputsValid) {

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -46,6 +46,10 @@ var o_search = {
                 }
             } else {
                 if(currentInput.hasClass("RANGE")) {
+                    /*
+                    If Current focused input value is different from returned normalized data
+                    it will be excluded from the search parameters because user is trying to input a new value
+                    */
                     if(currentInput.hasClass("input_currently_focused") && currentInput.val() !== value) {
                         delete opus.selections[eachSlug];
                     } else {

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -34,24 +34,25 @@ var o_search = {
         $.each(normalizedInputData, function(eachSlug, value) {
             let currentInput = $(`input[name="${eachSlug}"]`);
             if(value === null) {
-                if(currentInput.hasClass("RANGE") && !currentInput.hasClass("input_currently_focused")) {
-                    $("#sidebar").addClass("search_overlay");
-                    currentInput.addClass("search_input_invalid_no_focus");
-                    currentInput.removeClass("search_input_invalid");
-                    currentInput.val(opus.selections[eachSlug]);
-                    opus.allInputsValid = false;
+                if(currentInput.hasClass("RANGE")) {
+                    if(currentInput.hasClass("input_currently_focused")) {
+                        $("#sidebar").addClass("search_overlay");
+                    } else {
+                        $("#sidebar").addClass("search_overlay");
+                        currentInput.addClass("search_input_invalid_no_focus");
+                        currentInput.removeClass("search_input_invalid");
+                        currentInput.val(opus.selections[eachSlug]);
+                    }
                 }
-                if(currentInput.hasClass("input_currently_focused")) {
-                    delete opus.selections[eachSlug];
-                }
+                opus.allInputsValid = false;
             } else {
                 if(currentInput.hasClass("RANGE")) {
                     /*
-                    If Current focused input value is different from returned normalized data
-                    it will be excluded from the search parameters because user is trying to input a new value
+                    If current focused input value is different from returned normalized data
+                    we will not overwrite its displayed value.
                     */
                     if(currentInput.hasClass("input_currently_focused") && currentInput.val() !== value) {
-                        delete opus.selections[eachSlug];
+                        o_search.slugRangeInputValidValueFromLastSearch[eachSlug] = value;
                     } else {
                         currentInput.val(value);
                         o_search.slugRangeInputValidValueFromLastSearch[eachSlug] = value;

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -25,7 +25,6 @@ var o_widgets = {
             scrollInertia:300,
             callbacks:{
                 onScroll:function(){
-                    console.log("scrolling");
                     $("input.STRING").autocomplete("close");
                 }
             }
@@ -595,6 +594,7 @@ var o_widgets = {
              }
 
              // If we have a string input widget open, initialize autocomplete for string input
+             let displayDropDownList = true;
              let stringInputDropDown = $(`input[name="${slug}"].STRING`).autocomplete({
                  minLength: 1,
                  source: function(request, response) {
@@ -634,7 +634,7 @@ var o_widgets = {
 
                          let hintsOfString = stringSearchChoicesData["choices"];
                          o_search.truncatedResults = stringSearchChoicesData["truncated_results"];
-                         response(hintsOfString);
+                         response(displayDropDownList ? hintsOfString : null);
                      });
                  },
                  focus: function(focusEvent, ui) {
@@ -649,6 +649,9 @@ var o_widgets = {
                      // o_hash.updateHash();
                      return false;
                  },
+                 // search: function(searchEvent, ui) {
+                 //     console.log(searchEvent);
+                 // }
              })
              .keyup(function(keyupEvent) {
                  /*
@@ -657,11 +660,14 @@ var o_widgets = {
                  (2) change event is triggered if input is an empty string
                  */
                  if(keyupEvent.which === 13) {
+                     displayDropDownList = false;
                      $(`input[name="${slug}"]`).autocomplete("close");
                      let currentStringInputValue = $(`input[name="${slug}"]`).val().trim();
                      if(currentStringInputValue === "") {
                          $(`input[name="${slug}"]`).trigger("change");
                      }
+                 } else {
+                     displayDropDownList = true;
                  }
              })
              .focusout(function(focusoutEvent) {

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -24,7 +24,7 @@ var o_widgets = {
             theme:"rounded-dark",
             scrollInertia:300,
             callbacks:{
-                onScroll:function(){
+                onScrollStart:function(){
                     $("input.STRING").autocomplete("close");
                 }
             }

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -23,6 +23,12 @@ var o_widgets = {
         $(".widget_column").mCustomScrollbar({
             theme:"rounded-dark",
             scrollInertia:300,
+            callbacks:{
+                onScroll:function(){
+                    console.log("scrolling");
+                    $("input.STRING").autocomplete("close");
+                }
+            }
         });
         $(".sidebar_wrapper").mCustomScrollbar({
             theme:"rounded-dark",


### PR DESCRIPTION
# Modifications:
* Issue #573 
  * Now if the focused range input value is changed between calling final normalized api and waiting for return of api call, that input will not be treated as one of the search parameters because user is still typing a new value. When user finishes typing the value in focused range input, it will be treated as search parameter if user leaves focus or hits enter.
  * Test Scenario:
    * Open "Observation Duration", and type "12" in min and "5100" in max
    * Open "Right Ascension", and type "3" in min
    * Quickly (or add api delay) leaves focus from "Right Ascension" min to "Observation Duration" min, and change "Observation Duration" min to "14"
    * "Observation Duration" min will have green border and search will be run with "5100" in "Observation Duration" max and "3" in "Right Ascension" min. "Observation Duration" min will be excluded because user is in focus there and trying to type a new value.
    * Change focus from "Observation Duration" min to max, and don't type anything.
    * Search will be run with "5100" in "Observation Duration" max "14" in "Observation Duration" min and "3" in "Right Ascension" min because user didn't change value in "Observation Duration" max.
* Issue #574 
  * Add a parameter "displayDropDownList" to deal with the source of the dropdown list (coming from an ajax return)
  * Test Scenario:
    * Open "Product ID" and type "1", select any of items in dropdown lists to perform the search
    * Hold backspace all the way until the value is "1/" and hit enter real quick (or add api delay)
    * Search will be run when enter is hit, and there will be no dropdown list shown
* Issue #575 
  * Now if the widget column window is scrolling, the string hints list will disappear
  * Test Scenario:
    * Open "Product ID" and type "1", string hints dropdown list will show up
    * Scroll the widget column window, and the dropdown list will disappear (even with only 1 scroll, it will disappear)