### PR TITLE
Fix selections and extras and add default qtype

### DIFF
--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -252,9 +252,10 @@ ul.searchMenu {
     border-width: 3px;
 }
 
-.modal {
+/* We have to comment this out to prevent user from clicking navbar link when modal is open */
+/* .modal {
     top: 4%;
-}
+} */
 
 .modal-content {
     border-radius: 1%;

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -252,11 +252,6 @@ ul.searchMenu {
     border-width: 3px;
 }
 
-/* We have to comment this out to prevent user from clicking navbar link when modal is open */
-/* .modal {
-    top: 4%;
-} */
-
 .modal-content {
     border-radius: 1%;
 }

--- a/opus/application/static_media/js/hash.js
+++ b/opus/application/static_media/js/hash.js
@@ -59,8 +59,7 @@ var o_hash = {
                 }
             }
         );
-        // console.log("hash from hash.js");
-        // console.log(hash);
+
         if (updateURL) {
             window.location.hash = '/' + hash.join('&');
         }
@@ -83,9 +82,7 @@ var o_hash = {
 
     getHashArray: function() {
         let hashArray = [];
-        // this is a workaround for firefox
-        // when user hit enter in input#page, the url hash will be "", we will remove input#page eventually
-        let hashInfo = this.getHash() ? this.getHash() : o_browse.tempHash;
+        let hashInfo = o_hash.getHash();
         $.each(hashInfo.split('&'), function(index, valuePair) {
             let paramArray = valuePair.split("=");
             hashArray[paramArray[0]] = paramArray[1];

--- a/opus/application/static_media/js/hash.js
+++ b/opus/application/static_media/js/hash.js
@@ -107,6 +107,7 @@ var o_hash = {
 
         hash = (hash.search('&') > -1 ? hash.split('&') : [hash]);
         let selections = {};  // the new set of pairs that will not include the result_table specific session vars
+
         $.each(hash, function(index, pair) {
             let slug = pair.split('=')[0];
             let value = pair.split('=')[1];

--- a/opus/application/static_media/js/hash.js
+++ b/opus/application/static_media/js/hash.js
@@ -99,7 +99,7 @@ var o_hash = {
     },
 
     // part is part of the hash, selections or prefs
-    getSelectionsFromHash: function() {
+    getSelectionsExtrasFromHash: function() {
         let hash = o_hash.getHash();
         if (!hash) {
             return;
@@ -107,21 +107,28 @@ var o_hash = {
 
         hash = (hash.search('&') > -1 ? hash.split('&') : [hash]);
         let selections = {};  // the new set of pairs that will not include the result_table specific session vars
+        let extras = {}; // store qtype from url
 
         $.each(hash, function(index, pair) {
             let slug = pair.split('=')[0];
             let value = pair.split('=')[1];
 
             if (!(slug in opus.prefs) && value) {
-                if (slug in selections) {
-                    selections[slug].push(value);
+
+                if (slug.match(/qtype/)) {
+                    extras[slug] = [value];
                 } else {
-                    selections[slug] = [value];
+                    if (slug in selections) {
+                        selections[slug].push(value);
+                    } else {
+                        selections[slug] = [value];
+                    }
                 }
+
             }
         });
 
-        return selections;
+        return [selections, extras];
     },
 
 

--- a/opus/application/static_media/js/hash.js
+++ b/opus/application/static_media/js/hash.js
@@ -116,12 +116,14 @@ var o_hash = {
             if (!(slug in opus.prefs) && value) {
 
                 if (slug.match(/qtype/)) {
+                    // each qtype will only have one value at a time
                     extras[slug] = [value];
                 } else {
                     if (slug in selections) {
                         selections[slug].push(value);
                     } else {
-                        selections[slug] = [value];
+                        // selections[slug] = [value];
+                        selections[slug] = value.replace("+", " ").split(",");
                     }
                 }
 

--- a/opus/application/static_media/js/hash.js
+++ b/opus/application/static_media/js/hash.js
@@ -115,7 +115,7 @@ var o_hash = {
 
             if (!(slug in opus.prefs) && value) {
 
-                if (slug.match(/qtype/)) {
+                if (slug.startsWith("qtype-")) {
                     // each qtype will only have one value at a time
                     extras[slug] = [value];
                 } else {

--- a/opus/application/static_media/js/hash.js
+++ b/opus/application/static_media/js/hash.js
@@ -98,11 +98,11 @@ var o_hash = {
         return hash;
     },
 
-    // part is part of the hash, selections or prefs
+    // get both selections and extras (qtype) from hash.
     getSelectionsExtrasFromHash: function() {
         let hash = o_hash.getHash();
         if (!hash) {
-            return;
+            return [undefined, undefined];
         }
 
         hash = (hash.search('&') > -1 ? hash.split('&') : [hash]);

--- a/opus/application/static_media/js/hash.js
+++ b/opus/application/static_media/js/hash.js
@@ -119,12 +119,7 @@ var o_hash = {
                     // each qtype will only have one value at a time
                     extras[slug] = [value];
                 } else {
-                    if (slug in selections) {
-                        selections[slug].push(value);
-                    } else {
-                        // selections[slug] = [value];
-                        selections[slug] = value.replace("+", " ").split(",");
-                    }
+                    selections[slug] = value.replace("+", " ").split(",");
                 }
 
             }

--- a/opus/application/static_media/js/menu.js
+++ b/opus/application/static_media/js/menu.js
@@ -38,7 +38,7 @@ var o_menu = {
                   o_menu.markMenuItem(this);
                   o_widgets.getWidget(slug,'#op-search-widgets');
              }
-
+             
              o_hash.updateHash();
              return false;
          });

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -71,9 +71,8 @@ var opus = {
     // searching - making queries
     selections: {},        // the user's search
     extras: {},            // extras to the query, carries units, string_selects, qtypes, size, refreshes result count!!
-    last_selections: {},   // last_ are used to moniter changes
-    last_extras: {},
-    last_hash: '',
+    lastSelections: {},   // last_ are used to moniter changes
+    lastExtras: {},
     result_count: 0,
     qtype_default: 'any',
     force_load: true, // set this to true to force load() when selections haven't changed
@@ -113,18 +112,12 @@ var opus = {
         whether to fire an ajax call.
         */
 
-        // let selections = o_hash.getSelectionsFromHash();
         let [selections, extras] = o_hash.getSelectionsExtrasFromHash();
-        // console.log("=== From getSelectionsExtrasFromHash ===");
-        // console.log(selections);
-        // console.log(extras);
 
-        if (selections === undefined) {
+        if (selections === undefined && extras === undefined) {
             return;
         }
 
-        // console.log("=== selections from getSelectionsFromHash ===")
-        // console.log(selections);
         // if (!$.isEmptyObject(opus.selections) || !opus.checkIfDrawnWidgetsAreDefault() || !opus.checkIfMetadataAreDefault()) {
         if ($.isEmptyObject(selections) || !opus.checkIfDrawnWidgetsAreDefault()) {
             $(".op-reset-button button").prop("disabled", false);
@@ -135,48 +128,18 @@ var opus = {
             $(".op-reset-button button").prop("disabled", true);
         }
 
-        // compare selections and last selections
-        if (o_utils.areObjectsEqual(selections, opus.last_selections) && o_utils.areObjectsEqual(extras, opus.extras)) {
-            // selections have not changed from opus.last_selections
+        // compare selections and last selections, extras and last extras
+        if (o_utils.areObjectsEqual(selections, opus.lastSelections) && o_utils.areObjectsEqual(extras, opus.lastExtras)) {
+            // selections have not changed from opus.lastSelections
             if (!opus.force_load) { // so we do only non-reloading pref changes
                 return;
             }
         } else {
-            // selections in the url hash is different from opus.last_selections
+            // selections in the url hash is different from opus.lastSelections
             // reset the pages:
             opus.prefs.page = default_pages;
 
-            // create an object from selections to compare with opus.selections
-            // let modifiedSelections = {};
-            // $.each(Object.keys(selections), function(idx, slug) {
-            //     // Note: when we select qtype, it is not updated in opus.selections
-            //     // Therefore, we will not put qtype in modifiedSelections to compare with opus.selection
-            //     if (!slug.match(/qtype/)) {
-            //         modifiedSelections[slug] = selections[slug][0].replace("+", " ").split(",");
-            //     }
-            // });
-
-            // debug print out
-            console.log("=== selections ===")
-            console.log(selections);
-            // console.log("=== modifiedSelections ===")
-            // console.log(modifiedSelections);
-            console.log("=== opus.selections ===");
-            console.log(opus.selections);
-            console.log("=== opus.last_selections ===");
-            console.log(opus.last_selections);
-            console.log("=== opus.extras ===");
-            console.log(opus.extras);
-            console.log("=== opus.last_extras ===");
-            console.log(opus.last_extras);
-            // console.log("Are modifiedSelections and opus.selections the same ?");
-            // console.log(o_utils.areObjectsEqual(modifiedSelections, opus.selections));
-            console.log("Are selections and opus.selections the same?");
-            console.log(o_utils.areObjectsEqual(selections, opus.selections));
-            console.log("Are extras and opus.extras the same?");
-            console.log(o_utils.areObjectsEqual(extras, opus.extras));
-
-            // if data in selections !== data in opus.selections, it means selections are modified manually in url, reload the page (modified url in url bar and hit enter)
+            // if data in selections !== data in opus.selections or extras !== data in opus.extras, it means selections/qtype are modified manually in url, reload the page (modified url in url bar and hit enter)
             if (!o_utils.areObjectsEqual(selections, opus.selections) || !o_utils.areObjectsEqual(extras, opus.extras)) {
                 opus.selections = selections;
                 opus.extras = extras;
@@ -199,9 +162,10 @@ var opus = {
         $("#op-search-widgets .spinner").fadeIn();
 
         // update last selections after the comparison of selections and last selections
+        // update last extras after the comparison of extras and last extras
         // move this above allNormalizedApiCall to avoid recursive api call
-        opus.last_selections = selections;
-        opus.last_extras = extras;
+        opus.lastSelections = selections;
+        opus.lastExtras = extras;
 
         // chain ajax calls, validate range inputs before result count api call
         o_search.allNormalizedApiCall().then(opus.getResultCount).then(opus.updatePageAfterResultCountAPI);
@@ -244,7 +208,7 @@ var opus = {
         o_search.validateRangeInput(normalizedData, true);
 
         // query string has changed
-        // opus.last_selections = selections;
+        // opus.lastSelections = selections;
         opus.lastResultCountRequestNo++;
         let resultCountHash = o_hash.getHash();
 

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -55,6 +55,7 @@ var opus = {
         "page": default_pages,  // what page are we on, per view, default defined in header.html
                                // like {"gallery":1, "data":1, "cart_gallery":1, "cart_data":1 };
         "limit": 100, // results per page
+        "cart_page": 1, // this will be removed in startobs branch, we put it here for now because it should not be included in selections
      }, // pref changes do not trigger load()
 
     col_labels: [],  // contains labels that match prefs.cols, which are slugs for each column label
@@ -111,7 +112,11 @@ var opus = {
         whether to fire an ajax call.
         */
 
-        let selections = o_hash.getSelectionsFromHash();
+        // let selections = o_hash.getSelectionsFromHash();
+        let [selections, extras] = o_hash.getSelectionsExtrasFromHash();
+        console.log("=== From getSelectionsExtrasFromHash ===");
+        console.log(selections);
+        console.log(extras);
 
         if (selections === undefined) {
             return;

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -119,7 +119,7 @@ var opus = {
         if (selections === undefined) {
             // safety check, the if condition should never be true
             if (extras !== undefined) {
-                console.error("Returned extras is wrong when URL has an empty hash")
+                console.error("Returned extras is wrong when URL has an empty hash");
             }
             return;
         }

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -71,7 +71,7 @@ var opus = {
     // searching - making queries
     selections: {},        // the user's search
     extras: {},            // extras to the query, carries units, string_selects, qtypes, size, refreshes result count!!
-    lastSelections: {},   // last_ are used to moniter changes
+    lastSelections: {},   // last_ are used to monitor changes
     lastExtras: {},
     result_count: 0,
     qtype_default: 'any',
@@ -130,14 +130,10 @@ var opus = {
 
         // compare selections and last selections, extras and last extras
         if (o_utils.areObjectsEqual(selections, opus.lastSelections) && o_utils.areObjectsEqual(extras, opus.lastExtras)) {
-            // selections have not changed from opus.lastSelections
-            // AND extras have not changed from opus.lastExtras
             if (!opus.force_load) { // so we do only non-reloading pref changes
                 return;
             }
         } else {
-            // selections in the url hash is different from opus.lastSelections
-            // OR extras in the url hash is different from opus.lastExtras
             // reset the pages:
             opus.prefs.page = default_pages;
 
@@ -209,8 +205,6 @@ var opus = {
         }
         o_search.validateRangeInput(normalizedData, true);
 
-        // query string has changed
-        // opus.lastSelections = selections;
         opus.lastResultCountRequestNo++;
         let resultCountHash = o_hash.getHash();
 

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -114,7 +114,13 @@ var opus = {
 
         let [selections, extras] = o_hash.getSelectionsExtrasFromHash();
 
-        if (selections === undefined && extras === undefined) {
+        // Note: When URL has an empty hash, both selections and extras returned from getSelectionsExtrasFromHash will be undefined.
+        // There won't be a case with only one of them is undefined.
+        if (selections === undefined) {
+            // safety check, the if condition should never be true
+            if (extras !== undefined) {
+                console.error("Returned extras is wrong when URL has an empty hash")
+            }
             return;
         }
 

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -68,34 +68,34 @@ var opus = {
     // additional defaults are in base.html
 
     // searching - making queries
-    selections:{},        // the user's search
-    extras:{},            // extras to the query, carries units, string_selects, qtypes, size, refreshes result count!!
-    last_selections:{},   // last_ are used to moniter changes
-    last_hash:'',
-    result_count:0,
+    selections: {},        // the user's search
+    extras: {},            // extras to the query, carries units, string_selects, qtypes, size, refreshes result count!!
+    last_selections: {},   // last_ are used to moniter changes
+    last_hash: '',
+    result_count: 0,
     qtype_default: 'any',
     force_load: true, // set this to true to force load() when selections haven't changed
 
     // searching - ui
-    widgets_drawn:[], // keeps track of what widgets are actually drawn
-    widgets_fetching:[], // this widget is currently being fetched
-    widget_elements_drawn:[], // the element is drawn but the widget might not be fetched yet
-    widget_full_sizes:{}, // when a widget is minimized and doesn't have a custom size defined we keep track of what the full size was so we can restore it when they unminimize/maximize widget
+    widgets_drawn: [], // keeps track of what widgets are actually drawn
+    widgets_fetching: [], // this widget is currently being fetched
+    widget_elements_drawn: [], // the element is drawn but the widget might not be fetched yet
+    widget_full_sizes: {}, // when a widget is minimized and doesn't have a custom size defined we keep track of what the full size was so we can restore it when they unminimize/maximize widget
     menu_state: {'cats':['obs_general']},
     default_widgets: default_widgets.split(','),
-    widget_click_timeout:0,
+    widget_click_timeout: 0,
 
     // browse tab
-    pages:0, // total number of pages this result
+    pages: 0, // total number of pages this result
 
     // cart
-    cart_change:true, // cart has changed since last load of cart_tab
+    cart_change: true, // cart has changed since last load of cart_tab
     cart_q_intrvl: false,
-    cart_options_viz:false,
+    cart_options_viz: false,
 
     // these are for the process that detects there was a change in the selection criteria and updates things
-    main_timer:false,
-    main_timer_interval:1000,
+    main_timer: false,
+    main_timer_interval: 1000,
 
     allInputsValid: true,
 
@@ -117,6 +117,8 @@ var opus = {
             return;
         }
 
+        // console.log("=== selections from getSelectionsFromHash ===")
+        // console.log(selections);
         // if (!$.isEmptyObject(opus.selections) || !opus.checkIfDrawnWidgetsAreDefault() || !opus.checkIfMetadataAreDefault()) {
         if ($.isEmptyObject(selections) || !opus.checkIfDrawnWidgetsAreDefault()) {
             $(".op-reset-button button").prop("disabled", false);
@@ -147,6 +149,18 @@ var opus = {
                     modifiedSelections[slug] = selections[slug][0].replace("+", " ").split(",");
                 }
             });
+
+            // debug print out
+            console.log("=== selections ===")
+            console.log(selections);
+            console.log("=== modifiedSelections ===")
+            console.log(modifiedSelections);
+            console.log("=== opus.selections ===");
+            console.log(opus.selections);
+            console.log("=== opus.last_selections ===");
+            console.log(opus.last_selections);
+            console.log("Are modifiedSelections and opus.selections the same ?");
+            console.log(o_utils.areObjectsEqual(modifiedSelections, opus.selections));
 
             // if data in selections !== data in opus.selections, it means selections are modified manually in url, reload the page (modified url in url bar and hit enter)
             if (!o_utils.areObjectsEqual(modifiedSelections, opus.selections)) {

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -131,11 +131,13 @@ var opus = {
         // compare selections and last selections, extras and last extras
         if (o_utils.areObjectsEqual(selections, opus.lastSelections) && o_utils.areObjectsEqual(extras, opus.lastExtras)) {
             // selections have not changed from opus.lastSelections
+            // AND extras have not changed from opus.lastExtras
             if (!opus.force_load) { // so we do only non-reloading pref changes
                 return;
             }
         } else {
             // selections in the url hash is different from opus.lastSelections
+            // OR extras in the url hash is different from opus.lastExtras
             // reset the pages:
             opus.prefs.page = default_pages;
 

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -72,6 +72,7 @@ var opus = {
     selections: {},        // the user's search
     extras: {},            // extras to the query, carries units, string_selects, qtypes, size, refreshes result count!!
     last_selections: {},   // last_ are used to moniter changes
+    last_extras: {},
     last_hash: '',
     result_count: 0,
     qtype_default: 'any',
@@ -114,9 +115,9 @@ var opus = {
 
         // let selections = o_hash.getSelectionsFromHash();
         let [selections, extras] = o_hash.getSelectionsExtrasFromHash();
-        console.log("=== From getSelectionsExtrasFromHash ===");
-        console.log(selections);
-        console.log(extras);
+        // console.log("=== From getSelectionsExtrasFromHash ===");
+        // console.log(selections);
+        // console.log(extras);
 
         if (selections === undefined) {
             return;
@@ -135,7 +136,7 @@ var opus = {
         }
 
         // compare selections and last selections
-        if (o_utils.areObjectsEqual(selections, opus.last_selections)) {
+        if (o_utils.areObjectsEqual(selections, opus.last_selections) && o_utils.areObjectsEqual(extras, opus.extras)) {
             // selections have not changed from opus.last_selections
             if (!opus.force_load) { // so we do only non-reloading pref changes
                 return;
@@ -146,30 +147,39 @@ var opus = {
             opus.prefs.page = default_pages;
 
             // create an object from selections to compare with opus.selections
-            let modifiedSelections = {};
-            $.each(Object.keys(selections), function(idx, slug) {
-                // Note: when we select qtype, it is not updated in opus.selections
-                // Therefore, we will not put qtype in modifiedSelections to compare with opus.selection
-                if (!slug.match(/qtype/)) {
-                    modifiedSelections[slug] = selections[slug][0].replace("+", " ").split(",");
-                }
-            });
+            // let modifiedSelections = {};
+            // $.each(Object.keys(selections), function(idx, slug) {
+            //     // Note: when we select qtype, it is not updated in opus.selections
+            //     // Therefore, we will not put qtype in modifiedSelections to compare with opus.selection
+            //     if (!slug.match(/qtype/)) {
+            //         modifiedSelections[slug] = selections[slug][0].replace("+", " ").split(",");
+            //     }
+            // });
 
             // debug print out
             console.log("=== selections ===")
             console.log(selections);
-            console.log("=== modifiedSelections ===")
-            console.log(modifiedSelections);
+            // console.log("=== modifiedSelections ===")
+            // console.log(modifiedSelections);
             console.log("=== opus.selections ===");
             console.log(opus.selections);
             console.log("=== opus.last_selections ===");
             console.log(opus.last_selections);
-            console.log("Are modifiedSelections and opus.selections the same ?");
-            console.log(o_utils.areObjectsEqual(modifiedSelections, opus.selections));
+            console.log("=== opus.extras ===");
+            console.log(opus.extras);
+            console.log("=== opus.last_extras ===");
+            console.log(opus.last_extras);
+            // console.log("Are modifiedSelections and opus.selections the same ?");
+            // console.log(o_utils.areObjectsEqual(modifiedSelections, opus.selections));
+            console.log("Are selections and opus.selections the same?");
+            console.log(o_utils.areObjectsEqual(selections, opus.selections));
+            console.log("Are extras and opus.extras the same?");
+            console.log(o_utils.areObjectsEqual(extras, opus.extras));
 
             // if data in selections !== data in opus.selections, it means selections are modified manually in url, reload the page (modified url in url bar and hit enter)
-            if (!o_utils.areObjectsEqual(modifiedSelections, opus.selections)) {
-                opus.selections = modifiedSelections;
+            if (!o_utils.areObjectsEqual(selections, opus.selections) || !o_utils.areObjectsEqual(extras, opus.extras)) {
+                opus.selections = selections;
+                opus.extras = extras;
                 location.reload();
                 return;
             } else {
@@ -191,6 +201,7 @@ var opus = {
         // update last selections after the comparison of selections and last selections
         // move this above allNormalizedApiCall to avoid recursive api call
         opus.last_selections = selections;
+        opus.last_extras = extras;
 
         // chain ajax calls, validate range inputs before result count api call
         o_search.allNormalizedApiCall().then(opus.getResultCount).then(opus.updatePageAfterResultCountAPI);

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -215,8 +215,8 @@ var o_search = {
                 }
             }
 
-            if (opus.last_selections && opus.last_selections[slug]) {
-                if (opus.last_selections[slug][0] === $(this).val().trim()) {
+            if (opus.lastSelections && opus.lastSelections[slug]) {
+                if (opus.lastSelections[slug][0] === $(this).val().trim()) {
                     return;
                 }
             }
@@ -392,7 +392,7 @@ var o_search = {
             }
 
             o_hash.updateHash();
-            if (o_utils.areObjectsEqual(opus.selections, opus.last_selections))  {
+            if (o_utils.areObjectsEqual(opus.selections, opus.lastSelections))  {
                 // Put back normal hinting info
                 opus.widgets_drawn.forEach(function(eachSlug) {
                     o_search.getHinting(eachSlug);

--- a/opus/application/static_media/js/utils.js
+++ b/opus/application/static_media/js/utils.js
@@ -16,7 +16,7 @@ var o_utils = {
      **/
 
 
-    // this is for comparing selections to last_selections
+    // this is for comparing selections to lastSelections
     // expects an object whose values are all arrays
     areObjectsEqual: function(obj1, obj2) {
       // perhaps not fabulous; see https://stackoverflow.com/questions/3791516/comparing-native-javascript-objects-with-jquery

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -399,8 +399,16 @@ var o_widgets = {
                 $("#widget__"+slug).html(widget_str);
             }}).done(function() {
 
-                // console.log("=== opus.extras ===");
-                // console.log(opus.extras);
+                // If there is no specified qtype in the url, we want default qtype to be in the url
+                // This will also put qtype in the url when a widget is open.
+                // Need to wait until api return to determine if the widget has qtype selections
+                let hash = o_hash.getHashArray();
+                let qtype = "qtype-" + slug;
+                if ($(`#widget__${slug} select[name="${qtype}"]`).length !== 0 && !hash[qtype]) {
+                    opus.extras[qtype] = [opus.qtype_default];
+                    o_hash.updateHash();
+                }
+
              // if we are drawing a range widget we need to check if the qtype dropdown is
              // already defined by the url:
              if (slug.match(/.*(1|2)/)) {
@@ -411,13 +419,8 @@ var o_widgets = {
                  if ($.inArray('qtype-' + id, opus.extras) > -1 && opus.extras['qtype-'+id]) {
                      // this widgets dropdown is defined in the url, update the html select dropdown to match
                      $('#' + widget + ' select').attr("value", opus.extras['qtype-'+id]);
-                 } else {
-                     // If there is no specified qtype in the url, we want default qtype to be in the url
-                     // This will also put qtype in the url when a widget is open
-                     opus.extras["qype-" + id] = opus.qtype_default;
                  }
-                 console.log("=== opus.extras ===");
-                 console.log(opus.extras);
+
                  // add the helper icon to range widgets.
                 // add the helper text for range widgets
                 if ($('.' + widget).hasClass('range-widget') && $('.' + widget).find('select').length) {

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -406,6 +406,7 @@ var o_widgets = {
             let hash = o_hash.getHashArray();
             let qtype = "qtype-" + slug;
             if ($(`#widget__${slug} select[name="${qtype}"]`).length !== 0 && !hash[qtype]) {
+                // When a widget with qtype is open, the value of the first option tag is the default value for qtype
                 let defaultOption = $(`#widget__${slug} select[name="${qtype}"]`).first("option").val();
                 opus.extras[qtype] = [defaultOption];
                 o_hash.updateHash();

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -405,7 +405,8 @@ var o_widgets = {
                 let hash = o_hash.getHashArray();
                 let qtype = "qtype-" + slug;
                 if ($(`#widget__${slug} select[name="${qtype}"]`).length !== 0 && !hash[qtype]) {
-                    opus.extras[qtype] = [opus.qtype_default];
+                    let defaultOption = $(`#widget__${slug} select[name="${qtype}"]`).first("option").val();
+                    opus.extras[qtype] = [defaultOption];
                     o_hash.updateHash();
                 }
 

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -400,7 +400,7 @@ var o_widgets = {
             }}).done(function() {
 
                 // If there is no specified qtype in the url, we want default qtype to be in the url
-                // This will also put qtype in the url when a widget is open.
+                // This will also put qtype in the url when a widget with qtype is open.
                 // Need to wait until api return to determine if the widget has qtype selections
                 let hash = o_hash.getHashArray();
                 let qtype = "qtype-" + slug;

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -399,6 +399,8 @@ var o_widgets = {
                 $("#widget__"+slug).html(widget_str);
             }}).done(function() {
 
+                // console.log("=== opus.extras ===");
+                // console.log(opus.extras);
              // if we are drawing a range widget we need to check if the qtype dropdown is
              // already defined by the url:
              if (slug.match(/.*(1|2)/)) {
@@ -406,11 +408,16 @@ var o_widgets = {
                  let id = slug.match(/(.*)[1|2]/)[1];
 
                 // is the qtype constrained in the url?
-                 if ($.inArray('qtype-' + id,opus.extras) > -1 && opus.extras['qtype-'+id]) {
+                 if ($.inArray('qtype-' + id, opus.extras) > -1 && opus.extras['qtype-'+id]) {
                      // this widgets dropdown is defined in the url, update the html select dropdown to match
-                     $('#' + widget + ' select').attr("value",opus.extras['qtype-'+id]);
+                     $('#' + widget + ' select').attr("value", opus.extras['qtype-'+id]);
+                 } else {
+                     // If there is no specified qtype in the url, we want default qtype to be in the url
+                     // This will also put qtype in the url when a widget is open
+                     opus.extras["qype-" + id] = opus.qtype_default;
                  }
-
+                 console.log("=== opus.extras ===");
+                 console.log(opus.extras);
                  // add the helper icon to range widgets.
                 // add the helper text for range widgets
                 if ($('.' + widget).hasClass('range-widget') && $('.' + widget).find('select').length) {


### PR DESCRIPTION
# Update:
- Add default qtype in url when widgets with qtype is open.
- Modify getSelectionsFromHash to getSelectionsExtrasFromHash.
  - Return format of selections will match opus.selections.
  - Return format of extras will match opus.extras.
- Fix double result count loading issue.
- Clean up indents of getWidget function in widgets.js.