### PR TITLE
Don't trigger a search or a new cache table based on a qtype that isn…

### DIFF
--- a/opus/application/apps/search/test_search.py
+++ b/opus/application/apps/search/test_search.py
@@ -581,28 +581,6 @@ class searchTests(TestCase):
         self.assertEqual(extras['qtypes'], qtypes_expected)
 
 
-    # ##  set_user_search_number
-    # def test__set_user_search_number(self):
-    #     no = set_user_search_number(self.selections)
-    #     self.assertTrue(no)
-    #
-    # def test__set_user_search_number_with_times(self):
-    #     selections = {'obs_general.planet_id': ['Saturn'], 'obs_general.time_sec2': ['2009-12-28'], 'obs_general.time1': ['2009-12-23']}
-    #     search_no = set_user_search_number(selections)
-    #     print(search_no)
-    #     self.assertGreater(len(str(search_no)), 0)
-    #
-    #
-    # def test__set_user_search_number_2_planets(self):
-    #     selections = {}
-    #     selections['obs_general.planet_id'] = ['Saturn']
-    #     no = set_user_search_number(selections)
-    #     print(no)
-    #     # breaking this, this test needs to see if there are any rows in the table
-    #     self.assertGreater(no, 0)
-    #
-
-
             ##############################################
             ######### get_range_query UNIT TESTS #########
             ##############################################
@@ -1430,6 +1408,96 @@ class searchTests(TestCase):
         self.assertEqual(params, expected_params)
 
 
+            #####################################################
+            ######### set_user_search_number UNIT TESTS #########
+            #####################################################
+
+    def test__set_user_search_number_dead_qtype_str(self):
+        "[test_search.py] set_user_search_number: dead qtype string"
+        selections = {'obs_pds.volume_id': ['FRED']}
+        extras = {'qtypes': {'obs_pds.volume_id': ['excludes']},
+                  'order': (['obs_pds.volume_id'], [False])}
+        num1 = set_user_search_number(selections, extras)
+        extras = {'qtypes': {'obs_pds.volume_id': ['excludes'],
+                             'obs_pds.data_set_id': ['matches']}, # goes away
+                  'order': (['obs_pds.volume_id'], [False])}
+        num2 = set_user_search_number(selections, extras)
+        self.assertEqual(num1, (1, True))
+        self.assertEqual(num2, (1, False))
+
+    def test__set_user_search_number_dead_qtype_num_1(self):
+        "[test_search.py] set_user_search_number: dead qtype numeric 1"
+        selections = {'obs_general.declination1': ['1']}
+        extras = {'qtypes': {'obs_general.declination1': ['any']},
+                  'order': (['obs_general.time1'], [False])}
+        num1 = set_user_search_number(selections, extras)
+        extras = {'qtypes': {'obs_general.declination1': ['any'],
+                             'obs_general.right_asc1': ['only']}, # goes away
+                  'order': (['obs_general.time1'], [False])}
+        num2 = set_user_search_number(selections, extras)
+        self.assertEqual(num1, (1, True))
+        self.assertEqual(num2, (1, False))
+
+    def test__set_user_search_number_dead_qtype_num_2(self):
+        "[test_search.py] set_user_search_number: dead qtype numeric 2"
+        selections = {'obs_general.declination2': ['1']}
+        extras = {'qtypes': {'obs_general.declination1': ['any']},
+                  'order': (['obs_general.time1'], [False])}
+        num1 = set_user_search_number(selections, extras)
+        extras = {'qtypes': {'obs_general.declination1': ['any'],
+                             'obs_general.right_asc1': ['only']}, # goes away
+                  'order': (['obs_general.time1'], [False])}
+        num2 = set_user_search_number(selections, extras)
+        self.assertEqual(num1, (1, True))
+        self.assertEqual(num2, (1, False))
+
+    def test__set_user_search_number_qtype_num_1(self):
+        "[test_search.py] set_user_search_number: qtype numeric 1"
+        # No qtype vs. used qtype means different search
+        selections = {'obs_general.declination1': ['1']}
+        extras = {'qtypes': {},
+                  'order': (['obs_general.time1'], [False])}
+        num1 = set_user_search_number(selections, extras)
+        extras = {'qtypes': {'obs_general.declination1': ['any']},
+                  'order': (['obs_general.time1'], [False])}
+        num2 = set_user_search_number(selections, extras)
+        self.assertEqual(num1, (1, True))
+        self.assertEqual(num2, (2, True))
+
+    def test__set_user_search_number_qtype_num_2(self):
+        "[test_search.py] set_user_search_number: qtype numeric 2"
+        # No qtype vs. used qtype means different search
+        selections = {'obs_general.declination2': ['1']}
+        extras = {'qtypes': {},
+                  'order': (['obs_general.time1'], [False])}
+        num1 = set_user_search_number(selections, extras)
+        extras = {'qtypes': {'obs_general.declination1': ['any']},
+                  'order': (['obs_general.time1'], [False])}
+        num2 = set_user_search_number(selections, extras)
+        self.assertEqual(num1, (1, True))
+        self.assertEqual(num2, (2, True))
+
+
+    # ##  set_user_search_number
+    # def test__set_user_search_number(self):
+    #     no = set_user_search_number(self.selections)
+    #     self.assertTrue(no)
+    #
+    # def test__set_user_search_number_with_times(self):
+    #     selections = {'obs_general.planet_id': ['Saturn'], 'obs_general.time_sec2': ['2009-12-28'], 'obs_general.time1': ['2009-12-23']}
+    #     search_no = set_user_search_number(selections)
+    #     print(search_no)
+    #     self.assertGreater(len(str(search_no)), 0)
+    #
+    #
+    # def test__set_user_search_number_2_planets(self):
+    #     selections = {}
+    #     selections['obs_general.planet_id'] = ['Saturn']
+    #     no = set_user_search_number(selections)
+    #     print(no)
+    #     # breaking this, this test needs to see if there are any rows in the table
+    #     self.assertGreater(no, 0)
+    #
     # def test__range_query_time_any(self):
     #     # range query: form type = TIME, qtype any
     #     selections = {}

--- a/opus/application/apps/search/views.py
+++ b/opus/application/apps/search/views.py
@@ -714,8 +714,18 @@ def set_user_search_number(selections, extras):
     qtypes_json = None
     qtypes_hash = 'NONE' # Needed for UNIQUE constraint to work
     if 'qtypes' in extras:
-        if len(extras['qtypes']):
-            qtypes_json = str(json.dumps(sort_dictionary(extras['qtypes'])))
+        qtypes = extras['qtypes']
+        # Remove qtypes that aren't used for searching because they don't
+        # do anything to make the search unique
+        new_qtypes = {}
+        for qtype, val in qtypes.items():
+            qtype_no_num = strip_numeric_suffix(qtype)
+            if (qtype_no_num in selections or
+                qtype_no_num+'1' in selections or
+                qtype_no_num+'2' in selections):
+                new_qtypes[qtype] = val
+        if len(new_qtypes):
+            qtypes_json = str(json.dumps(sort_dictionary(new_qtypes)))
             qtypes_hash = hashlib.md5(str.encode(qtypes_json)).hexdigest()
 
     units_json = None

--- a/opus/application/static_media/js/hash.js
+++ b/opus/application/static_media/js/hash.js
@@ -5,7 +5,7 @@
 /* jshint varstmt: true */
 /* jshint multistr: true */
 /* globals $ */
-/* globals o_browse, opus */
+/* globals opus */
 
 /* jshint varstmt: false */
 var o_hash = {
@@ -101,20 +101,39 @@ var o_hash = {
             let value = pair.split('=')[1];
 
             if (!(slug in opus.prefs) && value) {
-
                 if (slug.startsWith("qtype-")) {
                     // each qtype will only have one value at a time
                     extras[slug] = [value];
                 } else {
                     selections[slug] = value.replace("+", " ").split(",");
                 }
-
             }
         });
 
         return [selections, extras];
     },
 
+    extrasWithoutUnusedQtypes: function(selections, extras) {
+        // If a qtype is present in extras but is not used in the search
+        // selections, then don't include it at all. This is so that when we
+        // compare selections and extras over time, a "lonely" qtype won't be
+        // taken into account and trigger a new backend search.
+        let hash = o_hash.getHash();
+        hash = (hash.search('&') > -1 ? hash.split('&') : [hash]);
+        let hashSlugs = hash.map(x => x.split('=')[0]);
+        let newExtras = {};
+        $.each(extras, function(slug, value) {
+            if (slug.startsWith("qtype-")) {
+                let qtypeSlug = slug.slice(6);
+                if (hashSlugs.indexOf(qtypeSlug) >= 0 ||
+                    hashSlugs.indexOf(qtypeSlug+'1') >= 0 ||
+                    hashSlugs.indexOf(qtypeSlug+'2') >= 0) {
+                    newExtras[slug] = value;
+                }
+            }
+        });
+        return newExtras;
+    },
 
     initFromHash: function() {
         let hash = o_hash.getHash();

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -114,7 +114,9 @@ var opus = {
         }
 
         // compare selections and last selections, extras and last extras
-        if (o_utils.areObjectsEqual(selections, opus.lastSelections) && o_utils.areObjectsEqual(extras, opus.lastExtras)) {
+        if (o_utils.areObjectsEqual(selections, opus.lastSelections) &&
+                                    o_utils.areObjectsEqual(o_hash.extrasWithoutUnusedQtypes(selections, extras),
+                                                            o_hash.extrasWithoutUnusedQtypes(opus.lastSelections, opus.lastExtras))) {
             if (!opus.force_load) { // so we do only non-reloading pref changes
                 return;
             }
@@ -124,7 +126,9 @@ var opus = {
             opus.prefs.cart_startobs = 1;
 
             // if data in selections !== data in opus.selections or extras !== data in opus.extras, it means selections/qtype are modified manually in url, reload the page (modified url in url bar and hit enter)
-            if (!o_utils.areObjectsEqual(selections, opus.selections) || !o_utils.areObjectsEqual(extras, opus.extras)) {
+            if (!o_utils.areObjectsEqual(selections, opus.selections) ||
+                !o_utils.areObjectsEqual(o_hash.extrasWithoutUnusedQtypes(selections, extras),
+                                         o_hash.extrasWithoutUnusedQtypes(opus.selections, opus.extras))) {
                 opus.selections = selections;
                 opus.extras = extras;
                 location.reload();


### PR DESCRIPTION
- When comparing old and new selections/extras, ignore any qtypes that don't have actual search values. This solves the problem of new string or range widgets triggering an instead result_count when created or destroyed.
- Just for good measure, do the same thing in the backend. Ignore orphaned qtypes when deciding whether or not to create a new search cache table.
