### PR TITLE
New ui dave

### DIFF
--- a/opus/application/apps/cart/templates/cart/cart.html
+++ b/opus/application/apps/cart/templates/cart/cart.html
@@ -8,7 +8,8 @@
             </div>
             <h1>Download Options</h1>
             <!-- <p>Total Files: <span id="total_files">{{ download_count }}</span></p> -->
-            <p>Total Size (before zip): <span id="total_download_size">{{ total_download_size_pretty }}</span></p>
+            <!-- <p>Total Size (before zip): <span id="total_download_size">{{ total_download_size_pretty }}</span></p> -->
+            <p>Total Size (before zip): <span class="spinner">&nbsp;</span><span id="total_download_size">{{ total_download_size_pretty }}</span></p>
 
             <div id="download_options">
                 {% for product_cat, product_list in product_cat_list %}

--- a/opus/application/apps/ui/templates/widget.html
+++ b/opus/application/apps/ui/templates/widget.html
@@ -1,34 +1,35 @@
 {% comment %}
-	this is all inside of: <li id="widget__{{ slug }}" class = "widget">
+    this is all inside of: <li id="widget__{{ slug }}" class = "widget">
 
-	range-qtype-helper div is appended in widgets.js becuase omg was impossible to layout #todo
+    range-qtype-helper div is appended in widgets.js becuase omg was impossible to layout #todo
 {% endcomment %}
 
 <div class="card">
     <header class="card-header">
         <h6 class="card-title mt-0">
-					{{ label }} {{ units }}
-					<i class = "fa fa-info-circle" title = "{{tooltip|safe }}"></i>
-					<span class="float-right border-left border-dark">
-						<a href="#card__{{ slug }}" data-toggle="collapse" data-target="#card__{{ slug }}" aria-expanded="true">
-								<i class="icon-action fa fa-chevron-down pull-right"></i>
-		        </a>
-						<a href="#" data-action="close" data-slug="{{slug}}" class="close_card">
-		            <i class="icon-action fa fa-times"></i>
-		        </a>
-					</span>
+                    {{ label }} {{ units }}
+                    <i class = "fa fa-info-circle" title = "{{tooltip|safe }}"></i>
+                    <span class="spinner">&nbsp;</span>
+                    <span class="float-right border-left border-dark">
+                        <a href="#card__{{ slug }}" data-toggle="collapse" data-target="#card__{{ slug }}" aria-expanded="true">
+                                <i class="icon-action fa fa-chevron-down pull-right"></i>
+                </a>
+                        <a href="#" data-action="close" data-slug="{{slug}}" class="close_card">
+                    <i class="icon-action fa fa-times"></i>
+                </a>
+                    </span>
         </h6>
     </header>
 
     <div class="collapse show" id="card__{{ slug }}" style="">
         <article class="card-body p-1 widget__{{ slug }}
-							{% if form_type in range_form_types %}
-								 range-widget
-							{% endif %}
-							{% if form_type in mult_form_types %}
-								 mult-widget
-							{% endif %}
-						">
+                            {% if form_type in range_form_types %}
+                                 range-widget
+                            {% endif %}
+                            {% if form_type in mult_form_types %}
+                                 mult-widget
+                            {% endif %}
+                        ">
             <div class="widget-main">
                 <div id = "hint__{{ slug }}" class = "range_hints"></div>
                 <ul>
@@ -39,7 +40,7 @@
                         </div>
                     {% endif %}
 
-                    	{{ form|safe }}
+                        {{ form|safe }}
                 </ul>
             </div>
         </article>

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -900,11 +900,20 @@ li a.search-param:hover {
     background-repeat: no-repeat;
 }
 
-#cart_summary .spinner {
+p > .spinner {
+    /* display:inline-block; */
+    display: none;
+    line-height: 16px;
+    margin: 0 10px;
+}
+
+/* #cart_summary .spinner { */
+#download_links .spinner {
     display:none;
     margin:0px 10px;
     width:30px;
 }
+
 #cart_summary .button-container button {
   margin-bottom: 1em;
 }

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -900,12 +900,7 @@ li a.search-param:hover {
     background-repeat: no-repeat;
 }
 
-.card-title .spinner {
-    /* display:inline-block; */
-}
-
 p > .spinner {
-    /* display:inline-block; */
     display: none;
     line-height: 16px;
     margin: 0 10px;

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -900,6 +900,10 @@ li a.search-param:hover {
     background-repeat: no-repeat;
 }
 
+.card-title .spinner {
+    /* display:inline-block; */
+}
+
 p > .spinner {
     /* display:inline-block; */
     display: none;
@@ -907,7 +911,6 @@ p > .spinner {
     margin: 0 10px;
 }
 
-/* #cart_summary .spinner { */
 #download_links .spinner {
     display:none;
     margin:0px 10px;

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1166,6 +1166,9 @@ var o_browse = {
         // wait! is this page already drawn?
         if ($(`${selector} .thumb-page[data-page='${page}']`).length > 0 && !o_browse.tableSorting) {
             o_browse.setScrollbarPosition(selector, page);
+            if($(".page-loading-status > .loader").is(":visible")){
+                $(".page-loading-status > .loader").hide();
+            }
             return;
         } else {
             // reset counter
@@ -1247,6 +1250,9 @@ var o_browse = {
         let data = JSON.parse( response );
         if ($(`.thumb-page[data-page='${data.page_no}']`).length != 0) {
             console.log(`data.reqno: ${data.reqno}, last reqno: ${o_browse.lastLoadDataRequestNo}`);
+            if($(".page-loading-status > .loader").is(":visible")){
+                $(".page-loading-status > .loader").hide();
+            }
             return;
         }
 

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -677,6 +677,11 @@ var o_browse = {
                 o_browse.initTable(opus.col_labels);
                 opus.prefs.page.gallery = 1;
                 o_browse.loadData(1);
+            } else {
+                // remove spinner if nothing is re-draw when we click save changes
+                if($(".page-loading-status > .loader").is(":visible")){
+                    $(".page-loading-status > .loader").hide();
+                }
             }
         });
 
@@ -758,6 +763,7 @@ var o_browse = {
                     o_browse.resetMetadata(default_columns.split(','));
                     break;
                 case "submit":
+                    $(".page-loading-status > .loader").show();
                     break;
                 case "cancel":
                     $('#myModal').modal('hide')

--- a/opus/application/static_media/js/cart.js
+++ b/opus/application/static_media/js/cart.js
@@ -33,6 +33,9 @@ var o_cart = {
 
          // check an input on selected products and images updates file_info
          $("#cart").on("click","#download_options input", function() {
+             $("#total_download_size").hide();
+             $("p > .spinner").fadeIn().css("display", "inline-block");
+             
              let add_to_url = o_cart.getDownloadFiltersChecked();
              o_cart.lastCartRequestNo++;
              let url = "/opus/__cart/status.json?reqno=" + o_cart.lastCartRequestNo + "&" + add_to_url + "&download=1";
@@ -40,6 +43,7 @@ var o_cart = {
                  if(info.reqno < o_cart.lastCartRequestNo) {
                      return;
                  }
+                 $("p > .spinner").hide()
                  $("#total_download_size").fadeOut().html(info.total_download_size_pretty).fadeIn();
              });
          });

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -476,7 +476,7 @@ var o_search = {
             // this is a mult field
             o_search.getValidMults(slug, deferredObj);
         } else {
-          $(`#widget__${slug}.spinner`).fadeOut();
+          $(`#widget__${slug} .spinner`).fadeOut();
           let adjustSearchWidgetHeight = _.debounce(o_search.adjustSearchWidgetHeight, 200);
           adjustSearchWidgetHeight();
         }
@@ -484,7 +484,7 @@ var o_search = {
 
     getRangeEndpoints: function(slug) {
 
-        $(`#widget__${slug}.spinner`).fadeIn();
+        $(`#widget__${slug} .spinner`).fadeIn();
 
         o_search.lastEndpointsRequestNo++;
         o_search.slugEndpointsReqno[slug] = o_search.lastEndpointsRequestNo;
@@ -492,7 +492,7 @@ var o_search = {
         $.ajax({url: url,
             dataType:"json",
             success: function(multdata){
-                $(`#widget__${slug}.spinner`).fadeOut();
+                $(`#widget__${slug} .spinner`).fadeOut();
 
                 if (multdata.reqno< o_search.slugEndpointsReqno[slug]) {
                     return;
@@ -503,11 +503,11 @@ var o_search = {
             },
             statusCode: {
                 404: function() {
-                    $(`#widget__${slug}.spinner`).removeClass("spinning");
+                    $(`#widget__${slug} .spinner`).fadeOut();
                 }
             },
             error:function (xhr, ajaxOptions, thrownError){
-                $(`#widget__${slug}.spinner`).removeClass("spinning");
+                $(`#widget__${slug} .spinner`).fadeOut();
                 // range input hints are "?" when wrong values of url is pasted
                 $(`#hint__${slug}`).html("<span>min: ?</span><span>max: ?</span><span> nulls: ?</span>");
             }
@@ -516,7 +516,7 @@ var o_search = {
 
     getValidMults: function (slug) {
         // turn on spinner
-        $(`#widget__${slug}.spinner`).fadeIn();
+        $(`#widget__${slug} .spinner`).fadeIn();
 
         o_search.lastMultsRequestNo++;
         o_search.slugMultsReqno[slug] = o_search.lastMultsRequestNo;
@@ -552,11 +552,11 @@ var o_search = {
             },
             statusCode: {
                 404: function() {
-                  $(`#widget__${slug}.spinner`).removeClass("spinning");
+                  $(`#widget__${slug} .spinner`).fadeOut();
               }
             },
             error:function (xhr, ajaxOptions, thrownError){
-                $(`#widget__${slug}.spinner`).removeClass("spinning");
+                $(`#widget__${slug} .spinner`).fadeOut();
                 // checkbox hints are "?" when wrong values of url is pasted
                 $(".hints").each(function() {
                     $(this).html("<span>?</span>");


### PR DESCRIPTION
# Update
(3) Search: There used to be spinners that would appear when you changed the search to show that the green hints were being updated, and that the category list was being updated. These are gone.
    * Now spinner will show up next to the card-title when it's updating hints

(5) Browse: Go to the Detail page then back to the Browse page. The spinner will be present and run forever.
    * Spinner will not show up now (because the page is fetched and loadData is not called)

(6) Browse: When you finish with "Select Metadata", there is no spinner while the initial data page reloads.
    * Spinner will show up when we click save changes and there are changes in metadata selection. If there is no metadata selection changes, then clicking save changes will not display the spinner (because  loadData is not called)

(12) Cart: When changing the selection of product types, the Total Size should have a spinner while waiting for the API to return.
    * Spinner will show up when there is a change in product type selection and we are still waiting for the return of api call