### PR TITLE
New ui dave

### DIFF
--- a/opus/application/apps/ui/templates/base.html
+++ b/opus/application/apps/ui/templates/base.html
@@ -136,9 +136,9 @@
                         <div class="row dataTable browse-infiniteScroll-element mx-0">
                             <div class="col-lg p-0">
                             <!-- <div class="col-lg pr-0"> -->
-                                <div class="table-page-load-status">
+                                <!-- <div class="page-loading-status">
                                     <div class="loader"></div>
-                                </div>
+                                </div> -->
                                 <table id="dataTable" class="table table-hover table-bordered table-striped table-dark table-sm">
                                     <thead>
                                         <tr></tr>
@@ -146,6 +146,9 @@
                                     <tbody></tbody>
                                 </table>
                             </div>
+                        </div>
+                        <div class="page-loading-status">
+                            <div class="loader"></div>
                         </div>
                     </div>
                 </div>

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -428,7 +428,7 @@ th.sticky-header {
 /* Fix the spinner*/
 .table-page-load-status .loader {
     display: none;
-    top: 250px;
+    /* top: 250px; */
 }
 
 .fadey {
@@ -899,6 +899,7 @@ li a.search-param:hover {
     display:inline-block;
     background-repeat: no-repeat;
 }
+
 #cart_summary .spinner {
     display:none;
     margin:0px 10px;

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -426,7 +426,7 @@ th.sticky-header {
 
 
 /* Fix the spinner*/
-.table-page-load-status .loader {
+.page-loading-status .loader {
     display: none;
     /* top: 250px; */
 }

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -133,7 +133,6 @@ var o_browse = {
         // browse sort order - flip sort order of a slug
         $(".sort-contents").on("click", "li .flip-sort", function() {
             $(".table-page-load-status > .loader").show();
-            console.log("click pill sort")
             let slug = $(this).parent().attr("data-slug");
             let descending = $(this).parent().attr("data-descending");
             o_browse.tableSorting = true;
@@ -146,11 +145,9 @@ var o_browse = {
             }
             let slugIndex = $.inArray(slug, opus.prefs.order);
             if (slugIndex >= 0) {
-                console.log("here?")
                 // The clicked-on slug should always be in the order list; this is just a safety precaution
                 opus.prefs.order[slugIndex] = new_slug;
             }
-            console.log(opus.prefs["order"])
             o_hash.updateHash();
             // o_browse.updatePage();
             o_browse.renderSortedDataFromBeginning();
@@ -1194,7 +1191,6 @@ var o_browse = {
             }
 
             if (!opus.gallery_begun) {
-                console.log("re-draw from beginning")
                 o_browse.initTable(data.columns);
 
                 if (!$(selector).data("infiniteScroll")) {

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -112,7 +112,7 @@ var o_browse = {
 
         // browse sort order - remove sort slug
         $(".sort-contents").on("click", "li .remove-sort", function() {
-            $(".table-page-load-status > .loader").show();
+            $(".page-loading-status > .loader").show();
             let slug = $(this).parent().attr("data-slug");
             let descending = $(this).parent().attr("data-descending");
             o_browse.tableSorting = true;
@@ -132,7 +132,7 @@ var o_browse = {
 
         // browse sort order - flip sort order of a slug
         $(".sort-contents").on("click", "li .flip-sort", function() {
-            $(".table-page-load-status > .loader").show();
+            $(".page-loading-status > .loader").show();
             let slug = $(this).parent().attr("data-slug");
             let descending = $(this).parent().attr("data-descending");
             o_browse.tableSorting = true;
@@ -307,8 +307,8 @@ var o_browse = {
         // click table column header to reorder by that column
         $("#browse").on("click", ".dataTable th a",  function() {
             // show this spinner right away when table is clicked
-            // we will hide page status loader from infiniteScroll if table-page-load-status loader is spinning
-            $(".table-page-load-status > .loader").show();
+            // we will hide page status loader from infiniteScroll if page-loading-status loader is spinning
+            $(".page-loading-status > .loader").show();
             let orderBy =  $(this).data("slug");
 
             let orderIndicator = $(this).find("span:last")
@@ -1017,11 +1017,13 @@ var o_browse = {
             $(".gallery", namespace).append(html);
         }
         // $(".gallery", namespace).append(html);
-        // $(".table-page-load-status").hide();
+        // $(".page-loading-status").hide();
 
         o_browse.adjustTableSize();
         o_browse.galleryScrollbar.update();
-
+        if($(".page-loading-status > .loader").is(":visible")){
+            $(".page-loading-status > .loader").hide();
+        }
         o_hash.updateHash(true);
     },
 
@@ -1179,8 +1181,8 @@ var o_browse = {
             let request_time = new Date().getTime() - start_time;
             if (data.reqno < o_browse.lastLoadDataRequestNo) {
                 // make sure to remove spinner before return
-                if($(".table-page-load-status > .loader").is(":visible")){
-                    $(".table-page-load-status > .loader").hide();
+                if($(".page-loading-status > .loader").is(":visible")){
+                    $(".page-loading-status > .loader").hide();
                 }
                 return;
             }
@@ -1208,8 +1210,9 @@ var o_browse = {
                     });
 
                     $(selector).on("request.infiniteScroll", function( event, path ) {
-                        // hide default page status loader if table-page-load-status loader is spinning
-                        if($(".table-page-load-status > .loader").is(":visible")){
+                        // hide default page status loader if page-loading-status loader is spinning
+                        // && o_browse.tableSorting
+                        if($(".page-loading-status > .loader").is(":visible") ){
                             $(".infinite-scroll-request").hide();
                         }
                     });
@@ -1233,9 +1236,9 @@ var o_browse = {
                 $(selector).infiniteScroll('loadNextPage');
                 opus.gallery_begun = true;
             }
-            if($(".table-page-load-status > .loader").is(":visible")){
-                $(".table-page-load-status > .loader").hide();
-            }
+            // if($(".page-loading-status > .loader").is(":visible")){
+            //     $(".page-loading-status > .loader").hide();
+            // }
             o_browse.tableSorting = false;
         });
     },
@@ -1299,7 +1302,7 @@ var o_browse = {
         o_browse.undoRangeSelect();
 
         $(`.${opus.prefs.browse}#browse`).fadeIn();
-
+        $(".page-loading-status > .loader").show();
         o_browse.updateBrowseNav();
         o_browse.renderMetadataSelector();   // just do this in background so there's no delay when we want it...
 

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -299,6 +299,8 @@ var o_browse = {
 
         // click table column header to reorder by that column
         $("#browse").on("click", ".dataTable th a",  function() {
+            // show this spinner right away when table is clicked
+            // we will hide page status loader from infiniteScroll if table-page-load-status loader is spinning
             $(".table-page-load-status > .loader").show();
             let orderBy =  $(this).data("slug");
 
@@ -999,7 +1001,7 @@ var o_browse = {
             $(".gallery", namespace).append(html);
         }
         // $(".gallery", namespace).append(html);
-        $(".table-page-load-status").hide();
+        // $(".table-page-load-status").hide();
 
         o_browse.adjustTableSize();
         o_browse.galleryScrollbar.update();
@@ -1187,7 +1189,10 @@ var o_browse = {
                     });
 
                     $(selector).on("request.infiniteScroll", function( event, path ) {
-                        $(".table-page-load-status").show();
+                        // hide default page status loader if table-page-load-status loader is spinning
+                        if($(".table-page-load-status > .loader").is(":visible")){
+                            $(".infinite-scroll-request").hide();
+                        }
                     });
                     $(selector).on("scrollThreshold.infiniteScroll", function( event ) {
                         if(opus.lastPageDrawn[opus.prefs.view] < o_browse.infiniteScrollCurrentMaxPageNumber) {
@@ -1209,6 +1214,7 @@ var o_browse = {
                 $(selector).infiniteScroll('loadNextPage');
                 opus.gallery_begun = true;
             }
+
             $(".table-page-load-status > .loader").hide();
             o_browse.tableSorting = false;
         });

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -241,7 +241,6 @@ var opus = {
 
         // close any open modals
         $("#galleryView").modal('hide');
-
         opus.prefs.view = tab ? tab : opus.prefs.view;
         o_hash.updateHash();
         opus.lastBlogUpdate();


### PR DESCRIPTION
# Dummy pull request of updates on new_ui_dave:
# Update
* Table spinner:
    * Now spinner will show up right away when any table header or sort pill is clicked
        * Note: previously, spinner is coming from infiniteScroll status loader, and it will show up when there is a request (before load) event from infiniteScroll. And that's coming from loadData function, that's why there is a little gap with no spinner on the screen between the time when we click one header and infiniteScroll request event happened (before loading page 1).
* Table sort pill:
    * Now clicking sort pill will re-draw table smoothly (similar to the re-drawing behavior when any table header is clicked)