### PR TITLE
Implement maximum number of observations in cart

### DIFF
--- a/opus/application/apps/cart/test_cart.py
+++ b/opus/application/apps/cart/test_cart.py
@@ -19,7 +19,7 @@ class cartTests(TestCase):
         logging.disable(logging.ERROR)
         cache.clear()
         self.factory = RequestFactory()
-        
+
     def tearDown(self):
         sys.tracebacklimit = 1000 # default: 1000
         logging.disable(logging.NOTSET)
@@ -86,7 +86,7 @@ class cartTests(TestCase):
     def test__api_edit_cart_no_request(self):
         "[test_cart.py] api_edit_cart: no request"
         with self.assertRaises(Http404):
-            api_edit_cart(None)
+            api_edit_cart(None, 'add')
 
     def test__api_edit_cart_no_get(self):
         "[test_cart.py] api_edit_cart: no GET"
@@ -94,7 +94,7 @@ class cartTests(TestCase):
         request = self.factory.get('/__cart/add.json')
         request.GET = None
         with self.assertRaises(Http404):
-            api_edit_cart(request)
+            api_edit_cart(request, 'add')
 
 
             ################################################

--- a/opus/application/apps/metadata/views.py
+++ b/opus/application/apps/metadata/views.py
@@ -87,40 +87,10 @@ def api_get_result_count(request, fmt, internal=False):
         exit_api_call(api_code, ret)
         raise ret
 
-    (selections, extras) = url_to_search_params(request.GET)
-    if selections is None:
-        log.error('api_get_result_count: Could not find selections for '
-                  +'request %s', str(request.GET))
-        ret = Http404(settings.HTTP404_SEARCH_PARAMS_INVALID)
-        exit_api_call(api_code, ret)
-        raise ret
-
-    table = get_user_query_table(selections, extras, api_code=api_code)
-
-    if not table: # pragma: no cover
-        log.error('api_get_result_count: Could not find/create query table for '
-                  +'request %s', str(request.GET))
-        ret = HttpResponseServerError(settings.HTTP500_SEARCH_FAILED)
-        exit_api_call(api_code, ret)
-        return ret
-
-    cache_key = settings.CACHE_KEY_PREFIX + ':resultcount:' + table
-    count = cache.get(cache_key)
-    if count is None:
-        cursor = connection.cursor()
-        sql = 'SELECT COUNT(*) FROM ' + connection.ops.quote_name(table)
-        cursor.execute(sql)
-        try:
-            count = cursor.fetchone()[0]
-        except DatabaseError as e: # pragma: no cover
-            log.error('api_get_result_count: SQL query failed for request %s: '
-                      +' SQL "%s" ERR "%s"',
-                      str(request.GET), sql, str(e))
-            ret = HttpResponseServerError(settings.HTTP500_SQL_FAILED)
-            exit_api_call(api_code, ret)
-            return ret
-
-        cache.set(cache_key, count)
+    count, _, err = get_result_count_helper(request, api_code)
+    if err is not None:
+        exit_api_call(api_code, err)
+        return err
 
     data = {'result_count': count}
     if internal:
@@ -583,6 +553,45 @@ def api_get_fields(request, fmt='json', slug=None):
 # SUPPORT ROUTINES
 #
 ################################################################################
+
+# This routine is public because it's called by _edit_cart_addall
+# in cart/views.py
+def get_result_count_helper(request, api_code):
+    (selections, extras) = url_to_search_params(request.GET)
+    if selections is None:
+        log.error('get_result_count_helper: Could not find selections for '
+                  +'request %s', str(request.GET))
+        ret = Http404(settings.HTTP404_SEARCH_PARAMS_INVALID)
+        exit_api_call(api_code, ret)
+        raise ret
+
+    table = get_user_query_table(selections, extras, api_code=api_code)
+
+    if not table: # pragma: no cover
+        log.error('get_result_count_helper: Could not find/create query table '
+                  +'for request %s', str(request.GET))
+        ret = HttpResponseServerError(settings.HTTP500_SEARCH_FAILED)
+        return None, None, ret
+
+    cache_key = settings.CACHE_KEY_PREFIX + ':resultcount:' + table
+    count = cache.get(cache_key)
+    if count is None:
+        cursor = connection.cursor()
+        sql = 'SELECT COUNT(*) FROM ' + connection.ops.quote_name(table)
+        cursor.execute(sql)
+        try:
+            count = cursor.fetchone()[0]
+        except DatabaseError as e: # pragma: no cover
+            log.error('get_result_count_helper: SQL query failed for request '
+                      +'%s: SQL "%s" ERR "%s"',
+                      str(request.GET), sql, str(e))
+            ret = HttpResponseServerError(settings.HTTP500_SQL_FAILED)
+            return None, None, ret
+
+        cache.set(cache_key, count)
+
+    return count, table, None
+
 
 # This routine is public because it's called by the API guide in guide/views.py
 def get_fields_info(fmt, slug=None, collapse=False):

--- a/opus/application/settings.py
+++ b/opus/application/settings.py
@@ -352,6 +352,7 @@ STRINGCHOICE_FULL_SEARCH_TIME_THRESHOLD2 = 500 # ms
 
 THUMBNAIL_NOT_FOUND = 'https://tools.pds-rings.seti.org/static_media/img/thumbnail_not_found.png'
 
+MAX_SELECTIONS_ALLOWED = 10000
 MAX_SELECTIONS_FOR_DATA_DOWNLOAD = 250
 MAX_SELECTIONS_FOR_URL_DOWNLOAD = 10000
 MAX_DOWNLOAD_SIZE = 3*1024*1024*1024 # 3 gig max for any single download
@@ -368,8 +369,10 @@ HTTP404_SEARCH_PARAMS_INVALID = 'Search params invalid'
 HTTP404_UNKNOWN_FORMAT = 'Unknown format'
 HTTP404_UNKNOWN_SLUG = 'Unknown slug'
 HTTP404_UNKNOWN_OPUS_ID = 'Unknown OPUSID'
+HTTP404_MISSING_OPUS_ID = 'Missing OPUSID'
 HTTP404_UNKNOWN_CATEGORY = 'Unknown category'
 HTTP404_MISSING_REQNO = 'Missing reqno'
+HTTP404_BAD_OR_MISSING_RANGE = 'Bad or missing range'
 
 HTTP500_SEARCH_FAILED = 'Search failed'
 HTTP500_SQL_FAILED = 'SQL query failed'

--- a/opus/application/test_api/test_cart_api.py
+++ b/opus/application/test_api/test_cart_api.py
@@ -16,18 +16,18 @@ class ApiCartTests(TestCase, ApiTestHelper):
 
     def setUp(self):
         self.maxDiff = None
-        sys.tracebacklimit = 0 # default: 1000
         settings.CACHE_KEY_PREFIX = 'opustest:' + settings.DB_SCHEMA_NAME
         logging.disable(logging.ERROR)
+        self.cart_maximum = settings.MAX_SELECTIONS_ALLOWED
         if settings.TEST_GO_LIVE: # pragma: no cover
             self.client = requests.Session()
         else:
             self.client = RequestsClient()
         cache.clear()
-        
+
     def tearDown(self):
-        sys.tracebacklimit = 1000 # default: 1000
         logging.disable(logging.NOTSET)
+        settings.MAX_SELECTIONS_ALLOWED = self.cart_maximum
 
 
             ##################################################
@@ -70,8 +70,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/add.json?reqno=456'
-        expected = {'count': 0, 'error': 'No opusid specified', 'reqno': 456}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_MISSING_OPUS_ID)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -81,8 +80,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/add.json?opusid=&reqno=456'
-        expected = {'count': 0, 'error': 'No opusid specified', 'reqno': 456}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_MISSING_OPUS_ID)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -168,8 +166,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/add.json?reqno=124'
-        expected = {'count': 0, 'error': 'No opusid specified', 'reqno': 124}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_MISSING_OPUS_ID)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -201,8 +198,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/add.json?download=1&reqno=456'
-        expected = {"error": "No opusid specified", "count": 0, "reqno": 456, "total_download_count": 0, "total_download_size": 0, "total_download_size_pretty": "0B", "product_cat_list": []}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_MISSING_OPUS_ID)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -232,6 +228,69 @@ class ApiCartTests(TestCase, ApiTestHelper):
         expected = {'count': 2, 'reqno': 0}
         self._run_json_equal(url, expected)
 
+    def test__api_cart_add_one_too_many_0(self):
+        "[test_cart_api.py] /__cart/add: good OPUSID no download too many 1"
+        settings.MAX_SELECTIONS_ALLOWED = 0
+        url = '/opus/__cart/reset.json'
+        self._run_status_equal(url, 200)
+        url = '/opus/__cart/add.json?opusid=co-iss-n1460961026&reqno=456'
+        expected = {'count': 0, 'error': 'Too many observations in cart', 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/opus/__cart/status.json?reqno=456'
+        expected = {'count': 0, 'reqno': 456}
+        self._run_json_equal(url, expected)
+
+    def test__api_cart_add_one_too_many_1(self):
+        "[test_cart_api.py] /__cart/add: good OPUSID no download too many 1"
+        settings.MAX_SELECTIONS_ALLOWED = 1
+        url = '/opus/__cart/reset.json'
+        self._run_status_equal(url, 200)
+        url = '/opus/__cart/add.json?opusid=co-iss-n1460961026&reqno=456'
+        expected = {'count': 1, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/opus/__cart/status.json?reqno=456'
+        expected = {'count': 1, 'reqno': 456}
+        self._run_json_equal(url, expected)
+
+    def test__api_cart_add_duplicate_too_many_1(self):
+        "[test_cart_api.py] /__cart/add: duplicate OPUSID no download too many 1"
+        settings.MAX_SELECTIONS_ALLOWED = 1
+        url = '/opus/__cart/reset.json'
+        self._run_status_equal(url, 200)
+        url = '/opus/__cart/add.json?opusid=co-iss-n1460961026&reqno=456'
+        expected = {'count': 1, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/opus/__cart/add.json?opusid=co-iss-n1460961026&reqno=456'
+        expected = {'count': 1, 'error': 'Too many observations in cart', 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/opus/__cart/status.json?reqno=456'
+        expected = {'count': 1, 'reqno': 456}
+        self._run_json_equal(url, expected)
+
+    def test__api_cart_add_mixture_too_many_2(self):
+        "[test_cart_api.py] /__cart/add: mixture no download too many 2"
+        settings.MAX_SELECTIONS_ALLOWED = 2
+        url = '/opus/__cart/reset.json'
+        self._run_status_equal(url, 200)
+        url = '/opus/__cart/add.json?opusid=vg-iss-2-s-c4360010&reqno=456'
+        expected = {'count': 1, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/opus/__cart/add.json?opusid=vg-iss-2-s-c4360010&reqno=456'
+        expected = {'count': 1, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/opus/__cart/add.json?opusid=vg-iss-2-s-c4360010&reqno=456'
+        expected = {'count': 1, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/opus/__cart/add.json?opusid=hst-12003-wfc3-ibcz21ff&reqno=456'
+        expected = {'count': 2, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/opus/__cart/add.json?opusid=vg-iss-2-s-c4360018&reqno=456'
+        expected = {'count': 2, 'error': 'Too many observations in cart', 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/opus/__cart/status.json?reqno=456'
+        expected = {'count': 2, 'reqno': 456}
+        self._run_json_equal(url, expected)
+
 
             ##################################################
             ######### /__cart/remove.json: API TESTS #########
@@ -247,8 +306,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/remove.json?reqno=456'
-        expected = {'count': 0, 'error': 'No opusid specified', 'reqno': 456}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_MISSING_OPUS_ID)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -258,8 +316,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/remove.json?opusid=&reqno=456'
-        expected = {'count': 0, 'error': 'No opusid specified', 'reqno': 456}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_MISSING_OPUS_ID)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -364,8 +421,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/remove.json?reqno=124'
-        expected = {'count': 0, 'error': 'No opusid specified', 'reqno': 124}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_MISSING_OPUS_ID)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -404,8 +460,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/remove.json?download=1&reqno=456'
-        expected = {"error": "No opusid specified", "count": 0, "reqno": 456, "total_download_count": 0, "total_download_size": 0, "total_download_size_pretty": "0B", "product_cat_list": []}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_MISSING_OPUS_ID)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -456,8 +511,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/addrange.json?reqno=456'
-        expected = {'count': 0, 'error': 'no range given', 'reqno': 456}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_BAD_OR_MISSING_RANGE)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -467,8 +521,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/addrange.json?range=&reqno=456'
-        expected = {'count': 0, 'error': 'no range given', 'reqno': 456}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_BAD_OR_MISSING_RANGE)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -478,8 +531,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/addrange.json?range=co-vims-v1484504505_ir&reqno=456'
-        expected = {'count': 0, 'error': 'bad range', 'reqno': 456}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_BAD_OR_MISSING_RANGE)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -489,8 +541,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/addrange.json?range=co-vims-v1484504505_ir,&reqno=456'
-        expected = {'count': 0, 'error': 'bad range', 'reqno': 456}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_BAD_OR_MISSING_RANGE)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -500,8 +551,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/addrange.json?range=,co-vims-v1484504505_ir&reqno=456'
-        expected = {'count': 0, 'error': 'bad range', 'reqno': 456}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_BAD_OR_MISSING_RANGE)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -511,8 +561,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/addrange.json?range=co-vims-v1484504505_ir,co-vims-v1484504505_ir,co-vims-v1484504505_ir&reqno=456'
-        expected = {'count': 0, 'error': 'bad range', 'reqno': 456}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_BAD_OR_MISSING_RANGE)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -650,8 +699,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/addrange.json?volumeidXX=COVIMS_0006&range=vg-iss-2-s-c4360001,vg-iss-2-s-c4360001&reqno=456'
-        expected = {'count': 0, 'error': 'bad search', 'reqno': 456}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_SEARCH_PARAMS_INVALID)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -694,8 +742,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/addrange.json?reqno=124'
-        expected = {'count': 0, 'error': 'no range given', 'reqno': 124}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_BAD_OR_MISSING_RANGE)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -716,8 +763,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/addrange.json?download=1&reqno=456'
-        expected = {"error": "no range given", "count": 0, "reqno": 456, "total_download_count": 0, "total_download_size": 0, "total_download_size_pretty": "0B", "product_cat_list": []}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_BAD_OR_MISSING_RANGE)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -732,6 +778,61 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 17, 'reqno': 456}
         self._run_json_equal(url, expected)
+
+    def test__api_cart_addrange_one_too_many_0(self):
+        "[test_cart_api.py] /__cart/addrange: one good OPUSID no download too many 0"
+        settings.MAX_SELECTIONS_ALLOWED = 0
+        url = '/opus/__cart/reset.json'
+        self._run_status_equal(url, 200)
+        url = '/opus/__cart/addrange.json?volumeid=COVIMS_0006&range=co-vims-v1484504505_ir,co-vims-v1484504505_ir&reqno=567'
+        expected = {'count': 0, 'error': 'Too many observations in cart', 'reqno': 567}
+        self._run_json_equal(url, expected)
+        url = '/opus/__cart/status.json?reqno=456'
+        expected = {'count': 0, 'reqno': 456}
+        self._run_json_equal(url, expected)
+
+    def test__api_cart_addrange_one_too_many_1(self):
+        "[test_cart_api.py] /__cart/addrange: one good OPUSID no download too many 1"
+        settings.MAX_SELECTIONS_ALLOWED = 1
+        url = '/opus/__cart/reset.json'
+        self._run_status_equal(url, 200)
+        url = '/opus/__cart/addrange.json?volumeid=COVIMS_0006&range=co-vims-v1484504505_ir,co-vims-v1484504505_ir&reqno=567'
+        expected = {'count': 1, 'error': False, 'reqno': 567}
+        self._run_json_equal(url, expected)
+        url = '/opus/__cart/status.json?reqno=456'
+        expected = {'count': 1, 'reqno': 456}
+        self._run_json_equal(url, expected)
+
+    def test__api_cart_addrange_duplicate2_too_many_33(self):
+        "[test_cart_api.py] /__cart/addrange: duplicate 2 no download too many 33"
+        settings.MAX_SELECTIONS_ALLOWED = 33
+        url = '/opus/__cart/reset.json'
+        self._run_status_equal(url, 200)
+        url = '/opus/__cart/addrange.json?volumeid=COVIMS_0006&range=co-vims-v1488642557_ir,co-vims-v1488646261_ir&reqno=456'
+        expected = {'count': 17, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/opus/__cart/addrange.json?volumeid=COVIMS_0006&range=co-vims-v1488642557_ir,co-vims-v1488646261_ir&reqno=456'
+        expected = {'count': 17, 'error': 'Too many observations in cart', 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/opus/__cart/status.json?reqno=456'
+        expected = {'count': 17, 'reqno': 456}
+        self._run_json_equal(url, expected)
+
+    def test__api_cart_addrange_duplicate2_too_many_34(self):
+        "[test_cart_api.py] /__cart/addrange: duplicate 2 no download too many 34"
+        settings.MAX_SELECTIONS_ALLOWED = 34
+        url = '/opus/__cart/reset.json'
+        self._run_status_equal(url, 200)
+        url = '/opus/__cart/addrange.json?volumeid=COVIMS_0006&range=co-vims-v1488642557_ir,co-vims-v1488646261_ir&reqno=456'
+        expected = {'count': 17, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/opus/__cart/addrange.json?volumeid=COVIMS_0006&range=co-vims-v1488642557_ir,co-vims-v1488646261_ir&reqno=456'
+        expected = {'count': 17, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/opus/__cart/status.json?reqno=456'
+        expected = {'count': 17, 'reqno': 456}
+        self._run_json_equal(url, expected)
+
 
 
             #######################################################
@@ -748,8 +849,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/removerange.json?reqno=456'
-        expected = {'count': 0, 'error': 'no range given', 'reqno': 456}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_BAD_OR_MISSING_RANGE)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -759,8 +859,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/removerange.json?range=&reqno=456'
-        expected = {'count': 0, 'error': 'no range given', 'reqno': 456}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_BAD_OR_MISSING_RANGE)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -770,8 +869,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/removerange.json?range=co-vims-v1484504505_ir&reqno=456'
-        expected = {'count': 0, 'error': 'bad range', 'reqno': 456}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_BAD_OR_MISSING_RANGE)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -781,8 +879,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/removerange.json?range=co-vims-v1484504505_ir,&reqno=456'
-        expected = {'count': 0, 'error': 'bad range', 'reqno': 456}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_BAD_OR_MISSING_RANGE)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -792,8 +889,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/removerange.json?range=,co-vims-v1484504505_ir&reqno=456'
-        expected = {'count': 0, 'error': 'bad range', 'reqno': 456}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_BAD_OR_MISSING_RANGE)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -803,8 +899,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/removerange.json?range=co-vims-v1484504505_ir,co-vims-v1484504505_ir,co-vims-v1484504505_ir&reqno=456'
-        expected = {'count': 0, 'error': 'bad range', 'reqno': 456}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_BAD_OR_MISSING_RANGE)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -912,8 +1007,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/removerange.json?volumeidXX=COVIMS_0006&range=vg-iss-2-s-c4360001,vg-iss-2-s-c4360001&reqno=456'
-        expected = {'count': 0, 'error': 'bad search', 'reqno': 456}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_SEARCH_PARAMS_INVALID)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -968,8 +1062,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/removerange.json?reqno=124'
-        expected = {'count': 0, 'error': 'no range given', 'reqno': 124}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_BAD_OR_MISSING_RANGE)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -990,8 +1083,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/removerange.json?download=1&reqno=456'
-        expected = {"error": "no range given", "count": 0, "reqno": 456, "total_download_count": 0, "total_download_size": 0, "total_download_size_pretty": "0B", "product_cat_list": []}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_BAD_OR_MISSING_RANGE)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -1038,16 +1130,33 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/addall.json?volumeid=VGISS_6210&reqno=456'
         expected = {'count': 906, 'error': False, 'reqno': 456}
         self._run_json_equal(url, expected)
+        url = '/opus/__cart/addall.json?volumeid=VGISS_6210&reqno=456'
+        expected = {'count': 906, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 906, 'reqno': 456}
         self._run_json_equal(url, expected)
 
     def test__api_cart_addall_duplicate2(self):
-        "[test_cart_api.py] /__cart/addall: add plus addall no download"
+        "[test_cart_api.py] /__cart/addall: addrange plus addall no download"
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/addrange.json?volumeid=VGISS_6210&range=vg-iss-2-s-c4360037,vg-iss-2-s-c4365644&reqno=456'
         expected = {'count': 597, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/opus/__cart/addall.json?volumeid=VGISS_6210&reqno=456'
+        expected = {'count': 906, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/opus/__cart/status.json?reqno=456'
+        expected = {'count': 906, 'reqno': 456}
+        self._run_json_equal(url, expected)
+
+    def test__api_cart_addall_duplicate3(self):
+        "[test_cart_api.py] /__cart/addall: add plus addall no download"
+        url = '/opus/__cart/reset.json'
+        self._run_status_equal(url, 200)
+        url = '/opus/__cart/add.json?opusid=vg-iss-2-s-c4360018&reqno=456'
+        expected = {'count': 1, 'error': False, 'reqno': 456}
         self._run_json_equal(url, expected)
         url = '/opus/__cart/addall.json?volumeid=VGISS_6210&reqno=456'
         expected = {'count': 906, 'error': False, 'reqno': 456}
@@ -1061,8 +1170,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         url = '/opus/__cart/reset.json'
         self._run_status_equal(url, 200)
         url = '/opus/__cart/addall.json?volumeidXX=COVIMS_0006&reqno=456'
-        expected = {'count': 0, 'error': 'bad search', 'reqno': 456}
-        self._run_json_equal(url, expected)
+        self._run_status_equal(url, 404, settings.HTTP404_SEARCH_PARAMS_INVALID)
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 0, 'reqno': 456}
         self._run_json_equal(url, expected)
@@ -1087,17 +1195,6 @@ class ApiCartTests(TestCase, ApiTestHelper):
         expected = {'count': 3531+906, 'reqno': 456}
         self._run_json_equal(url, expected)
 
-    def test__api_cart_addall_one(self):
-        "[test_cart_api.py] /__cart/addall: one time no download"
-        url = '/opus/__cart/reset.json'
-        self._run_status_equal(url, 200)
-        url = '/opus/__cart/addall.json?volumeid=VGISS_6210&reqno=987'
-        expected = {'count': 906, 'error': False, 'reqno': 987}
-        self._run_json_equal(url, expected)
-        url = '/opus/__cart/status.json?reqno=456'
-        expected = {'count': 906, 'reqno': 456}
-        self._run_json_equal(url, expected)
-
     def test__api_cart_addall_one_download(self):
         "[test_cart_api.py] /__cart/addall: one time with download"
         url = '/opus/__cart/reset.json'
@@ -1107,6 +1204,75 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected, ignore='tooltip')
         url = '/opus/__cart/status.json?reqno=456'
         expected = {'count': 34, 'reqno': 456}
+        self._run_json_equal(url, expected)
+
+    def test__api_cart_addall_one_too_many_905(self):
+        "[test_cart_api.py] /__cart/addall: one time no download too many 905"
+        settings.MAX_SELECTIONS_ALLOWED = 905
+        url = '/opus/__cart/reset.json'
+        self._run_status_equal(url, 200)
+        url = '/opus/__cart/addall.json?volumeid=VGISS_6210&reqno=456'
+        expected = {'count': 0, 'error': 'Too many observations in cart', 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/opus/__cart/status.json?reqno=456'
+        expected = {'count': 0, 'reqno': 456}
+        self._run_json_equal(url, expected)
+
+    def test__api_cart_addall_one_too_many_906(self):
+        "[test_cart_api.py] /__cart/addall: one time no download too many 906"
+        settings.MAX_SELECTIONS_ALLOWED = 906
+        url = '/opus/__cart/reset.json'
+        self._run_status_equal(url, 200)
+        url = '/opus/__cart/addall.json?volumeid=VGISS_6210&reqno=456'
+        expected = {'count': 906, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/opus/__cart/status.json?reqno=456'
+        expected = {'count': 906, 'reqno': 456}
+        self._run_json_equal(url, expected)
+
+    def test__api_cart_addall_duplicate_too_many_906(self):
+        "[test_cart_api.py] /__cart/addall: twice no download"
+        settings.MAX_SELECTIONS_ALLOWED = 906
+        url = '/opus/__cart/reset.json'
+        self._run_status_equal(url, 200)
+        url = '/opus/__cart/addall.json?volumeid=VGISS_6210&reqno=456'
+        expected = {'count': 906, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/opus/__cart/addall.json?volumeid=VGISS_6210&reqno=456'
+        expected = {'count': 906, 'error': 'Too many observations in cart', 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/opus/__cart/status.json?reqno=456'
+        expected = {'count': 906, 'reqno': 456}
+        self._run_json_equal(url, expected)
+
+    def test__api_cart_addall_duplicate3_too_many_906(self):
+        "[test_cart_api.py] /__cart/addall: add plus addall no download too many 906"
+        settings.MAX_SELECTIONS_ALLOWED = 906
+        url = '/opus/__cart/reset.json'
+        self._run_status_equal(url, 200)
+        url = '/opus/__cart/add.json?opusid=vg-iss-2-s-c4360018&reqno=456'
+        expected = {'count': 1, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/opus/__cart/addall.json?volumeid=VGISS_6210&reqno=456'
+        expected = {'count': 1, 'error': 'Too many observations in cart', 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/opus/__cart/status.json?reqno=456'
+        expected = {'count': 1, 'reqno': 456}
+        self._run_json_equal(url, expected)
+
+    def test__api_cart_addall_duplicate3_too_many_907(self):
+        "[test_cart_api.py] /__cart/addall: add plus addall no download too many 907"
+        settings.MAX_SELECTIONS_ALLOWED = 907
+        url = '/opus/__cart/reset.json'
+        self._run_status_equal(url, 200)
+        url = '/opus/__cart/add.json?opusid=vg-iss-2-s-c4360018&reqno=456'
+        expected = {'count': 1, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/opus/__cart/addall.json?volumeid=VGISS_6210&reqno=456'
+        expected = {'count': 906, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/opus/__cart/status.json?reqno=456'
+        expected = {'count': 906, 'reqno': 456}
         self._run_json_equal(url, expected)
 
 

--- a/opus/application/test_api/test_help_api.py
+++ b/opus/application/test_api/test_help_api.py
@@ -16,7 +16,6 @@ class ApiHelpTests(TestCase, ApiTestHelper):
 
     def setUp(self):
         self.maxDiff = None
-        sys.tracebacklimit = 0 # default: 1000
         settings.CACHE_KEY_PREFIX = 'opustest:' + settings.DB_SCHEMA_NAME
         logging.disable(logging.ERROR)
         if settings.TEST_GO_LIVE: # pragma: no cover
@@ -24,9 +23,8 @@ class ApiHelpTests(TestCase, ApiTestHelper):
         else:
             self.client = RequestsClient()
         cache.clear()
-        
+
     def tearDown(self):
-        sys.tracebacklimit = 1000 # default: 1000
         logging.disable(logging.NOTSET)
 
 

--- a/opus/application/test_api/test_metadata_api.py
+++ b/opus/application/test_api/test_metadata_api.py
@@ -17,7 +17,6 @@ class ApiMetadataTests(TestCase, ApiTestHelper):
 
     def setUp(self):
         self.maxDiff = None
-        sys.tracebacklimit = 0 # default: 1000
         settings.CACHE_KEY_PREFIX = 'opustest:' + settings.DB_SCHEMA_NAME
         logging.disable(logging.ERROR)
         if settings.TEST_GO_LIVE: # pragma: no cover
@@ -27,7 +26,6 @@ class ApiMetadataTests(TestCase, ApiTestHelper):
         cache.clear()
 
     def tearDown(self):
-        sys.tracebacklimit = 1000 # default: 1000
         logging.disable(logging.NOTSET)
 
     def _run_result_count_equal(self, url, expected, expected_reqno=None):

--- a/opus/application/test_api/test_result_counts.py
+++ b/opus/application/test_api/test_result_counts.py
@@ -20,13 +20,11 @@ class APIResultCountsTests(TestCase):
     # disable error logging and trace output before test
     def setUp(self):
         self.maxDiff = None
-        sys.tracebacklimit = 0 # default: 1000
         settings.CACHE_KEY_PREFIX = 'opustest:' + settings.DB_SCHEMA_NAME
         logging.disable(logging.DEBUG)
 
     # enable error logging and trace output after test
     def tearDown(self):
-        sys.tracebacklimit = 1000 # default: 1000
         logging.disable(logging.NOTSET)
 
     def test_api_result_counts_from_csv(self):

--- a/opus/application/test_api/test_results_api.py
+++ b/opus/application/test_api/test_results_api.py
@@ -17,7 +17,6 @@ class ApiResultsTests(TestCase, ApiTestHelper):
 
     def setUp(self):
         self.maxDiff = None
-        sys.tracebacklimit = 0 # default: 1000
         settings.CACHE_KEY_PREFIX = 'opustest:' + settings.DB_SCHEMA_NAME
         logging.disable(logging.ERROR)
         if settings.TEST_GO_LIVE: # pragma: no cover
@@ -27,7 +26,6 @@ class ApiResultsTests(TestCase, ApiTestHelper):
         cache.clear()
 
     def tearDown(self):
-        sys.tracebacklimit = 1000 # default: 1000
         logging.disable(logging.NOTSET)
 
 

--- a/opus/application/test_api/test_return_formats.py
+++ b/opus/application/test_api/test_return_formats.py
@@ -16,7 +16,6 @@ class ApiReturnFormatTests(TestCase):
 
     def setUp(self):
         self.maxDiff = None
-        sys.tracebacklimit = 0 # default: 1000
         settings.CACHE_KEY_PREFIX = 'opustest:' + settings.DB_SCHEMA_NAME
         logging.disable(logging.ERROR)
         if settings.TEST_GO_LIVE: # pragma: no cover
@@ -25,7 +24,6 @@ class ApiReturnFormatTests(TestCase):
             self.client = RequestsClient()
 
     def tearDown(self):
-        sys.tracebacklimit = 1000 # default: 1000
         logging.disable(logging.NOTSET)
 
     # FOR DEBUGGING PURPOSE: just run one single api call

--- a/opus/application/test_api/test_search_api.py
+++ b/opus/application/test_api/test_search_api.py
@@ -17,7 +17,6 @@ class ApiSearchTests(TestCase, ApiTestHelper):
 
     def setUp(self):
         self.maxDiff = None
-        sys.tracebacklimit = 0 # default: 1000
         settings.CACHE_KEY_PREFIX = 'opustest:' + settings.DB_SCHEMA_NAME
         logging.disable(logging.ERROR)
         self.search_count_threshold = settings.STRINGCHOICE_FULL_SEARCH_COUNT_THRESHOLD
@@ -31,9 +30,8 @@ class ApiSearchTests(TestCase, ApiTestHelper):
         else:
             self.client = RequestsClient()
         cache.clear()
-        
+
     def tearDown(self):
-        sys.tracebacklimit = 1000 # default: 1000
         logging.disable(logging.NOTSET)
         settings.STRINGCHOICE_FULL_SEARCH_COUNT_THRESHOLD = self.search_count_threshold
         settings.STRINGCHOICE_FULL_SEARCH_TIME_THRESHOLD = self.search_time_threshold

--- a/opus/application/test_api/test_ui_api.py
+++ b/opus/application/test_api/test_ui_api.py
@@ -17,7 +17,6 @@ class ApiUITests(TestCase, ApiTestHelper):
 
     def setUp(self):
         self.maxDiff = None
-        sys.tracebacklimit = 0 # default: 1000
         settings.CACHE_KEY_PREFIX = 'opustest:' + settings.DB_SCHEMA_NAME
         logging.disable(logging.ERROR)
         if settings.TEST_GO_LIVE: # pragma: no cover
@@ -37,7 +36,6 @@ class ApiUITests(TestCase, ApiTestHelper):
         }
 
     def tearDown(self):
-        sys.tracebacklimit = 1000 # default: 1000
         logging.disable(logging.NOTSET)
 
     def _run_url_slugs_equal(self, url, expected):

--- a/opus/application/test_api/test_vims_image_downlinks.py
+++ b/opus/application/test_api/test_vims_image_downlinks.py
@@ -21,12 +21,10 @@ class ApiVimsDownlinksTests(TestCase):
     # disable error logging and trace output before test
     def setUp(self):
         settings.CACHE_KEY_PREFIX = 'opustest:' + settings.DB_SCHEMA_NAME
-    #     sys.tracebacklimit = 0 # default: 1000
         logging.disable(logging.ERROR)
 
-    # # enable error logging and trace output after test
+    # enable error logging and trace output after test
     def tearDown(self):
-    #     sys.tracebacklimit = 1000 # default: 1000
         logging.disable(logging.NOTSET)
 
     ###############################


### PR DESCRIPTION
- Implement a maximum number of observations (currently 10,000) for cart add, addrange, and addall. An error is returned in the JSON if this number is exceeded, and the add doesn't happen.
- It's really hard to figure out whether an add will exceed the number if there are duplicates in what's being added (e.g. overlapping ranges). Rather than go through the difficulty of figuring this out, we are conservative and just assume the adds don't overlap. This means there may be a "Too many observations" error generated in cases when the add should actually succeed if the user were more careful in how they were adding things. I think this should be hit rarely.
- Switched from returning JSON errors for truly internal issues like bad URLs or failed SQL to raising a 404 or 500 HTTP response. Now JSON errors are only for things that the user directly caused. Note the JavaScript currently ignores response codes AND JSON error codes, so you can really get things confused when you have an internal failure or the user adds too many observations to the cart. Issues have been opened for these cases.
- Test cases added, updated, and cleaned up.
- This fixes issue #589 
