### PR TITLE
Add JSHINT directives. Minor code cleanup.

### DIFF
--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -31,7 +31,6 @@ var o_browse = {
 
     galleryScrollTo: 0,
     metadataSelectorDrawn: false,
-    currentSelectedMetadata: undefined,
 
     lastLoadDataRequestNo: 0,
 
@@ -722,11 +721,12 @@ var o_browse = {
 
     // metadata selector behaviors
     addMetadataSelectorBehaviors: function() {
-        o_browse.currentSelectedMetadata = opus.prefs.cols.slice();
+        // Global within this function so behaviors can communicate
+        var currentSelectedMetadata = opus.prefs.cols.slice();
 
         $("#metadataSelector").on("hide.bs.modal", function(e) {
             // update the data table w/the new columns
-            if (!o_utils.areObjectsEqual(opus.prefs.cols, o_browse.currentSelectedMetadata)) {
+            if (!o_utils.areObjectsEqual(opus.prefs.cols, currentSelectedMetadata)) {
                 o_browse.resetData();
                 o_browse.initTable(opus.col_labels);
                 opus.prefs.page.gallery = 1;
@@ -741,7 +741,7 @@ var o_browse = {
 
         $("#metadataSelector").on("show.bs.modal", function(e) {
             // save current column state so we can look for changes
-            o_browse.currentSelectedMetadata = opus.prefs.cols.slice();
+            currentSelectedMetadata = opus.prefs.cols.slice();
         });
 
         $('#metadataSelector .allMetadata').on("click", '.submenu li a', function() {
@@ -769,7 +769,6 @@ var o_browse = {
             return false;
         });
 
-
         // removes chosen column
         $("#metadataSelector .selectedMetadata").on("click", "li .unselect", function() {
             if (opus.prefs.cols.length <= 1) {
@@ -787,6 +786,7 @@ var o_browse = {
             }
             return false;
         });
+
         // buttons
         $("#metadataSelector").on("click", ".btn", function() {
             switch($(this).attr("type")) {
@@ -800,7 +800,7 @@ var o_browse = {
                 case "cancel":
                     $('#myModal').modal('hide');
                     opus.prefs.cols = [];
-                    o_browse.resetMetadata(o_browse.currentSelectedMetadata, true);
+                    o_browse.resetMetadata(currentSelectedMetadata, true);
                     break;
             }
         });

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1,4 +1,15 @@
+/* jshint esversion: 6 */
+/* jshint bitwise: true, curly: true, freeze: true, futurehostile: true */
+/* jshint latedef: true, leanswitch: true, noarg: true, nocomma: true */
+/* jshint nonbsp: true, nonew: true */
+/* jshint varstmt: true */
+/* globals $, _, PerfectScrollbar */
+/* globals o_cart, o_hash, o_menu, o_utils, opus */
+/* globals default_pages, default_columns */
+
+/* jshint varstmt: false */
 var o_browse = {
+/* jshint varstmt: true */
     selectedImageID: "",
     keyPressAction: "",
     tableSorting: false,
@@ -20,6 +31,7 @@ var o_browse = {
 
     galleryScrollTo: 0,
     metadataSelectorDrawn: false,
+    currentSelectedMetadata: undefined,
 
     lastLoadDataRequestNo: 0,
 
@@ -357,6 +369,7 @@ var o_browse = {
                 case "downloadData":
                 case "downloadURL":
                     document.location.href = $(this).attr("href");
+                    break;
                 case "help":
                     break;
             }
@@ -690,9 +703,9 @@ var o_browse = {
 
     resetMetadata: function(cols, closeModal) {
         opus.prefs.cols = cols.slice();
-        if (closeModal == true)
+        if (closeModal == true) {
             $("#metadataSelector").modal('hide');
-
+        }
         // uncheck all on left; we will check them as we go
         $("#metadataSelector .allMetadata .fa-check").hide();
 
@@ -707,12 +720,11 @@ var o_browse = {
 
     // metadata selector behaviors
     addMetadataSelectorBehaviors: function() {
-        // this is a global
-        var currentSelectedMetadata = opus.prefs.cols.slice();
+        o_browse.currentSelectedMetadata = opus.prefs.cols.slice();
 
         $("#metadataSelector").on("hide.bs.modal", function(e) {
             // update the data table w/the new columns
-            if (!o_utils.areObjectsEqual(opus.prefs.cols, currentSelectedMetadata)) {
+            if (!o_utils.areObjectsEqual(opus.prefs.cols, o_browse.currentSelectedMetadata)) {
                 o_browse.resetData();
                 o_browse.initTable(opus.col_labels);
                 opus.prefs.page.gallery = 1;
@@ -727,7 +739,7 @@ var o_browse = {
 
         $("#metadataSelector").on("show.bs.modal", function(e) {
             // save current column state so we can look for changes
-            currentSelectedMetadata = opus.prefs.cols.slice();
+            o_browse.currentSelectedMetadata = opus.prefs.cols.slice();
         });
 
         $('#metadataSelector .allMetadata').on("click", '.submenu li a', function() {
@@ -743,13 +755,13 @@ var o_browse = {
 
             if ($(chosenSlugSelector).length === 0) {
                 selectedMetadata.fadeIn();
-                // this slug was previously unselected, add to cols
+                    // this slug was previously unselected, add to cols
                 $(`<li id = "${chosenSlugSelector.substr(1)}">${label}<span class="info">&nbsp;<i class = "fas fa-info-circle" title = "${def}"></i>&nbsp;&nbsp;&nbsp;</span><span class="unselect"><i class="far fa-trash-alt"></span></li>`).hide().appendTo(".selectedMetadata > ul").fadeIn();
-                opus.prefs.cols.push(slug);
+                    opus.prefs.cols.push(slug);
             } else {
                 selectedMetadata.hide();
-                // slug had been checked, remove from the chosen
-                opus.prefs.cols.splice($.inArray(slug,opus.prefs.cols),1);
+                    // slug had been checked, remove from the chosen
+                    opus.prefs.cols.splice($.inArray(slug,opus.prefs.cols),1);
                 $(chosenSlugSelector).remove();
             }
             return false;
@@ -786,7 +798,7 @@ var o_browse = {
                 case "cancel":
                     $('#myModal').modal('hide');
                     opus.prefs.cols = [];
-                    o_browse.resetMetadata(currentSelectedMetadata, true);
+                    o_browse.resetMetadata(o_browse.currentSelectedMetadata, true);
                     break;
             }
         });
@@ -1199,7 +1211,7 @@ var o_browse = {
         page = (page === undefined ? opus.prefs.page[opus.prefs.browse] : page);
 
         // if the request is a block far away from current page cache, flush the cache and start over
-        var pagesDrawn = [];
+        let pagesDrawn = [];
         let namespace = o_browse.getViewInfo().namespace;
         $(`${namespace} [data-page]`).each(function(index, elem) {
             pagesDrawn.push($(elem).data("page"));

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -703,9 +703,11 @@ var o_browse = {
 
     resetMetadata: function(cols, closeModal) {
         opus.prefs.cols = cols.slice();
+
         if (closeModal == true) {
             $("#metadataSelector").modal('hide');
         }
+
         // uncheck all on left; we will check them as we go
         $("#metadataSelector .allMetadata .fa-check").hide();
 
@@ -755,13 +757,13 @@ var o_browse = {
 
             if ($(chosenSlugSelector).length === 0) {
                 selectedMetadata.fadeIn();
-                    // this slug was previously unselected, add to cols
+                // this slug was previously unselected, add to cols
                 $(`<li id = "${chosenSlugSelector.substr(1)}">${label}<span class="info">&nbsp;<i class = "fas fa-info-circle" title = "${def}"></i>&nbsp;&nbsp;&nbsp;</span><span class="unselect"><i class="far fa-trash-alt"></span></li>`).hide().appendTo(".selectedMetadata > ul").fadeIn();
-                    opus.prefs.cols.push(slug);
+                opus.prefs.cols.push(slug);
             } else {
                 selectedMetadata.hide();
-                    // slug had been checked, remove from the chosen
-                    opus.prefs.cols.splice($.inArray(slug,opus.prefs.cols),1);
+                // slug had been checked, remove from the chosen
+                opus.prefs.cols.splice($.inArray(slug,opus.prefs.cols),1);
                 $(chosenSlugSelector).remove();
             }
             return false;

--- a/opus/application/static_media/js/cart.js
+++ b/opus/application/static_media/js/cart.js
@@ -1,4 +1,14 @@
+/* jshint esversion: 6 */
+/* jshint bitwise: true, curly: true, freeze: true, futurehostile: true */
+/* jshint latedef: true, leanswitch: true, noarg: true, nocomma: true */
+/* jshint nonbsp: true, nonew: true */
+/* jshint varstmt: true */
+/* globals $, PerfectScrollbar */
+/* globals o_browse, o_hash, opus */
+
+/* jshint varstmt: false */
 var o_cart = {
+/* jshint varstmt: true */
     lastCartRequestNo: 0,
     lastRequestNo: 0,
     downloadInProcess: false,
@@ -199,7 +209,7 @@ var o_cart = {
     getCartTab: function() {
         o_browse.renderMetadataSelector();   // just do this in background so there's no delay when we want it...
         if (opus.cart_change) {
-            var zippedFiles_html = $(".zippedFiles", "#cart").html();
+            let zippedFiles_html = $(".zippedFiles", "#cart").html();
 
             // don't forget to remove existing stuff before append
             $(".gallery", "#cart").html("");
@@ -321,7 +331,7 @@ var o_cart = {
     editCart: function(opusId, action) {
         opus.cart_change = true;
 
-        var url = "/opus/__cart/" + action + ".json?";
+        let url = "/opus/__cart/" + action + ".json?";
         switch (action) {
             case "add":
             case "remove":
@@ -348,10 +358,12 @@ var o_cart = {
                 let limit = opus.prefs.limit * (last_page - first_page + 1);
 
                 let hashArray = o_hash.getHashArray();
-                if (hashArray.page !== undefined)
+                if (hashArray.page !== undefined) {
                     delete hashArray.page;
-                if (hashArray.limit !== undefined)
+                }
+                if (hashArray.limit !== undefined) {
                     delete hashArray.limit;
+                }
 
                 url += '&' + o_hash.hashArrayToHashString(hashArray);
                 url = url + "&limit=" + limit + "&page=" + first_page;

--- a/opus/application/static_media/js/detail.js
+++ b/opus/application/static_media/js/detail.js
@@ -1,4 +1,15 @@
+/* jshint esversion: 6 */
+/* jshint bitwise: true, curly: true, freeze: true, futurehostile: true */
+/* jshint latedef: true, leanswitch: true, noarg: true, nocomma: true */
+/* jshint nonbsp: true, nonew: true */
+/* jshint varstmt: true */
+/* jshint multistr: true */
+/* globals $, _, PerfectScrollbar */
+/* globals o_hash, opus */
+
+/* jshint varstmt: false */
 var o_detail = {
+/* jshint varstmt: true */
 
     getDetail: function(opusId) {
 

--- a/opus/application/static_media/js/hash.js
+++ b/opus/application/static_media/js/hash.js
@@ -1,4 +1,15 @@
+/* jshint esversion: 6 */
+/* jshint bitwise: true, curly: true, freeze: true, futurehostile: true */
+/* jshint latedef: true, leanswitch: true, noarg: true, nocomma: true */
+/* jshint nonbsp: true, nonew: true */
+/* jshint varstmt: true */
+/* jshint multistr: true */
+/* globals $ */
+/* globals o_browse, opus */
+
+/* jshint varstmt: false */
 var o_hash = {
+/* jshint varstmt: true */
     /**
      *
      *  changing, reading, and initiating a session from the browser hash
@@ -9,13 +20,13 @@ var o_hash = {
     updateHash: function(updateURL=true) {
 
         let hash = [];
-        for (var param in opus.selections) {
+        for (let param in opus.selections) {
             if (opus.selections[param].length) {
                 hash.push(param + "=" + opus.selections[param].join(",").replace(/ /g,"+"));
             }
         }
 
-        for (var key in opus.extras) {
+        for (let key in opus.extras) {
             try {
                 hash.push(key + "=" + opus.extras[key].join(","));
             } catch(e) {
@@ -65,12 +76,12 @@ var o_hash = {
     },
 
     getHashArray: function() {
-        var hashArray = [];
+        let hashArray = [];
         // this is a workaround for firefox
         // when user hit enter in input#page, the url hash will be "", we will remove input#page eventually
         let hashInfo = this.getHash() ? this.getHash() : o_browse.tempHash;
         $.each(hashInfo.split('&'), function(index, valuePair) {
-            var paramArray = valuePair.split("=");
+            let paramArray = valuePair.split("=");
             hashArray[paramArray[0]] = paramArray[1];
         });
         return hashArray;
@@ -87,10 +98,12 @@ var o_hash = {
     // part is part of the hash, selections or prefs
     getSelectionsFromHash: function() {
         let hash = o_hash.getHash();
-        if (!hash) return;
+        if (!hash) {
+            return;
+        }
 
         hash = (hash.search('&') > -1 ? hash.split('&') : [hash]);
-        var selections = {};  // the new set of pairs that will not include the result_table specific session vars
+        let selections = {};  // the new set of pairs that will not include the result_table specific session vars
         $.each(hash, function(index, pair) {
             let slug = pair.split('=')[0];
             let value = pair.split('=')[1];
@@ -110,7 +123,9 @@ var o_hash = {
 
     initFromHash: function() {
         let hash = o_hash.getHash();
-        if (!hash) return;
+        if (!hash) {
+            return;
+        }
         // first are any custom widget sizes in the hash?
         // just updating prefs here..
         hash = hash.split('&');

--- a/opus/application/static_media/js/menu.js
+++ b/opus/application/static_media/js/menu.js
@@ -1,4 +1,15 @@
+/* jshint esversion: 6 */
+/* jshint bitwise: true, curly: true, freeze: true, futurehostile: true */
+/* jshint latedef: true, leanswitch: true, noarg: true, nocomma: true */
+/* jshint nonbsp: true, nonew: true */
+/* jshint varstmt: true */
+/* jshint multistr: true */
+/* globals $ */
+/* globals o_hash, o_widgets, opus */
+
+/* jshint varstmt: false */
 var o_menu = {
+/* jshint varstmt: true */
 
     /**
      *
@@ -54,7 +65,7 @@ var o_menu = {
      getMenu: function() {
         $('.op-menu-text.spinner').addClass("op-show-spinner");
 
-        var hash = o_hash.getHash();
+        let hash = o_hash.getHash();
 
         $("#sidebar").load("/opus/__menu.html?" + hash, function() {
             // open menu items that were open before
@@ -72,7 +83,7 @@ var o_menu = {
             $(".menu_spinner").fadeOut("fast");
 
             o_menu.markCurrentMenuItem();
-            
+
             $('.op-menu-text.spinner').removeClass("op-show-spinner");
         });
      },
@@ -101,8 +112,8 @@ var o_menu = {
 
      // type = cat/group
      getCatGroupFromSlug: function(slug) {
-         var cat = "";
-         var group = "";
+         let cat = "";
+         let group = "";
          $("ul.menu_list>li a", "#search").each(function() {
              if (slug == $(this).data("slug")) {
                  cat = $(this).data("cat");

--- a/opus/application/static_media/js/mutationObserver.js
+++ b/opus/application/static_media/js/mutationObserver.js
@@ -1,4 +1,15 @@
+/* jshint esversion: 6 */
+/* jshint bitwise: true, curly: true, freeze: true, futurehostile: true */
+/* jshint latedef: true, leanswitch: true, noarg: true, nocomma: true */
+/* jshint nonbsp: true, nonew: true */
+/* jshint varstmt: true */
+/* jshint multistr: true */
+/* globals $, _ */
+/* globals o_browse, o_cart, o_search, opus */
+
+/* jshint varstmt: false */
 var o_mutationObserver = {
+/* jshint varstmt: true */
     // MutationObserver: detect any DOM changes and update ps correspondingly
     observePerfectScrollbar: function() {
         // Config object: tell the MutationObserver what type of changes to be detected

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -1,8 +1,22 @@
+/* jshint esversion: 6 */
+/* jshint bitwise: true, curly: true, freeze: true, futurehostile: true */
+/* jshint latedef: true, leanswitch: true, noarg: true, nocomma: true */
+/* jshint nonbsp: true, nonew: true */
+/* jshint varstmt: true */
+/* jshint multistr: true */
+/* globals $, _, PerfectScrollbar */
+/* globals o_browse, o_cart, o_detail, o_hash, o_menu, o_mutationObserver, o_search, o_utils, o_widgets */
+/* globals default_columns, default_widgets, default_sort_order, static_url */
+
 // generic globals, hmm..
+/* jshint varstmt: false */
 var default_pages = {"gallery":1, "dataTable":1, "cart_gallery":1, "cart_data":1 };
+/* jshint varstmt: true */
 
 // defining the opus namespace first; document ready comes after...
+/* jshint varstmt: false */
 var opus = {
+/* jshint varstmt: true */
 
 
     /**
@@ -406,20 +420,20 @@ $(document).ready(function() {
         opus.prefs.view = 'search';
     }
 
-    var adjustSearchHeight = _.debounce(o_search.adjustSearchHeight, 200);
-    var adjustBrowseHeight = _.debounce(o_browse.adjustBrowseHeight, 200);
-    var adjustTableSize = _.debounce(o_browse.adjustTableSize, 200);
-    var adjustProductInfoHeight = _.debounce(o_cart.adjustProductInfoHeight, 200);
-    var adjustDetailHeight = _.debounce(o_detail.adjustDetailHeight, 200);
-    var adjustHelpPanelHeight = _.debounce(opus.adjustHelpPanelHeight, 200);
+    let adjustSearchHeightDB = _.debounce(o_search.adjustSearchHeight, 200);
+    let adjustBrowseHeightDB = _.debounce(o_browse.adjustBrowseHeight, 200);
+    let adjustTableSizeDB = _.debounce(o_browse.adjustTableSize, 200);
+    let adjustProductInfoHeightDB = _.debounce(o_cart.adjustProductInfoHeight, 200);
+    let adjustDetailHeightDB = _.debounce(o_detail.adjustDetailHeight, 200);
+    let adjustHelpPanelHeightDB = _.debounce(opus.adjustHelpPanelHeight, 200);
 
-    $( window ).on("resize", function() {
-        adjustSearchHeight();
-        adjustBrowseHeight();
-        adjustTableSize();
-        adjustProductInfoHeight();
-        adjustDetailHeight();
-        adjustHelpPanelHeight();
+    $(window).on("resize", function() {
+        adjustSearchHeightDB();
+        adjustBrowseHeightDB();
+        adjustTableSizeDB();
+        adjustProductInfoHeightDB();
+        adjustDetailHeightDB();
+        adjustHelpPanelHeightDB();
     });
 
     o_mutationObserver.observePerfectScrollbar();
@@ -433,7 +447,7 @@ $(document).ready(function() {
         }
 
         // find out which tab they clicked
-        var tab = $(this).find("a").attr("href").substring(1);
+        let tab = $(this).find("a").attr("href").substring(1);
         if (tab == '/') {
             return true;  // they clicked the brand icon, take them to its link
         }
@@ -450,7 +464,7 @@ $(document).ready(function() {
 
     $(".op-help-item").on("click", function() {
         let url = "/opus/__help/";
-        var header = "";
+        let header = "";
         switch ($(this).data("action")) {
             case "about":
                 url += "about.html";

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -1,4 +1,15 @@
+/* jshint esversion: 6 */
+/* jshint bitwise: true, curly: true, freeze: true, futurehostile: true */
+/* jshint latedef: true, leanswitch: true, noarg: true, nocomma: true */
+/* jshint nonbsp: true, nonew: true */
+/* jshint varstmt: true */
+/* jshint multistr: true */
+/* globals $, PerfectScrollbar */
+/* globals o_hash, o_menu, o_utils, o_widgets, opus */
+
+/* jshint varstmt: false */
 var o_search = {
+/* jshint varstmt: true */
 
     /**
      *
@@ -152,7 +163,7 @@ var o_search = {
             let css_class = $(this).attr("class").split(' ')[0]; // class will be STRING, min or max
 
             // get values of all inputs
-            var values = [];
+            let values = [];
             if (css_class == 'STRING') {
                 $("#widget__" + slug + ' input.STRING').each(function() {
                     values.push($(this).val());
@@ -160,7 +171,7 @@ var o_search = {
                 opus.selections[slug] = values;
             } else {
                 // range query
-                var slugNoNum = slug.match(/(.*)[1|2]/)[1];
+                let slugNoNum = slug.match(/(.*)[1|2]/)[1];
                 // min
                 values = [];
                 $("#widget__" + slugNoNum + '1 input.min', '#search').each(function() {
@@ -211,8 +222,8 @@ var o_search = {
 
         $('#search').on("change", 'input.multichoice, input.singlechoice', function() {
            // mult widget gets changed
-           var id = $(this).attr("id").split('_')[0];
-           var value = $(this).attr("value").replace(/\+/g, '%2B');
+           let id = $(this).attr("id").split('_')[0];
+           let value = $(this).attr("value").replace(/\+/g, '%2B');
 
            if ($(this).is(':checked')) {
                let values = [];
@@ -232,12 +243,12 @@ var o_search = {
 
                // special menu behavior for surface geo, slide in a loading indicator..
                if (id == 'surfacetarget') {
-                    var surface_loading = '<li style = "margin-left:50%; display:none" class = "spinner">&nbsp;</li>';
+                    let surface_loading = '<li style = "margin-left:50%; display:none" class = "spinner">&nbsp;</li>';
                     $(surface_loading).appendTo($('a.surfacetarget').parent()).slideDown("slow").delay(500);
                }
 
            } else {
-               var remove = opus.selections[id].indexOf(value); // find index of value to remove
+               let remove = opus.selections[id].indexOf(value); // find index of value to remove
                opus.selections[id].splice(remove,1);        // remove value from array
            }
            o_hash.updateHash();
@@ -485,7 +496,7 @@ var o_search = {
 
         o_search.lastEndpointsRequestNo++;
         o_search.slugEndpointsReqno[slug] = o_search.lastEndpointsRequestNo;
-        var url = `/opus/__api/meta/range/endpoints/${slug}.json?${o_hash.getHash()}&reqno=${o_search.slugEndpointsReqno[slug]}`;
+        let url = `/opus/__api/meta/range/endpoints/${slug}.json?${o_hash.getHash()}&reqno=${o_search.slugEndpointsReqno[slug]}`;
         $.ajax({url: url,
             dataType:"json",
             success: function(multdata) {
@@ -515,7 +526,7 @@ var o_search = {
 
         o_search.lastMultsRequestNo++;
         o_search.slugMultsReqno[slug] = o_search.lastMultsRequestNo;
-        var url = `/opus/__api/meta/mults/${slug}.json?${o_hash.getHash()}&reqno=${o_search.slugMultsReqno[slug]}`;
+        let url = `/opus/__api/meta/mults/${slug}.json?${o_hash.getHash()}&reqno=${o_search.slugMultsReqno[slug]}`;
         $.ajax({url: url,
             dataType:"json",
             success: function(multdata) {
@@ -523,14 +534,14 @@ var o_search = {
                     return;
                 }
 
-                var dataSlug = multdata.field;
+                let dataSlug = multdata.field;
                 $("#widget__" + dataSlug + " .spinner").fadeOut('');
 
-                var widget = "widget__" + dataSlug;
-                var mults = multdata.mults;
+                let widget = "widget__" + dataSlug;
+                let mults = multdata.mults;
                 $('#' + widget + ' input').each( function() {
-                    var value = $(this).attr("value");
-                    var id = '#hint__' + slug + "_" + value.replace(/ /g,'-').replace(/[^\w\s]/gi, '');  // id of hinting span, defined in widgets.js getWidget
+                    let value = $(this).attr("value");
+                    let id = '#hint__' + slug + "_" + value.replace(/ /g,'-').replace(/[^\w\s]/gi, '');  // id of hinting span, defined in widgets.js getWidget
 
                     if (mults[value]) {
                           $(id).html('<span>' + mults[value] + '</span>');

--- a/opus/application/static_media/js/utils.js
+++ b/opus/application/static_media/js/utils.js
@@ -1,5 +1,13 @@
+/* jshint esversion: 6 */
+/* jshint bitwise: true, curly: true, freeze: true, futurehostile: true */
+/* jshint latedef: true, leanswitch: true, noarg: true, nocomma: true */
+/* jshint nonbsp: true, nonew: true */
+/* jshint varstmt: true */
+/* jshint multistr: true */
 
+/* jshint varstmt: false */
 var o_utils = {
+/* jshint varstmt: true */
 
     /**
      *

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -1,4 +1,15 @@
+/* jshint esversion: 6 */
+/* jshint bitwise: true, curly: true, freeze: true, futurehostile: true */
+/* jshint latedef: true, leanswitch: true, noarg: true, nocomma: true */
+/* jshint nonbsp: true, nonew: true */
+/* jshint varstmt: true */
+/* jshint multistr: true */
+/* globals $ */
+/* globals o_hash, o_menu, o_search, o_utils, opus */
+
+/* jshint varstmt: false */
 var o_widgets = {
+/* jshint varstmt: true */
 
     /**
      *
@@ -41,7 +52,7 @@ var o_widgets = {
 
         // close a card
         $('#search').on('click', '.close_card', function(myevent) {
-            var slug = $(this).data('slug');
+            let slug = $(this).data('slug');
             o_widgets.closeWidget(slug);
             let id = "#widget__"+slug;
             try {
@@ -69,7 +80,7 @@ var o_widgets = {
 
     closeWidget: function(slug) {
 
-        var slugNoNum;
+        let slugNoNum;
         try {
             slugNoNum = slug.match(/(.*)[1|2]/)[1];
         } catch (e) {
@@ -102,7 +113,7 @@ var o_widgets = {
         delete opus.extras[`qtype-${slugNoNum}`];
         delete opus.extras[`z-${slugNoNum}`];
 
-        var selector = `li [data-slug='${slug}']`;
+        let selector = `li [data-slug='${slug}']`;
         o_menu.markMenuItem(selector, "unselect");
 
         o_search.allNormalizedApiCall().then(function(normalizedData) {
@@ -147,7 +158,7 @@ var o_widgets = {
                 // adding a behavior: checking a planet box opens the corresponding targets
                 $('#search').on('change', '#widget__planet input:checkbox:checked', function() {
                     // a planet is .chosen_columns, and its corresponding target is not already open
-                    var mult_id = '.mult_group_' + $(this).attr('value');
+                    let mult_id = '.mult_group_' + $(this).attr('value');
                     $(mult_id).find('.indicator').addClass('fa-minus');
                     $(mult_id).find('.indicator').removeClass('fa-plus');
                     $(mult_id).next().slideDown("fast");
@@ -159,7 +170,7 @@ var o_widgets = {
                 // usually for when a planet checkbox is checked on page load
                 $('#widget__planet input:checkbox:checked', '#search').each(function() {
                     if ($(this).attr('id') && $(this).attr('id').split('_')[0] == 'planet') { // confine to param/vals - not other input controls
-                        var mult_id = '.mult_group_' + $(this).attr('value');
+                        let mult_id = '.mult_group_' + $(this).attr('value');
                         $(mult_id).find('.indicator').addClass('fa-minus');
                         $(mult_id).find('.indicator').removeClass('fa-plus');
                         $(mult_id).next().slideDown("fast");
@@ -172,7 +183,7 @@ var o_widgets = {
                // usually for when a planet checkbox is checked on page load
                $('#widget__planet input:checkbox:checked', '#search').each(function() {
                    if ($(this).attr('id') && $(this).attr('id').split('_')[0] == 'planet') { // confine to param/vals - not other input controls
-                       var mult_id = '.mult_group_' + $(this).attr('value');
+                       let mult_id = '.mult_group_' + $(this).attr('value');
                        $(mult_id).find('.indicator').addClass('fa-minus');
                        $(mult_id).find('.indicator').removeClass('fa-plus');
                        $(mult_id).next().slideDown("fast");
@@ -249,24 +260,24 @@ var o_widgets = {
 
          if (opus.selections[slug]) {
 
-             var form_type = $('#widget__' + slug + ' .widget_inner').attr("class").split(' ')[1];
+             let form_type = $('#widget__' + slug + ' .widget_inner').attr("class").split(' ')[1];
 
              if (form_type == 'RANGE') {
 
                  // this is a range widget
-                 var qtypes;
+                 let qtypes;
                  try {
                      qtypes = opus.extras['qtype-' + slugNoNum];
                  } catch(e) {
                      qtypes = [opus.qtype_default];
                  }
 
-                 var length = (opus.selections[slugMin].length > opus.selections[slugMax].length) ? opus.selections[slugMin].length : opus.selections[slugMax].length;
+                 let length = (opus.selections[slugMin].length > opus.selections[slugMax].length) ? opus.selections[slugMin].length : opus.selections[slugMax].length;
 
                  simple = [];
-                 for (var i=0;i<length;i++) {
+                 for (let i=0;i<length;i++) {
                      // ouch:
-                     var qtype;
+                     let qtype;
                      try{
                          qtype = qtypes[i];
                      } catch(e) {
@@ -296,11 +307,13 @@ var o_widgets = {
                       break;  // we have decided to only show the first range in the minimized display
                   }
                   simple = label + simple.join(' and ');
-                  if (length > 1) simple = simple + ' and more..';
+                  if (length > 1) {
+                      simple = simple + ' and more..';
+                  }
 
              } else if (form_type == 'STRING') {
-                 var s_arr = [];
-                 var last_qtype = '';
+                 let s_arr = [];
+                 let last_qtype = '';
                  for (let key in opus.selections[slug]) {
                      let value = opus.selections[slug][key];
                      let qtype;
@@ -341,10 +354,10 @@ var o_widgets = {
          // this is for when you are first drawing the browse tab and there
          // multiple widgets being requested at once and we want to preserve their order
          // and avoid race conditions that will throw them out of order
-         for (var k in opus.prefs.widgets) {
-             var slug = opus.prefs.widgets[k];
-             var widget = 'widget__' + slug;
-             var html = '<li id = "' + widget + '" class = "widget"></li>';
+         for (let k in opus.prefs.widgets) {
+             let slug = opus.prefs.widgets[k];
+             let widget = 'widget__' + slug;
+             let html = '<li id = "' + widget + '" class = "widget"></li>';
              $(html).appendTo('#op-search-widgets ');
              // $(html).hide().appendTo('#op-search-widgets').show("blind",{direction: "vertical" },200);
              opus.widget_elements_drawn.push(slug);
@@ -354,7 +367,9 @@ var o_widgets = {
      // adds a widget and its behaviors, adjusts the opus.prefs variable to include this widget, will not update the hash
     getWidget: function(slug, formscolumn, deferredObj=null) {
 
-        if (!slug) return;
+        if (!slug) {
+            return;
+        }
 
         if ($.inArray(slug, opus.widgets_drawn) > -1) {
             return; // widget already drawn
@@ -363,7 +378,7 @@ var o_widgets = {
             return; // widget being fetched
         }
 
-        var widget = 'widget__' + slug;
+        let widget = 'widget__' + slug;
 
         opus.widgets_fetching.push(slug);
 
@@ -374,7 +389,7 @@ var o_widgets = {
 
             o_widgets.updateWidgetCookies();
             // these sometimes get drawn on page load by placeWidgetContainers, but not this time:
-            var html = '<li id = "' + widget + '" class = "widget"></li>';
+            let html = '<li id = "' + widget + '" class = "widget"></li>';
             $(html).hide().prependTo(formscolumn).show("slow");
             opus.widget_elements_drawn.unshift(slug);
 
@@ -388,7 +403,7 @@ var o_widgets = {
              // already defined by the url:
              if (slug.match(/.*(1|2)/)) {
                // this is a range widget
-                 var id = slug.match(/(.*)[1|2]/)[1];
+                 let id = slug.match(/(.*)[1|2]/)[1];
 
                 // is the qtype constrained in the url?
                  if ($.inArray('qtype-' + id,opus.extras) > -1 && opus.extras['qtype-'+id]) {
@@ -400,7 +415,7 @@ var o_widgets = {
                 // add the helper text for range widgets
                 if ($('.' + widget).hasClass('range-widget') && $('.' + widget).find('select').length) {
                     // this is a range widget and also the any/all/only dropdown is included
-                    var help_icon = '<a href = "#" data-toggle="popover" data-placement="left">\
+                    let help_icon = '<a href = "#" data-toggle="popover" data-placement="left">\
                                     <i class="fa fa-info-circle"></i></a>';
 
                     $('.' + widget + ' .widget-main>ul>ul').append('<li class = "range-qtype-helper">' + help_icon + '</li>');
@@ -546,8 +561,8 @@ var o_widgets = {
              // add the spans that hold the hinting
              try {
                  $('#' + widget + ' ul label').after(function() {
-                    var value = $(this).find('input').attr("value");
-                    var span_id = 'hint__' + slug + '_' + value.replace(/ /g,'-').replace(/[^\w\s]/gi, '');  // special chars not allowed in id element
+                    let value = $(this).find('input').attr("value");
+                    let span_id = 'hint__' + slug + '_' + value.replace(/ /g,'-').replace(/[^\w\s]/gi, '');  // special chars not allowed in id element
                     return '<span class = "hints" id = "' + span_id + '"></span>';
                  });
              } catch(e) { } // these only apply to mult widgets


### PR DESCRIPTION
JSHINT is now clean for all code (except a few places where it complains about things that are actually correct). There are no more "var" statements except for top-level namespaces. Directives have been added to the top of each file to make JSHINT behave in the future. Simply copy-paste the code into jshint.com and look for warnings or errors.
