### PR TITLE
Add back __api/data.csv, which is used internally. Add HTML download …

### DIFF
--- a/opus/application/apps/results/urls.py
+++ b/opus/application/apps/results/urls.py
@@ -18,6 +18,7 @@ from results.views import (
 urlpatterns = [
     url(r'^__api/dataimages.json$', api_get_data_and_images),
     url(r'^api/data.(?P<fmt>json|html|csv)$', api_get_data),
+    url(r'^__api/data.(?P<fmt>csv)$', api_get_data),
     url(r'^api/metadata/(?P<opus_id>[-\w]+).(?P<fmt>json|html|csv)$', api_get_metadata),
     url(r'^api/metadata_v2/(?P<opus_id>[-\w]+).(?P<fmt>json|html|csv)$', api_get_metadata_v2),
     url(r'^__api/metadata_v2/(?P<opus_id>[-\w]+).(?P<fmt>json|html|csv)$', api_get_metadata_v2_internal),

--- a/opus/application/apps/ui/templates/base.html
+++ b/opus/application/apps/ui/templates/base.html
@@ -104,7 +104,7 @@
                                     <a href="#" class="metadataModal nav-link" data-toggle="modal" data-target="#metadataSelector" title="Select metadata to display or include in CSV files for each observation"><i class="fas fa-columns"></i>&nbsp;Select Metadata</a>
                                 </li>
                                 <li class="nav-item">
-                                    <a href="#" class="download_csv nav-link" title="Download CSV of selected metadata for ALL observations in current results"><i class="fas fa-download"></i>&nbsp;Download CSV (all results)</a>
+                                    <a href="#" class="op-download-csv nav-link" download title="Download CSV of selected metadata for ALL observations in current results"><i class="fas fa-download"></i>&nbsp;Download CSV (all results)</a>
                                 </li>
                                 <li class="nav-item">
                                     <span class="op-observation-text mr-2">Observation #</span>
@@ -158,7 +158,7 @@
                             <div class="browse-nav-container top_navbar collapse navbar-collapse">
                                 <ul class="navbar-nav mr-auto">
                                     <li class="nav-item">
-                                        <a href="javascript:void(0)" class="download_csv nav-link" title="Download CSV of selected metadata for all observations in cart" target="_blank"><i class="fas fa-file-csv"></i>&nbsp;Metadata CSV</a>
+                                        <a href="#" class="op-download-csv nav-link" download title="Download CSV of selected metadata for all observations in cart"><i class="fas fa-file-csv"></i>&nbsp;Metadata CSV</a>
                                     </li>
                                     <li class="nav-item">
                                         <div id="create_zip_data_file">
@@ -219,10 +219,10 @@
             <a class="dropdown-item cart-item" data-action="cart" href="#"><i class="fas fa-shopping-cart"></i>Add to cart</a>
             <a class="dropdown-item" data-action="range" href="#"><i class="fas fa-step-backward"></i>Range selection</a>
             <a class="dropdown-item" data-action="info" href="#"><i class="fas fa-info-circle"></i>Show detail</a>
-            <a class="dropdown-item" data-action="downloadCSV" href="#" target="__blank"><i class="fas fa-file-csv"></i>Download CSV of selected metadata&nbsp;</a>
-            <a class="dropdown-item" data-action="downloadCSVAll" href="#" target="__blank"><i class="fas fa-file-csv"></i>Download CSV of all metadata&nbsp;</a>
-            <a class="dropdown-item" data-action="downloadData" href="#" target="__blank"><i class="fas fa-download"></i>Download zipped data archive&nbsp;</a>
-            <a class="dropdown-item" data-action="downloadURL" href="#" target="__blank"><i class="fas fa-download"></i>Download zipped URL archive&nbsp;</a>
+            <a class="dropdown-item" data-action="downloadCSV" href="#" download><i class="fas fa-file-csv"></i>Download CSV of selected metadata&nbsp;</a>
+            <a class="dropdown-item" data-action="downloadCSVAll" href="#" download><i class="fas fa-file-csv"></i>Download CSV of all metadata&nbsp;</a>
+            <a class="dropdown-item" data-action="downloadData" href="#" download><i class="fas fa-download"></i>Download zipped data archive&nbsp;</a>
+            <a class="dropdown-item" data-action="downloadURL" href="#" download><i class="fas fa-download"></i>Download zipped URL archive&nbsp;</a>
             <!--a class="dropdown-item" data-action="help" href="#"><i class="far fa-question-circle"></i>Help</a-->
         </div>
 

--- a/opus/application/apps/ui/templates/detail.html
+++ b/opus/application/apps/ui/templates/detail.html
@@ -7,7 +7,7 @@
 
                 <h2>PDS Products</h2>
                 <div>
-                    <p>Download zipped <a data-action="downloadData" href="/opus/__api/download/{{ opus_id }}.zip">data archive</a> or <a data-action="downloadURL" href="/opus/__api/download/{{ opus_id }}.zip?urlonly=1">URL archive</a> for this observation (all products, current version only)</a></p>
+                    <p>Download zipped <a data-action="downloadData" href="#" download>data archive</a> or <a data-action="downloadURL" href="#" download>URL archive</a> for this observation (all products, current version only)</a></p>
                     <p>Click on any "Index" type to see the entry for this observation in that table.</p>
                     {% for version, version_items in products.items %}
                       <ul>
@@ -31,13 +31,13 @@
                 </div>
 
                 <h2>Selected Metadata</h2>
-                <p><a class="download_csv" target="_blank" href="#">Download CSV of selected metadata</a></p>
+                <p><a class="op-download-csv" download href="#">Download CSV of selected metadata</a></p>
                 <div id="cols_metadata_{{ opus_id }}">
                     <span class="spinner">&nbsp;</span>
                 </div>
                 <div>
                     <h2>All OPUS Metadata for this Observation</h2>
-                    <p>Download all metadata <a href="/opus/__api/metadata_v2/{{ opus_id }}.json" target="_blank">as JSON</a></p>
+                    <p>Download all metadata <a href="/opus/__api/metadata_v2/{{ opus_id }}.json" download>as JSON</a></p>
                     <div id="all_metadata_{{ opus_id }}"></div>
                 </div>
             </div>

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -5,7 +5,7 @@
 /* jshint varstmt: true */
 /* globals $, _, PerfectScrollbar */
 /* globals o_cart, o_hash, o_menu, o_utils, opus */
-/* globals default_pages, default_columns */
+/* globals default_columns */
 
 // font awesome icon class
 const pillSortUpArrow = "fas fa-arrow-circle-up";
@@ -102,17 +102,22 @@ var o_browse = {
         });
 
         // browse nav menu - download csv
-        $("#browse").on("click", ".download_csv", function() {
-            let col_str = opus.prefs.cols.join(',');
-            let hash = [];
+        $("#browse").on("click", ".op-download-csv", function() {
+            let colStr = opus.prefs.cols.join(',');
+            let selectionsHash = [];
             for (let param in opus.selections) {
                 if (opus.selections[param].length) {
-                    hash[hash.length] = param + '=' + opus.selections[param].join(',').replace(/ /g,'+');
+                    selectionsHash.push(param + '=' + opus.selections[param].join(',').replace(/ /g,'+'));
                 }
             }
-            let q_str = hash.join('&');
-            let csv_link = "/opus/__api/data.csv?" + q_str + "&cols=" + col_str + "&limit=" + opus.resultCount.toString() + "&order=" + opus.prefs.order.join(",");
-            $(this).attr("href", csv_link);
+            let selectionsHashStr = selectionsHash.join('&');
+            if (selectionsHashStr !== "") {
+                selectionsHashStr += "&";
+            }
+            let resultCountStr = opus.resultCount.toString();
+            let orderStr = opus.prefs.order.join(",");
+            let csvLink = `/opus/__api/data.csv?${selectionsHashStr}cols=${colStr}&limit=${resultCountStr}&order=${orderStr}`;
+            $(this).attr("href", csvLink);
         });
 
         // 1 - click on thumbnail opens modal window
@@ -711,7 +716,9 @@ var o_browse = {
         opus.prefs.detail = opusId;
         if (e.shiftKey || e.ctrlKey || e.metaKey) {
             // handles command click to open in new tab
-            let link = "/opus/#/" + o_hash.getHash();
+            let hashArray = o_hash.getHashArray();
+            hashArray.detail = opusId;
+            let link = "/opus/#/" + o_hash.hashArrayToHashString(hashArray);
             link = link.replace("view=browse", "view=detail");
             window.open(link, '_blank');
         } else {
@@ -789,7 +796,9 @@ var o_browse = {
     // metadata selector behaviors
     addMetadataSelectorBehaviors: function() {
         // Global within this function so behaviors can communicate
+        /* jshint varstmt: false */
         var currentSelectedMetadata = opus.prefs.cols.slice();
+        /* jshint varstmt: true */
 
         $("#metadataSelector").on("hide.bs.modal", function(e) {
             // update the data table w/the new columns

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -107,7 +107,8 @@ var o_browse = {
             let selectionsHash = [];
             for (let param in opus.selections) {
                 if (opus.selections[param].length) {
-                    selectionsHash.push(param + '=' + opus.selections[param].join(',').replace(/ /g,'+'));
+                    let valueStr = opus.selections[param].join(',').replace(/ /g,'+');
+                    selectionsHash.push(`${param}=${valueStr}`);
                 }
             }
             let selectionsHashStr = selectionsHash.join('&');

--- a/opus/application/static_media/js/cart.js
+++ b/opus/application/static_media/js/cart.js
@@ -30,9 +30,10 @@ var o_cart = {
 
      cartBehaviors: function() {
          // nav bar
-         $("#cart").on("click", ".download_csv", function(e) {
-             window.open(`/opus/__cart/data.csv?${o_hash.getHash()}`, '_blank');
-             //$(this).attr("href", "/opus/__cart/data.csv?"+ o_hash.getHash());
+         $("#cart").on("click", ".op-download-csv", function(e) {
+             let colStr = opus.prefs.cols.join(',');
+             let orderStr = opus.prefs.order.join(",");
+             $(this).attr("href", `/opus/__cart/data.csv?cols=${colStr}&order=${orderStr}`);
          });
 
          $("#cart").on("click", ".downloadData", function(e) {
@@ -111,7 +112,7 @@ var o_cart = {
                  if (data.error !== undefined) {
                      $(`<li>${data.error}</li>`).hide().prependTo("ul.zippedFiles", "#cart_summary").slideDown("fast");
                  } else {
-                     $(`<li><a href = "${data.filename}">${data.filename}</a></li>`).hide().prependTo("ul.zippedFiles", "#cart_summary").slideDown("slow");
+                     $(`<li><a href = "${data.filename}" download>${data.filename}</a></li>`).hide().prependTo("ul.zippedFiles", "#cart_summary").slideDown("slow");
                  }
                  $(".spinner", "#op-download-links").fadeOut();
              },

--- a/opus/application/static_media/js/detail.js
+++ b/opus/application/static_media/js/detail.js
@@ -13,8 +13,9 @@ var o_detail = {
 
     getDetail: function(opusId) {
 
-        $("#detail").on("click", ".download_csv", function() {
-            $(this).attr("href", "/opus/__api/metadata_v2/"+opusId+".csv?"+ o_hash.getHash());
+        $("#detail").on("click", ".op-download-csv", function() {
+            let colStr = opus.prefs.cols.join(',');
+            $(this).attr("href", `/opus/__api/metadata_v2/${opusId}.csv?cols=${colStr}`);
         });
 
         $("#detail").on("click", "a[data-action]", function() {

--- a/opus/application/static_media/js/hash.js
+++ b/opus/application/static_media/js/hash.js
@@ -118,16 +118,13 @@ var o_hash = {
         // selections, then don't include it at all. This is so that when we
         // compare selections and extras over time, a "lonely" qtype won't be
         // taken into account and trigger a new backend search.
-        let hash = o_hash.getHash();
-        hash = (hash.search('&') > -1 ? hash.split('&') : [hash]);
-        let hashSlugs = hash.map(x => x.split('=')[0]);
         let newExtras = {};
         $.each(extras, function(slug, value) {
             if (slug.startsWith("qtype-")) {
                 let qtypeSlug = slug.slice(6);
-                if (hashSlugs.indexOf(qtypeSlug) >= 0 ||
-                    hashSlugs.indexOf(qtypeSlug+'1') >= 0 ||
-                    hashSlugs.indexOf(qtypeSlug+'2') >= 0) {
+                if (qtypeSlug in selections ||
+                    qtypeSlug+'1' in selections ||
+                    qtypeSlug+'2' in selections) {
                     newExtras[slug] = value;
                 }
             }

--- a/opus/application/test_api/test_return_formats.py
+++ b/opus/application/test_api/test_return_formats.py
@@ -175,6 +175,10 @@ class ApiReturnFormatTests(TestCase, ApiTestHelper):
         "[test_return_formats.py] return formats /api/data.[fmt]"
         self._test_return_formats('/api/data.[fmt]', ('json', 'html', 'csv'))
 
+    def test__api_retfmt_results_data_pvt(self):
+        "[test_return_formats.py] return formats /__api/data.[fmt]"
+        self._test_return_formats('/__api/data.[fmt]', ('csv',))
+
     def test__api_retfmt_results_metadata(self):
         "[test_return_formats.py] return formats /api/metadata/opusid.[fmt]"
         self._test_return_formats('/api/metadata/vg-iss-2-s-c4362550.[fmt]', ('csv', 'json', 'html'))


### PR DESCRIPTION
- Add back __api/data.csv, which is used internally.
- Add HTML download tag for downloading CSV/archive files and remove target="_blank" in those cases.
- Initially hide internal URLs from user.
- Fix bug in qtypes introduced by last pull.
- Make Ctrl+click and Shift+click on detail (i) properly fill in URL. (B045)
- Other random cleanup and bug fixes.
