### PR TITLE
Fix broken qtypes. Set proper qtype when coming in from permalink. Fi…

### DIFF
--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -241,24 +241,23 @@ var o_search = {
         });
 
         // range behaviors and string behaviors for search widgets - qtype select dropdown
-        $('#search').on("change","select", function() {
-            var qtypes = [];
+        $('#search').on("change", "select", function() {
+            let qtypes = [];
 
             switch ($(this).attr("class")) {  // form type
                 case "RANGE":
-                    var slug_no_num = $(this).attr("name").match(/-(.*)/)[1];
-                    var slug = slug_no_num + '1';
+                    let slug_no_num = $(this).attr("name").match(/-(.*)/)[1];
 
-                    $("#widget__" + slug + ' select').each(function() {
-                        qtypes[qtypes.length] = $(this).val();
+                    $("#widget__" + slug_no_num + ' select').each(function() {
+                        qtypes.push($(this).val());
                     });
                     opus.extras['qtype-' + slug_no_num] = qtypes;
                     break;
 
                 case "STRING":
-                    var slug = $(this).attr("name").match(/-(.*)/)[1];
+                    let slug = $(this).attr("name").match(/-(.*)/)[1];
                     $("#widget__" + slug + ' select').each(function() {
-                        qtypes[qtypes.length] = $(this).val();
+                        qtypes.push($(this).val());
                     });
                     opus.extras['qtype-' + slug] = qtypes;
                     break;

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -246,20 +246,19 @@ var o_search = {
 
             switch ($(this).attr("class")) {  // form type
                 case "RANGE":
-                    let slug_no_num = $(this).attr("name").match(/-(.*)/)[1];
-
-                    $("#widget__" + slug_no_num + ' select').each(function() {
+                    let slugNoNum = $(this).attr("name").match(/-(.*)/)[1];
+                    $(`#widget__${slugNoNum} select`).each(function() {
                         qtypes.push($(this).val());
                     });
-                    opus.extras['qtype-' + slug_no_num] = qtypes;
+                    opus.extras[`qtype-${slugNoNum}`] = qtypes;
                     break;
 
                 case "STRING":
                     let slug = $(this).attr("name").match(/-(.*)/)[1];
-                    $("#widget__" + slug + ' select').each(function() {
+                    $(`#widget__${slug} select`).each(function() {
                         qtypes.push($(this).val());
                     });
-                    opus.extras['qtype-' + slug] = qtypes;
+                    opus.extras[`qtype-${slug}`] = qtypes;
                     break;
             }
 


### PR DESCRIPTION
It turns out that qtypes were completely broken. Changing a qtype in the dropdown box didn't actually change the hash. This was the result of an internal Django change I made awhile back and I didn't notice how it affected the UI.

This set of changes both fixes the fundamental working of qtypes, and handles qtypes coming in from permalinks. Previously these incoming qtypes were just ignored and the default was used.

Note there is no clean way to select a default item for a dropdown in Django 2.x, so this is a horrible hack. In fact ALL of the code in api_get_widget() and search/forms.py is horrible and needs to be rewritten from scratch. That's a project for another day.
