### PR TITLE
New ui startobs browse ps

### DIFF
--- a/opus/application/apps/ui/templates/base.html
+++ b/opus/application/apps/ui/templates/base.html
@@ -98,7 +98,7 @@
                         <div class="browse-nav-container top_navbar collapse navbar-collapse">
                             <ul class="navbar-nav mr-auto">
                                 <li class="nav-item">
-                                    <a href="#" class="browse_view nav-link"><i class="far fa-list-alt"></i></a>
+                                    <a href="#" class="op-browse-view nav-link"><i class="far fa-list-alt"></i></a>
                                 </li>
                                 <li class="nav-item">
                                     <a href="#" class="metadataModal nav-link" data-toggle="modal" data-target="#metadataSelector" title="Select metadata to display or include in CSV files for each observation"><i class="fas fa-columns"></i>&nbsp;Select Metadata</a>

--- a/opus/application/apps/ui/templates/base.html
+++ b/opus/application/apps/ui/templates/base.html
@@ -122,7 +122,7 @@
                         </div>
                     </nav>
                     <div class="panel-body gallery-contents container-fluid browse-infiniteScroll-element">
-                        <div class="row justify-content-start op-gallery-view op-scroll-container mr-0">
+                        <div class="row justify-content-start op-gallery-view mr-0">
                             <div class="mr-0 thumb gallery gallery-scroll"></div>
                             <div class="page-load-status">
                                 <div class="infinite-scroll-request loader-ellips">
@@ -132,7 +132,7 @@
                                 <p class="infinite-scroll-error">No more pages to load</p>
                             </div>
                         </div>
-                        <div class="row dataTable browse-infiniteScroll-element op-scroll-container mx-0">
+                        <div class="row dataTable browse-infiniteScroll-element mx-0">
                             <div class="col-lg p-0">
                             <!-- <div class="col-lg pr-0"> -->
                                 <!-- <div class="op-page-loading-status">

--- a/opus/application/apps/ui/templates/base.html
+++ b/opus/application/apps/ui/templates/base.html
@@ -122,7 +122,7 @@
                         </div>
                     </nav>
                     <div class="panel-body gallery-contents container-fluid browse-infiniteScroll-element">
-                        <div class="row justify-content-start op-height-0 op-gallery-view">
+                        <div class="row justify-content-start op-gallery-view mr-0">
                             <div class="mr-0 thumb gallery gallery-scroll"></div>
                             <div class="page-load-status">
                                 <div class="infinite-scroll-request loader-ellips">

--- a/opus/application/apps/ui/templates/base.html
+++ b/opus/application/apps/ui/templates/base.html
@@ -122,7 +122,7 @@
                         </div>
                     </nav>
                     <div class="panel-body gallery-contents container-fluid browse-infiniteScroll-element">
-                        <div class="row justify-content-start op-gallery-view mr-0">
+                        <div class="row justify-content-start op-gallery-view op-scroll-container mr-0">
                             <div class="mr-0 thumb gallery gallery-scroll"></div>
                             <div class="page-load-status">
                                 <div class="infinite-scroll-request loader-ellips">
@@ -132,7 +132,7 @@
                                 <p class="infinite-scroll-error">No more pages to load</p>
                             </div>
                         </div>
-                        <div class="row dataTable browse-infiniteScroll-element mx-0">
+                        <div class="row dataTable browse-infiniteScroll-element op-scroll-container mx-0">
                             <div class="col-lg p-0">
                             <!-- <div class="col-lg pr-0"> -->
                                 <!-- <div class="op-page-loading-status">

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -90,15 +90,20 @@ body {
     min-height: 700px;
 }
 
-.gallery-contents {
+/* .gallery-contents {
     overflow-y: hidden;
     overflow-x: hidden;
     position: relative;
-}
+} */
 
 /* Make sure y-axis rail is not moving and always visible */
-.gallery-contents > .ps__rail-y {
+.op-gallery-view > .ps__rail-y {
     background-color: transparent !important;
+}
+
+.op-gallery-view {
+    overflow: hidden;
+    position: relative;
 }
 
 #detail {

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -90,20 +90,14 @@ body {
     min-height: 700px;
 }
 
-/* .gallery-contents {
-    overflow-y: hidden;
-    overflow-x: hidden;
+.op-gallery-view {
+    overflow: hidden;
     position: relative;
-} */
+}
 
 /* Make sure y-axis rail is not moving and always visible */
 .op-gallery-view > .ps__rail-y {
     background-color: transparent !important;
-}
-
-.op-gallery-view {
-    overflow: hidden;
-    position: relative;
 }
 
 #detail {

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -1175,11 +1175,6 @@ ul.ui-autocomplete a.ui-state-active {
     background-color: #F9F6F6;
 }
 
-/* remove that extra space on top when loading table page */
-.op-height-0 {
-    height: 0;
-}
-
 .op-noSelect {
     -moz-user-select: none;
     -khtml-user-select: none;

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -62,17 +62,16 @@ var o_browse = {
         $(".gallery-contents, .dataTable").on('wheel ps-scroll-up', function(event) {
             let startobs = (opus.prefs.view === "cart" ? "cart_startobs" : "startobs");
             let tab = `#${opus.prefs.view}`;
-            let contentsView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
             if (opus.prefs[startobs] > 0) {
                 // we need something like this to see if the scroll is in the 'up' direction
                 //if (event.originalEvent.deltaY !== undefined && event.originalEvent.deltaY < 0)
                 let prev = $(`${tab} [data-obs]`).first().data("obs") - o_browse.getLimit();
                 if ($(`${tab} .gallery-contents`).scrollTop() === 0 || $(`${tab} .dataTable`).scrollTop() === 0) {
                     opus.prefs[startobs] = (prev > 0 ? prev : 1);
-                    $(`${tab} ${contentsView}`).infiniteScroll({
+                    $(`${tab} .op-scroll-container`).infiniteScroll({
                         "loadPrevPage": true
                     });
-                    $(`${tab} ${contentsView}`).infiniteScroll("loadNextPage");
+                    $(`${tab} .op-scroll-container`).infiniteScroll("loadNextPage");
                 }
             }
         });
@@ -537,7 +536,6 @@ var o_browse = {
     loadNextPageIfNeeded: function(opusId) {
         let startobs = (opus.prefs.view === "cart" ? "cart__startobs" : "startobs");
         let tab = `#${opus.prefs.view}`;
-        let contentsView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
         let maxObs = (opus.prefs.view === "browse" ? opus.resultCount : parseInt($("#op-cart-count").html()));
 
         let obsNum = $(`${tab} .thumbnail-container[data-id=${opusId}]`).data("obs") + 1;
@@ -548,7 +546,7 @@ var o_browse = {
                 // this will make sure we have correct html elements displayed for prev observation
                 $("#galleryViewContents").addClass("op-disabled");
                 opus.prefs[startobs] = obsNum;
-                $(`${tab} ${contentsView}`).infiniteScroll("loadNextPage");
+                $(`${tab} .op-scroll-container`).infiniteScroll("loadNextPage");
             }
         }
     },
@@ -556,7 +554,6 @@ var o_browse = {
     loadPrevPageIfNeeded: function(opusId) {
         let startobs = (opus.prefs.view === "cart" ? "cart__startobs" : "startobs");
         let tab = `#${opus.prefs.view}`;
-        let contentsView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
         o_browse.currentOpusId = opusId;
         // decrement obsNum to see if there is a previous one to retrieve
         let obsNum = $(`${tab} .thumbnail-container[data-id=${opusId}]`).data("obs") - 1;
@@ -569,7 +566,7 @@ var o_browse = {
                 $("#galleryViewContents").addClass("op-disabled");
                 let startObs = obsNum - o_browse.getLimit();
                 opus.prefs[startobs] = (startObs > 0 ? startObs : 1);
-                $(`${tab} ${contentsView}`).infiniteScroll("loadNextPage");
+                $(`${tab} .op-scroll-container`).infiniteScroll("loadNextPage");
             }
         }
     },
@@ -640,7 +637,6 @@ var o_browse = {
 
     checkScroll: function() {
         // infinite scroll is attached to the gallery, so we have to force a loadData when we are in table mode
-        let contentsView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
         if (opus.prefs.browse == "dataTable") {
             let bottom = $("tbody").offset().top + $("tbody").height();
             if (bottom <= $(document).height()) {
@@ -649,7 +645,7 @@ var o_browse = {
                 if (o_browse.dataNotAvailable) {
                     $(".infinite-scroll-request").hide();
                 }
-                $(`#${opus.prefs.view} ${contentsView}`).infiniteScroll("loadNextPage");
+                $(`#${opus.prefs.view} .op-scroll-container`).infiniteScroll("loadNextPage");
             }
         }
 
@@ -1199,13 +1195,8 @@ var o_browse = {
 
     loadData: function(startObs) {
         let view = o_browse.getViewInfo();
-        // console.log("view namespace");
-        // console.log(view.namespace);
-        // console.log("opus.prefs.browse");
-        // console.log(opus.prefs.browse);
-        let contentsView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
         // let selector = `${view.namespace} .gallery-contents`;
-        let selector = `${view.namespace} ${contentsView}`;
+        let selector = `${view.namespace} .op-scroll-container`;
 
         startObs = (startObs === undefined ? opus.prefs[`${view.prefix}startobs`] : startObs);
 
@@ -1252,7 +1243,6 @@ var o_browse = {
                 if (!$(selector).data("infiniteScroll")) {
                     $(selector).infiniteScroll({
                         path: function() {
-                            console.log(`====== LOAD NEW DATA ON ${contentsView}======`);
                             let startObs = opus.prefs[`${view.prefix}startobs`];
                             console.log(`in path - startObs: ${startObs}`);
                             let infiniteScrollData = $(selector).data("infiniteScroll");

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -25,7 +25,7 @@ var o_browse = {
     tableScrollbar: new PerfectScrollbar("#browse .dataTable", {
         minScrollbarLength: opus.minimumPSLength
     }),
-    galleryScrollbar: new PerfectScrollbar("#browse .gallery-contents", {
+    galleryScrollbar: new PerfectScrollbar("#browse .op-gallery-view", {
         suppressScrollX: true,
         minScrollbarLength: opus.minimumPSLength
     }),
@@ -575,11 +575,11 @@ var o_browse = {
     setScrollbarOnSlide: function(obsNum) {
         let tab = `#${opus.prefs.view}`;
         let galleryTargetTopPosition = $(`${tab} .thumbnail-container[data-obs="${obsNum}"]`).offset().top;
-        let galleryContainerTopPosition = $(`${tab} .gallery-contents`).offset().top;
-        let galleryScrollbarPosition = $(`${tab} .gallery-contents`).scrollTop();
+        let galleryContainerTopPosition = $(`${tab} .gallery-contents .op-gallery-view`).offset().top;
+        let galleryScrollbarPosition = $(`${tab} .gallery-contents .op-gallery-view`).scrollTop();
 
         let galleryTargetFinalPosition = galleryTargetTopPosition - galleryContainerTopPosition + galleryScrollbarPosition;
-        $(`${tab} .gallery-contents`).scrollTop(galleryTargetFinalPosition);
+        $(`${tab} .gallery-contents .op-gallery-view`).scrollTop(galleryTargetFinalPosition);
 
         // TODO
         // Create a new jQuery.Event object with specified event properties.
@@ -899,8 +899,8 @@ var o_browse = {
 
     updateBrowseNav: function() {
         if (opus.prefs.browse == "gallery") {
-            $("." + "dataTable", "#browse").hide();
-            $("." + opus.prefs.browse, "#browse").fadeIn();
+            $(".dataTable", "#browse").hide();
+            $(".op-gallery-view", "#browse").fadeIn();
 
             $(".browse_view", "#browse").html("<i class='far fa-list-alt'></i>&nbsp;View Table");
             $(".browse_view", "#browse").attr("title", "View sortable metadata table");
@@ -911,12 +911,10 @@ var o_browse = {
             o_browse.galleryScrollbar.settings.suppressScrollY = false;
 
             $(".gallery-contents > .ps__rail-y").removeClass("hide_ps__rail-y");
-            if (!$(".dataTable > .ps__rail-y").hasClass("hide_ps__rail-y")) {
-                $(".dataTable > .ps__rail-y").addClass("hide_ps__rail-y");
-            }
+            $(".dataTable > .ps__rail-y").addClass("hide_ps__rail-y");
         } else {
-            $("." + "gallery", "#browse").hide();
-            $("." + opus.prefs.browse, "#browse").fadeIn();
+            $(".op-gallery-view", "#browse").hide();
+            $(".dataTable", "#browse").fadeIn();
 
             $(".browse_view", "#browse").html("<i class='far fa-images'></i>&nbsp;View Gallery");
             $(".browse_view", "#browse").attr("title", "View sortable thumbnail gallery");
@@ -927,9 +925,7 @@ var o_browse = {
 
             o_browse.galleryScrollbar.settings.suppressScrollY = true;
 
-            if (!$(".gallery-contents > .ps__rail-y").hasClass("hide_ps__rail-y")) {
-                $(".gallery-contents > .ps__rail-y").addClass("hide_ps__rail-y");
-            }
+            $(".gallery-contents > .ps__rail-y").addClass("hide_ps__rail-y");
             $(".dataTable > .ps__rail-y").removeClass("hide_ps__rail-y");
         }
     },
@@ -1377,12 +1373,13 @@ var o_browse = {
 
     adjustBrowseHeight: function() {
         let tab = `#${opus.prefs.view}`;
-        let container_height = $(window).height()-120;
-        $(`${tab} .gallery-contents`).height(container_height);
+        let containerHeight = $(window).height()-120;
+        $(`${tab} .gallery-contents`).height(containerHeight);
+        $(`${tab} .gallery-contents .op-gallery-view`).height(containerHeight);
         o_browse.galleryScrollbar.update();
         o_browse.galleryBoundingRect = o_browse.countGalleryImages();
         $("#op-observation-slider").slider("option", "step", o_browse.galleryBoundingRect.x);
-        //opus.limit =  (floor($(window).width()/thumbnailSize) * floor(container_height/thumbnailSize));
+        //opus.limit =  (floor($(window).width()/thumbnailSize) * floor(containerHeight/thumbnailSize));
     },
 
     adjustTableSize: function() {

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -88,7 +88,7 @@ var o_browse = {
         });
 
         // browse nav menu - the gallery/table toggle
-        $("#browse").on("click", ".browse_view", function() {
+        $("#browse").on("click", ".op-browse-view", function() {
             o_browse.hideMenu();
             opus.prefs.browse = $(this).data("view");
 
@@ -902,9 +902,9 @@ var o_browse = {
             $(".dataTable", "#browse").hide();
             $(".op-gallery-view", "#browse").fadeIn();
 
-            $(".browse_view", "#browse").html("<i class='far fa-list-alt'></i>&nbsp;View Table");
-            $(".browse_view", "#browse").attr("title", "View sortable metadata table");
-            $(".browse_view", "#browse").data("view", "dataTable");
+            $(".op-browse-view", "#browse").html("<i class='far fa-list-alt'></i>&nbsp;View Table");
+            $(".op-browse-view", "#browse").attr("title", "View sortable metadata table");
+            $(".op-browse-view", "#browse").data("view", "dataTable");
 
             // $(".justify-content-center").show();
 
@@ -916,9 +916,9 @@ var o_browse = {
             $(".op-gallery-view", "#browse").hide();
             $(".dataTable", "#browse").fadeIn();
 
-            $(".browse_view", "#browse").html("<i class='far fa-images'></i>&nbsp;View Gallery");
-            $(".browse_view", "#browse").attr("title", "View sortable thumbnail gallery");
-            $(".browse_view", "#browse").data("view", "gallery");
+            $(".op-browse-view", "#browse").html("<i class='far fa-images'></i>&nbsp;View Gallery");
+            $(".op-browse-view", "#browse").attr("title", "View sortable thumbnail gallery");
+            $(".op-browse-view", "#browse").data("view", "gallery");
 
             // remove that extra space on top when loading table page
             // $(".justify-content-center").hide();

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -27,7 +27,9 @@ var o_browse = {
     }),
     galleryScrollbar: new PerfectScrollbar("#browse .op-gallery-view", {
         suppressScrollX: true,
-        minScrollbarLength: opus.minimumPSLength
+        minScrollbarLength: opus.minimumPSLength,
+        // minScrollbarLength: $(window).height()/5,
+        // maxScrollbarLength: $(window).height()/5,
     }),
     modalScrollbar: new PerfectScrollbar("#galleryViewContents .metadata", {
         minScrollbarLength: opus.minimumPSLength
@@ -62,16 +64,17 @@ var o_browse = {
         $(".gallery-contents, .dataTable").on('wheel ps-scroll-up', function(event) {
             let startobs = (opus.prefs.view === "cart" ? "cart_startobs" : "startobs");
             let tab = `#${opus.prefs.view}`;
+            let browseView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
             if (opus.prefs[startobs] > 0) {
                 // we need something like this to see if the scroll is in the 'up' direction
                 //if (event.originalEvent.deltaY !== undefined && event.originalEvent.deltaY < 0)
                 let prev = $(`${tab} [data-obs]`).first().data("obs") - o_browse.getLimit();
                 if ($(`${tab} .gallery-contents`).scrollTop() === 0 || $(`${tab} .dataTable`).scrollTop() === 0) {
                     opus.prefs[startobs] = (prev > 0 ? prev : 1);
-                    $(`${tab} .gallery-contents`).infiniteScroll({
+                    $(`${tab} ${browseView}`).infiniteScroll({
                         "loadPrevPage": true
                     });
-                    $(`${tab} .gallery-contents`).infiniteScroll("loadNextPage");
+                    $(`${tab} ${browseView}`).infiniteScroll("loadNextPage");
                 }
             }
         });
@@ -536,6 +539,7 @@ var o_browse = {
     loadNextPageIfNeeded: function(opusId) {
         let startobs = (opus.prefs.view === "cart" ? "cart__startobs" : "startobs");
         let tab = `#${opus.prefs.view}`;
+        let browseView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
         let maxObs = (opus.prefs.view === "browse" ? opus.resultCount : parseInt($("#op-cart-count").html()));
 
         let obsNum = $(`${tab} .thumbnail-container[data-id=${opusId}]`).data("obs") + 1;
@@ -546,7 +550,7 @@ var o_browse = {
                 // this will make sure we have correct html elements displayed for prev observation
                 $("#galleryViewContents").addClass("op-disabled");
                 opus.prefs[startobs] = obsNum;
-                $(`${tab} .gallery-contents`).infiniteScroll("loadNextPage");
+                $(`${tab} ${browseView}`).infiniteScroll("loadNextPage");
             }
         }
     },
@@ -554,7 +558,7 @@ var o_browse = {
     loadPrevPageIfNeeded: function(opusId) {
         let startobs = (opus.prefs.view === "cart" ? "cart__startobs" : "startobs");
         let tab = `#${opus.prefs.view}`;
-
+        let browseView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
         o_browse.currentOpusId = opusId;
         // decrement obsNum to see if there is a previous one to retrieve
         let obsNum = $(`${tab} .thumbnail-container[data-id=${opusId}]`).data("obs") - 1;
@@ -567,7 +571,7 @@ var o_browse = {
                 $("#galleryViewContents").addClass("op-disabled");
                 let startObs = obsNum - o_browse.getLimit();
                 opus.prefs[startobs] = (startObs > 0 ? startObs : 1);
-                $(`${tab} .gallery-contents`).infiniteScroll("loadNextPage");
+                $(`${tab} ${browseView}`).infiniteScroll("loadNextPage");
             }
         }
     },
@@ -638,6 +642,7 @@ var o_browse = {
 
     checkScroll: function() {
         // infinite scroll is attached to the gallery, so we have to force a loadData when we are in table mode
+        let browseView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
         if (opus.prefs.browse == "dataTable") {
             let bottom = $("tbody").offset().top + $("tbody").height();
             if (bottom <= $(document).height()) {
@@ -646,7 +651,7 @@ var o_browse = {
                 if (o_browse.dataNotAvailable) {
                     $(".infinite-scroll-request").hide();
                 }
-                $(`#${opus.prefs.view} .gallery-contents`).infiniteScroll("loadNextPage");
+                $(`#${opus.prefs.view} ${browseView}`).infiniteScroll("loadNextPage");
             }
         }
 
@@ -1196,7 +1201,13 @@ var o_browse = {
 
     loadData: function(startObs) {
         let view = o_browse.getViewInfo();
-        let selector = `${view.namespace} .gallery-contents`;
+        // console.log("view namespace");
+        // console.log(view.namespace);
+        // console.log("opus.prefs.browse");
+        // console.log(opus.prefs.browse);
+        let browseView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
+        // let selector = `${view.namespace} .gallery-contents`;
+        let selector = `${view.namespace} ${browseView}`;
 
         startObs = (startObs === undefined ? opus.prefs[`${view.prefix}startobs`] : startObs);
 
@@ -1243,6 +1254,7 @@ var o_browse = {
                 if (!$(selector).data("infiniteScroll")) {
                     $(selector).infiniteScroll({
                         path: function() {
+                            console.log(`====== LOAD NEW DATA ON ${browseView}======`);
                             let startObs = opus.prefs[`${view.prefix}startobs`];
                             console.log(`in path - startObs: ${startObs}`);
                             let infiniteScrollData = $(selector).data("infiniteScroll");

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -62,16 +62,17 @@ var o_browse = {
         $(".gallery-contents, .dataTable").on('wheel ps-scroll-up', function(event) {
             let startobs = (opus.prefs.view === "cart" ? "cart_startobs" : "startobs");
             let tab = `#${opus.prefs.view}`;
+            let contentsView = o_browse.getScrollContainerClass();
             if (opus.prefs[startobs] > 0) {
                 // we need something like this to see if the scroll is in the 'up' direction
                 //if (event.originalEvent.deltaY !== undefined && event.originalEvent.deltaY < 0)
                 let prev = $(`${tab} [data-obs]`).first().data("obs") - o_browse.getLimit();
                 if ($(`${tab} .gallery-contents`).scrollTop() === 0 || $(`${tab} .dataTable`).scrollTop() === 0) {
                     opus.prefs[startobs] = (prev > 0 ? prev : 1);
-                    $(`${tab} .op-scroll-container`).infiniteScroll({
+                    $(`${tab} ${contentsView}`).infiniteScroll({
                         "loadPrevPage": true
                     });
-                    $(`${tab} .op-scroll-container`).infiniteScroll("loadNextPage");
+                    $(`${tab} ${contentsView}`).infiniteScroll("loadNextPage");
                 }
             }
         });
@@ -536,6 +537,7 @@ var o_browse = {
     loadNextPageIfNeeded: function(opusId) {
         let startobs = (opus.prefs.view === "cart" ? "cart__startobs" : "startobs");
         let tab = `#${opus.prefs.view}`;
+        let contentsView = o_browse.getScrollContainerClass();
         let maxObs = (opus.prefs.view === "browse" ? opus.resultCount : parseInt($("#op-cart-count").html()));
 
         let obsNum = $(`${tab} .thumbnail-container[data-id=${opusId}]`).data("obs") + 1;
@@ -546,7 +548,7 @@ var o_browse = {
                 // this will make sure we have correct html elements displayed for prev observation
                 $("#galleryViewContents").addClass("op-disabled");
                 opus.prefs[startobs] = obsNum;
-                $(`${tab} .op-scroll-container`).infiniteScroll("loadNextPage");
+                $(`${tab} ${contentsView}`).infiniteScroll("loadNextPage");
             }
         }
     },
@@ -554,6 +556,7 @@ var o_browse = {
     loadPrevPageIfNeeded: function(opusId) {
         let startobs = (opus.prefs.view === "cart" ? "cart__startobs" : "startobs");
         let tab = `#${opus.prefs.view}`;
+        let contentsView = o_browse.getScrollContainerClass();
         o_browse.currentOpusId = opusId;
         // decrement obsNum to see if there is a previous one to retrieve
         let obsNum = $(`${tab} .thumbnail-container[data-id=${opusId}]`).data("obs") - 1;
@@ -566,7 +569,7 @@ var o_browse = {
                 $("#galleryViewContents").addClass("op-disabled");
                 let startObs = obsNum - o_browse.getLimit();
                 opus.prefs[startobs] = (startObs > 0 ? startObs : 1);
-                $(`${tab} .op-scroll-container`).infiniteScroll("loadNextPage");
+                $(`${tab} ${contentsView}`).infiniteScroll("loadNextPage");
             }
         }
     },
@@ -637,6 +640,7 @@ var o_browse = {
 
     checkScroll: function() {
         // infinite scroll is attached to the gallery, so we have to force a loadData when we are in table mode
+        let contentsView = o_browse.getScrollContainerClass();
         if (opus.prefs.browse == "dataTable") {
             let bottom = $("tbody").offset().top + $("tbody").height();
             if (bottom <= $(document).height()) {
@@ -645,7 +649,7 @@ var o_browse = {
                 if (o_browse.dataNotAvailable) {
                     $(".infinite-scroll-request").hide();
                 }
-                $(`#${opus.prefs.view} .op-scroll-container`).infiniteScroll("loadNextPage");
+                $(`#${opus.prefs.view} ${contentsView}`).infiniteScroll("loadNextPage");
             }
         }
 
@@ -1193,10 +1197,18 @@ var o_browse = {
         return url;
     },
 
+    // return the infiniteScroll container class for either gallery or table view
+    // NOTE: the reason we don't want to use a single unified class is because we have two infiniteScroll instances.
+    // If they share a same class say "op-scroll-container", then later on $(selector).infiniteScroll("loadNextPage") will call load event handler twice (selector selects both container) and render the data twice (duplicated data).
+    getScrollContainerClass: function() {
+        return (opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable");
+    },
+
     loadData: function(startObs) {
         let view = o_browse.getViewInfo();
         // let selector = `${view.namespace} .gallery-contents`;
-        let selector = `${view.namespace} .op-scroll-container`;
+        let contentsView = o_browse.getScrollContainerClass();
+        let selector = `${view.namespace} ${contentsView}`;
 
         startObs = (startObs === undefined ? opus.prefs[`${view.prefix}startobs`] : startObs);
 

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -64,17 +64,17 @@ var o_browse = {
         $(".gallery-contents, .dataTable").on('wheel ps-scroll-up', function(event) {
             let startobs = (opus.prefs.view === "cart" ? "cart_startobs" : "startobs");
             let tab = `#${opus.prefs.view}`;
-            let browseView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
+            let contentsView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
             if (opus.prefs[startobs] > 0) {
                 // we need something like this to see if the scroll is in the 'up' direction
                 //if (event.originalEvent.deltaY !== undefined && event.originalEvent.deltaY < 0)
                 let prev = $(`${tab} [data-obs]`).first().data("obs") - o_browse.getLimit();
                 if ($(`${tab} .gallery-contents`).scrollTop() === 0 || $(`${tab} .dataTable`).scrollTop() === 0) {
                     opus.prefs[startobs] = (prev > 0 ? prev : 1);
-                    $(`${tab} ${browseView}`).infiniteScroll({
+                    $(`${tab} ${contentsView}`).infiniteScroll({
                         "loadPrevPage": true
                     });
-                    $(`${tab} ${browseView}`).infiniteScroll("loadNextPage");
+                    $(`${tab} ${contentsView}`).infiniteScroll("loadNextPage");
                 }
             }
         });
@@ -539,7 +539,7 @@ var o_browse = {
     loadNextPageIfNeeded: function(opusId) {
         let startobs = (opus.prefs.view === "cart" ? "cart__startobs" : "startobs");
         let tab = `#${opus.prefs.view}`;
-        let browseView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
+        let contentsView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
         let maxObs = (opus.prefs.view === "browse" ? opus.resultCount : parseInt($("#op-cart-count").html()));
 
         let obsNum = $(`${tab} .thumbnail-container[data-id=${opusId}]`).data("obs") + 1;
@@ -550,7 +550,7 @@ var o_browse = {
                 // this will make sure we have correct html elements displayed for prev observation
                 $("#galleryViewContents").addClass("op-disabled");
                 opus.prefs[startobs] = obsNum;
-                $(`${tab} ${browseView}`).infiniteScroll("loadNextPage");
+                $(`${tab} ${contentsView}`).infiniteScroll("loadNextPage");
             }
         }
     },
@@ -558,7 +558,7 @@ var o_browse = {
     loadPrevPageIfNeeded: function(opusId) {
         let startobs = (opus.prefs.view === "cart" ? "cart__startobs" : "startobs");
         let tab = `#${opus.prefs.view}`;
-        let browseView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
+        let contentsView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
         o_browse.currentOpusId = opusId;
         // decrement obsNum to see if there is a previous one to retrieve
         let obsNum = $(`${tab} .thumbnail-container[data-id=${opusId}]`).data("obs") - 1;
@@ -571,7 +571,7 @@ var o_browse = {
                 $("#galleryViewContents").addClass("op-disabled");
                 let startObs = obsNum - o_browse.getLimit();
                 opus.prefs[startobs] = (startObs > 0 ? startObs : 1);
-                $(`${tab} ${browseView}`).infiniteScroll("loadNextPage");
+                $(`${tab} ${contentsView}`).infiniteScroll("loadNextPage");
             }
         }
     },
@@ -642,7 +642,7 @@ var o_browse = {
 
     checkScroll: function() {
         // infinite scroll is attached to the gallery, so we have to force a loadData when we are in table mode
-        let browseView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
+        let contentsView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
         if (opus.prefs.browse == "dataTable") {
             let bottom = $("tbody").offset().top + $("tbody").height();
             if (bottom <= $(document).height()) {
@@ -651,7 +651,7 @@ var o_browse = {
                 if (o_browse.dataNotAvailable) {
                     $(".infinite-scroll-request").hide();
                 }
-                $(`#${opus.prefs.view} ${browseView}`).infiniteScroll("loadNextPage");
+                $(`#${opus.prefs.view} ${contentsView}`).infiniteScroll("loadNextPage");
             }
         }
 
@@ -1205,9 +1205,9 @@ var o_browse = {
         // console.log(view.namespace);
         // console.log("opus.prefs.browse");
         // console.log(opus.prefs.browse);
-        let browseView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
+        let contentsView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
         // let selector = `${view.namespace} .gallery-contents`;
-        let selector = `${view.namespace} ${browseView}`;
+        let selector = `${view.namespace} ${contentsView}`;
 
         startObs = (startObs === undefined ? opus.prefs[`${view.prefix}startobs`] : startObs);
 
@@ -1254,7 +1254,7 @@ var o_browse = {
                 if (!$(selector).data("infiniteScroll")) {
                     $(selector).infiniteScroll({
                         path: function() {
-                            console.log(`====== LOAD NEW DATA ON ${browseView}======`);
+                            console.log(`====== LOAD NEW DATA ON ${contentsView}======`);
                             let startObs = opus.prefs[`${view.prefix}startobs`];
                             console.log(`in path - startObs: ${startObs}`);
                             let infiniteScrollData = $(selector).data("infiniteScroll");

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -27,9 +27,7 @@ var o_browse = {
     }),
     galleryScrollbar: new PerfectScrollbar("#browse .op-gallery-view", {
         suppressScrollX: true,
-        minScrollbarLength: opus.minimumPSLength,
-        // minScrollbarLength: $(window).height()/5,
-        // maxScrollbarLength: $(window).height()/5,
+        minScrollbarLength: opus.minimumPSLength
     }),
     modalScrollbar: new PerfectScrollbar("#galleryViewContents .metadata", {
         minScrollbarLength: opus.minimumPSLength

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -906,12 +906,7 @@ var o_browse = {
             $(".op-browse-view", "#browse").attr("title", "View sortable metadata table");
             $(".op-browse-view", "#browse").data("view", "dataTable");
 
-            // $(".justify-content-center").show();
-
             o_browse.galleryScrollbar.settings.suppressScrollY = false;
-
-            $(".gallery-contents > .ps__rail-y").removeClass("hide_ps__rail-y");
-            $(".dataTable > .ps__rail-y").addClass("hide_ps__rail-y");
         } else {
             $(".op-gallery-view", "#browse").hide();
             $(".dataTable", "#browse").fadeIn();
@@ -920,13 +915,7 @@ var o_browse = {
             $(".op-browse-view", "#browse").attr("title", "View sortable thumbnail gallery");
             $(".op-browse-view", "#browse").data("view", "gallery");
 
-            // remove that extra space on top when loading table page
-            // $(".justify-content-center").hide();
-
             o_browse.galleryScrollbar.settings.suppressScrollY = true;
-
-            $(".gallery-contents > .ps__rail-y").addClass("hide_ps__rail-y");
-            $(".dataTable > .ps__rail-y").removeClass("hide_ps__rail-y");
         }
     },
 

--- a/opus/application/static_media/js/mutationObserver.js
+++ b/opus/application/static_media/js/mutationObserver.js
@@ -165,8 +165,6 @@ var o_mutationObserver = {
             let lastMutationIdx = mutationsList.length - 1;
             mutationsList.forEach((mutation, idx) => {
                 if (idx === lastMutationIdx) {
-                    console.log("gallery view")
-                    console.log(mutation)
                     adjustBrowseHeight();
                 }
             });
@@ -177,8 +175,6 @@ var o_mutationObserver = {
             let lastMutationIdx = mutationsList.length - 1;
             mutationsList.forEach((mutation, idx) => {
                 if (idx === lastMutationIdx) {
-                    console.log("table view")
-                    console.log(mutation)
                     adjustTableSize();
                 }
             });
@@ -189,8 +185,6 @@ var o_mutationObserver = {
             let lastMutationIdx = mutationsList.length - 1;
             mutationsList.forEach((mutation, idx) => {
                 if (idx === lastMutationIdx) {
-                    console.log("switch gallery and table view")
-                    console.log(mutation)
                     adjustBrowseHeight();
                     adjustTableSize();
                 }

--- a/opus/application/static_media/js/mutationObserver.js
+++ b/opus/application/static_media/js/mutationObserver.js
@@ -165,6 +165,8 @@ var o_mutationObserver = {
             let lastMutationIdx = mutationsList.length - 1;
             mutationsList.forEach((mutation, idx) => {
                 if (idx === lastMutationIdx) {
+                    console.log("gallery view")
+                    console.log(mutation)
                     adjustBrowseHeight();
                 }
             });
@@ -175,6 +177,21 @@ var o_mutationObserver = {
             let lastMutationIdx = mutationsList.length - 1;
             mutationsList.forEach((mutation, idx) => {
                 if (idx === lastMutationIdx) {
+                    console.log("table view")
+                    console.log(mutation)
+                    adjustTableSize();
+                }
+            });
+        });
+
+        // update ps when switching between gallery and table view
+        let switchGalleryAndTableObserver = new MutationObserver(function(mutationsList) {
+            let lastMutationIdx = mutationsList.length - 1;
+            mutationsList.forEach((mutation, idx) => {
+                if (idx === lastMutationIdx) {
+                    console.log("switch gallery and table view")
+                    console.log(mutation)
+                    adjustBrowseHeight();
                     adjustTableSize();
                 }
             });
@@ -190,8 +207,9 @@ var o_mutationObserver = {
         let metadataSelector = $("#metadataSelector")[0];
         let metadataSelectorContents = $("#metadataSelectorContents")[0];
         let browseDialogModal = $("#galleryView.modal")[0];
-        let galleryView = $(".op-gallery-view")[0];
+        let galleryView = $(".gallery")[0];
         let tableView = $("#dataTable")[0];
+        let switchGalleryAndTable = $(".op-browse-view")[0]
 
         // Note:
         // The reason of observing sidebar and widdget content element (ps sibling) in search page instead of observing the whole page (html structure) is because:
@@ -223,5 +241,7 @@ var o_mutationObserver = {
         galleryViewObserver.observe(galleryView, generalObserverConfig);
         // update ps in browse table view
         tableViewObserver.observe(tableView, generalObserverConfig);
+        // update ps when switching between gallery and table view
+        switchGalleryAndTableObserver.observe(switchGalleryAndTable, attrObserverConfig);
     },
 };

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -279,8 +279,8 @@ var opus = {
 
             case 'browse':
                 if (opus.prefs.browse == 'dataTable') {
-                    $('.gallery','#browse').hide();
-                    $('.data','#browse').show();
+                    $('.op-gallery-view','#browse').hide();
+                    $('.dataTable','#browse').show();
                 }
                 $('#browse').fadeIn();
                 o_browse.getBrowseTab();


### PR DESCRIPTION
# This is a dummy pull-request to track the changes of PS in browse view
# Update:
- rename browse_view to op-browse-view
- Move PS for browse gallery view to .op-gallery-view (container)
    - Under .gallery-contents:
        - PS for gallery view is attached to .op-gallery-view
        - PS for table view is attached to .dataTable (same as original implementation)
    - Update mutationObserver for switching between gallery and table view
# TODO:
- Fix the scrollbar size in gallery view
- Instantiate infiniteScroll on both gallery view and table view
- Display spinner when infiniteScroll is loading in gallery view