### PR TITLE
New ui startobs infinite scroll down direction

### DIFF
--- a/opus/application/apps/ui/templates/base.html
+++ b/opus/application/apps/ui/templates/base.html
@@ -98,7 +98,7 @@
                         <div class="browse-nav-container top_navbar collapse navbar-collapse">
                             <ul class="navbar-nav mr-auto">
                                 <li class="nav-item">
-                                    <a href="#" class="browse_view nav-link"><i class="far fa-list-alt"></i></a>
+                                    <a href="#" class="op-browse-view nav-link"><i class="far fa-list-alt"></i></a>
                                 </li>
                                 <li class="nav-item">
                                     <a href="#" class="metadataModal nav-link" data-toggle="modal" data-target="#metadataSelector" title="Select metadata to display or include in CSV files for each observation"><i class="fas fa-columns"></i>&nbsp;Select Metadata</a>

--- a/opus/application/apps/ui/templates/base.html
+++ b/opus/application/apps/ui/templates/base.html
@@ -122,7 +122,7 @@
                         </div>
                     </nav>
                     <div class="panel-body gallery-contents container-fluid browse-infiniteScroll-element">
-                        <div class="row justify-content-start op-gallery-view mr-0">
+                        <div class="row justify-content-start op-gallery-view mr-0 op-scroll-container">
                             <div class="mr-0 thumb gallery gallery-scroll"></div>
                             <div class="page-load-status">
                                 <div class="infinite-scroll-request loader-ellips">
@@ -132,7 +132,7 @@
                                 <p class="infinite-scroll-error">No more pages to load</p>
                             </div>
                         </div>
-                        <div class="row dataTable browse-infiniteScroll-element mx-0">
+                        <div class="row dataTable browse-infiniteScroll-element mx-0 op-scroll-container">
                             <div class="col-lg p-0">
                             <!-- <div class="col-lg pr-0"> -->
                                 <!-- <div class="op-page-loading-status">

--- a/opus/application/apps/ui/templates/base.html
+++ b/opus/application/apps/ui/templates/base.html
@@ -124,20 +124,9 @@
                     <div class="panel-body gallery-contents container-fluid browse-infiniteScroll-element">
                         <div class="row justify-content-start op-gallery-view mr-0">
                             <div class="mr-0 thumb gallery gallery-scroll"></div>
-                            <!-- <div class="page-load-status">
-                                <div class="infinite-scroll-request loader-ellips">
-                                    <div class='loader'></div>
-                                </div>
-                                <p class="infinite-scroll-last">End of content</p>
-                                <p class="infinite-scroll-error">No more pages to load</p>
-                            </div> -->
                         </div>
                         <div class="row op-dataTable-view browse-infiniteScroll-element mx-0">
                             <div class="col-lg p-0">
-                            <!-- <div class="col-lg pr-0"> -->
-                                <!-- <div class="op-page-loading-status">
-                                    <div class="loader"></div>
-                                </div> -->
                                 <table id="dataTable" class="table table-hover table-bordered table-striped table-dark table-sm op-noSelect">
                                     <thead>
                                         <tr></tr>

--- a/opus/application/apps/ui/templates/base.html
+++ b/opus/application/apps/ui/templates/base.html
@@ -124,13 +124,13 @@
                     <div class="panel-body gallery-contents container-fluid browse-infiniteScroll-element">
                         <div class="row justify-content-start op-gallery-view mr-0">
                             <div class="mr-0 thumb gallery gallery-scroll"></div>
-                            <div class="page-load-status">
+                            <!-- <div class="page-load-status">
                                 <div class="infinite-scroll-request loader-ellips">
                                     <div class='loader'></div>
                                 </div>
                                 <p class="infinite-scroll-last">End of content</p>
                                 <p class="infinite-scroll-error">No more pages to load</p>
-                            </div>
+                            </div> -->
                         </div>
                         <div class="row op-dataTable-view browse-infiniteScroll-element mx-0">
                             <div class="col-lg p-0">
@@ -145,6 +145,14 @@
                                     <tbody></tbody>
                                 </table>
                             </div>
+                        </div>
+                        <!-- we moved the spinner to the same level as .op-gallery-view and .op-dataTable-view so that it can be shared for both infiniteScroll instances  -->
+                        <div class="page-load-status">
+                            <div class="infinite-scroll-request loader-ellips">
+                                <div class='loader'></div>
+                            </div>
+                            <p class="infinite-scroll-last">End of content</p>
+                            <p class="infinite-scroll-error">No more pages to load</p>
                         </div>
                     </div>
                 </div>

--- a/opus/application/apps/ui/templates/base.html
+++ b/opus/application/apps/ui/templates/base.html
@@ -132,7 +132,7 @@
                                 <p class="infinite-scroll-error">No more pages to load</p>
                             </div>
                         </div>
-                        <div class="row dataTable browse-infiniteScroll-element mx-0">
+                        <div class="row op-dataTable-view browse-infiniteScroll-element mx-0">
                             <div class="col-lg p-0">
                             <!-- <div class="col-lg pr-0"> -->
                                 <!-- <div class="op-page-loading-status">

--- a/opus/application/apps/ui/templates/base.html
+++ b/opus/application/apps/ui/templates/base.html
@@ -122,7 +122,7 @@
                         </div>
                     </nav>
                     <div class="panel-body gallery-contents container-fluid browse-infiniteScroll-element">
-                        <div class="row justify-content-start op-gallery-view mr-0 op-scroll-container">
+                        <div class="row justify-content-start op-gallery-view mr-0">
                             <div class="mr-0 thumb gallery gallery-scroll"></div>
                             <div class="page-load-status">
                                 <div class="infinite-scroll-request loader-ellips">
@@ -132,7 +132,7 @@
                                 <p class="infinite-scroll-error">No more pages to load</p>
                             </div>
                         </div>
-                        <div class="row dataTable browse-infiniteScroll-element mx-0 op-scroll-container">
+                        <div class="row dataTable browse-infiniteScroll-element mx-0">
                             <div class="col-lg p-0">
                             <!-- <div class="col-lg pr-0"> -->
                                 <!-- <div class="op-page-loading-status">

--- a/opus/application/apps/ui/templates/base.html
+++ b/opus/application/apps/ui/templates/base.html
@@ -122,7 +122,7 @@
                         </div>
                     </nav>
                     <div class="panel-body gallery-contents container-fluid browse-infiniteScroll-element">
-                        <div class="row justify-content-start op-height-0 op-gallery-view">
+                        <div class="row justify-content-start op-gallery-view mr-0">
                             <div class="mr-0 thumb gallery gallery-scroll"></div>
                             <div class="page-load-status">
                                 <div class="infinite-scroll-request loader-ellips">

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -416,30 +416,30 @@ th.sticky-header {
     transform: translateY(-50%);
 }
 
-.dataTable {
+.op-dataTable-view {
     width: 100%;
     position: relative;
     overflow: hidden;
 }
 
-.dataTable .ps__rail-y {
+.op-dataTable-view .ps__rail-y {
     background-color: transparent !important;
     z-index: 11;
 }
 
 /* Make sure x-scrollbar in dataTable is always at the left and visible */
-.dataTable .ps__rail-x {
+.op-dataTable-view .ps__rail-x {
     background-color: transparent !important;
     opacity: 0.9 !important;
 }
 
 /* change from 1px to 2px to make ps__thumb-y more cnetered */
-.dataTable .ps__thumb-y {
+.op-dataTable-view .ps__thumb-y {
     right: 2px;
 }
 
 /* avoid seeing through ps__rail_x in table view */
-.dataTable .ps__thumb-x {
+.op-dataTable-view .ps__thumb-x {
     bottom: 1px;
 }
 

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -90,15 +90,20 @@ body {
     min-height: 700px;
 }
 
-.gallery-contents {
+/* .gallery-contents {
     overflow-y: hidden;
     overflow-x: hidden;
     position: relative;
-}
+} */
 
 /* Make sure y-axis rail is not moving and always visible */
-.gallery-contents > .ps__rail-y {
+.op-gallery-view > .ps__rail-y {
     background-color: transparent !important;
+}
+
+.op-gallery-view {
+    overflow: hidden;
+    position: relative;
 }
 
 #detail {

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -90,20 +90,14 @@ body {
     min-height: 700px;
 }
 
-/* .gallery-contents {
-    overflow-y: hidden;
-    overflow-x: hidden;
+.op-gallery-view {
+    overflow: hidden;
     position: relative;
-} */
+}
 
 /* Make sure y-axis rail is not moving and always visible */
 .op-gallery-view > .ps__rail-y {
     background-color: transparent !important;
-}
-
-.op-gallery-view {
-    overflow: hidden;
-    position: relative;
 }
 
 #detail {

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -1175,11 +1175,6 @@ ul.ui-autocomplete a.ui-state-active {
     background-color: #F9F6F6;
 }
 
-/* remove that extra space on top when loading table page */
-.op-height-0 {
-    height: 0;
-}
-
 .op-noSelect {
     -moz-user-select: none;
     -khtml-user-select: none;

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -22,7 +22,7 @@ var o_browse = {
     reRenderData: false,
     metadataSelectorDrawn: false,
 
-    tableScrollbar: new PerfectScrollbar("#browse .dataTable", {
+    tableScrollbar: new PerfectScrollbar("#browse .op-dataTable-view", {
         minScrollbarLength: opus.minimumPSLength
     }),
     galleryScrollbar: new PerfectScrollbar("#browse .op-gallery-view", {
@@ -57,19 +57,19 @@ var o_browse = {
     browseBehaviors: function() {
         // note: using .on vs .click allows elements to be added dynamically w/out bind/rebind of handler
 
-        $(".op-gallery-view, .dataTable").on('scroll', _.debounce(o_browse.checkScroll, 500));
+        $(".op-gallery-view, .op-dataTable-view").on('scroll', _.debounce(o_browse.checkScroll, 500));
 
-        $(".op-gallery-view, .dataTable").on('wheel ps-scroll-up', function(event) {
+        $(".op-gallery-view, .op-dataTable-view").on('wheel ps-scroll-up', function(event) {
             let startobs = (opus.prefs.view === "cart" ? "cart_startobs" : "startobs");
             let tab = `#${opus.prefs.view}`;
-            let contentsView = o_browse.getScrollContainerClass();
+            // let contentsView = o_browse.getScrollContainerClass();
             if (opus.prefs[startobs] > 0) {
                 // we need something like this to see if the scroll is in the 'up' direction
                 //if (event.originalEvent.deltaY !== undefined && event.originalEvent.deltaY < 0)
                 let prev = $(`${tab} [data-obs]`).first().data("obs") - o_browse.getLimit();
 
                 // Comment this out while working on scroll down
-                if ($(`${tab} ${contentsView}`).scrollTop() === 0) {
+                if ($(`${tab} .op-${opus.prefs.browse}-view`).scrollTop() === 0) {
                     // opus.prefs[startobs] = (prev > 0 ? prev : 1);
                     // $(`${tab} ${contentsView}`).infiniteScroll({
                     //     "loadPrevPage": true
@@ -289,7 +289,7 @@ var o_browse = {
         });
 
         // click table column header to reorder by that column
-        $("#browse").on("click", ".dataTable th a",  function() {
+        $("#browse").on("click", ".op-dataTable-view th a",  function() {
             // show this spinner right away when table is clicked
             // we will hide page status loader from infiniteScroll if op-page-loading-status loader is spinning
             $(".op-page-loading-status > .loader").show();
@@ -359,7 +359,7 @@ var o_browse = {
             let targetSlug = slug;
             let isDescending = true;
             let descending = $(this).parent().attr("data-descending");
-            let headerOrderIndicator = $(`.dataTable th a[data-slug="${slug}"]`).find("span:last");
+            let headerOrderIndicator = $(`.op-dataTable-view th a[data-slug="${slug}"]`).find("span:last");
             let pillOrderIndicator = $(this);
             o_browse.reRenderData = true;
 
@@ -497,8 +497,8 @@ var o_browse = {
             headerOrderIndicator.attr("class", `column_ordering ${headerOrderArrow}`);
 
             // Reset arrows on rest of table headers
-            // let headers = $(`.dataTable th a:not([data-slug="opusid"], [data-slug=${slug}])`).find("span:last");
-            let headers = $(`.dataTable th a:not([data-slug=${slug}])`).find("span:last");
+            // let headers = $(`.op-dataTable-view th a:not([data-slug="opusid"], [data-slug=${slug}])`).find("span:last");
+            let headers = $(`.op-dataTable-view th a:not([data-slug=${slug}])`).find("span:last");
             headers.data("sort", "none");
             headers.attr("class", defaultTableSortArrow);
         }
@@ -511,7 +511,7 @@ var o_browse = {
             let orderEntrySlug = orderEntry[0] === "-" ? orderEntry.slice(1) : orderEntry;
 
             // retrieve label from either displayed header's data-label attribute or displayed pill's text
-            let label = $(`#browse .dataTable th a[data-slug="${orderEntrySlug}"]`).data("label") || $(`#browse .sort-contents span[data-slug="${orderEntrySlug}"] .flip-sort`).text();
+            let label = $(`#browse .op-dataTable-view th a[data-slug="${orderEntrySlug}"]`).data("label") || $(`#browse .sort-contents span[data-slug="${orderEntrySlug}"] .flip-sort`).text();
 
             listHtml += "<li class='list-inline-item'>";
             listHtml += `<span class='badge badge-pill badge-light' data-slug="${orderEntrySlug}" data-descending="${isPillOrderDesc}">`;
@@ -539,7 +539,7 @@ var o_browse = {
     loadNextPageIfNeeded: function(opusId) {
         let startobs = (opus.prefs.view === "cart" ? "cart__startobs" : "startobs");
         let tab = `#${opus.prefs.view}`;
-        let contentsView = o_browse.getScrollContainerClass();
+        // let contentsView = o_browse.getScrollContainerClass();
         let maxObs = (opus.prefs.view === "browse" ? opus.resultCount : parseInt($("#op-cart-count").html()));
 
         let obsNum = $(`${tab} .thumbnail-container[data-id=${opusId}]`).data("obs") + 1;
@@ -550,7 +550,7 @@ var o_browse = {
                 // this will make sure we have correct html elements displayed for prev observation
                 $("#galleryViewContents").addClass("op-disabled");
                 opus.prefs[startobs] = obsNum;
-                $(`${tab} ${contentsView}`).infiniteScroll("loadNextPage");
+                $(`${tab} .op-${opus.prefs.browse}-view`).infiniteScroll("loadNextPage");
             }
         }
     },
@@ -558,7 +558,7 @@ var o_browse = {
     loadPrevPageIfNeeded: function(opusId) {
         let startobs = (opus.prefs.view === "cart" ? "cart__startobs" : "startobs");
         let tab = `#${opus.prefs.view}`;
-        let contentsView = o_browse.getScrollContainerClass();
+        // let contentsView = o_browse.getScrollContainerClass();
         o_browse.currentOpusId = opusId;
         // decrement obsNum to see if there is a previous one to retrieve
         let obsNum = $(`${tab} .thumbnail-container[data-id=${opusId}]`).data("obs") - 1;
@@ -571,7 +571,7 @@ var o_browse = {
                 $("#galleryViewContents").addClass("op-disabled");
                 let startObs = obsNum - o_browse.getLimit();
                 opus.prefs[startobs] = (startObs > 0 ? startObs : 1);
-                $(`${tab} ${contentsView}`).infiniteScroll("loadNextPage");
+                $(`${tab} .op-${opus.prefs.browse}-view`).infiniteScroll("loadNextPage");
             }
         }
     },
@@ -594,10 +594,10 @@ var o_browse = {
 
         /* make sure it's scrolled to the correct position in table view
         let tableTargetTopPosition = $(`#dataTable tbody tr[data-obs='${obsNum}']`).offset().top;
-        let tableContainerTopPosition = $(".dataTable").offset().top;
-        let tableScrollbarPosition = $(".dataTable").scrollTop();
+        let tableContainerTopPosition = $(".op-dataTable-view").offset().top;
+        let tableScrollbarPosition = $(".op-dataTable-view").scrollTop();
         let tableTargetFinalPosition = tableTargetTopPosition - tableContainerTopPosition + tableScrollbarPosition
-        $(`${namespace} .dataTable`).scrollTop(tableTargetFinalPosition);*/
+        $(`${namespace} .op-dataTable-view`).scrollTop(tableTargetFinalPosition);*/
     },
 
     // called when the slider is moved...
@@ -890,7 +890,7 @@ var o_browse = {
 
     updateBrowseNav: function() {
         if (opus.prefs.browse == "gallery") {
-            $(".dataTable", "#browse").hide();
+            $(".op-dataTable-view", "#browse").hide();
             $(".op-gallery-view", "#browse").fadeIn();
 
             $(".op-browse-view", "#browse").html("<i class='far fa-list-alt'></i>&nbsp;View Table");
@@ -900,7 +900,7 @@ var o_browse = {
             o_browse.galleryScrollbar.settings.suppressScrollY = false;
         } else {
             $(".op-gallery-view", "#browse").hide();
-            $(".dataTable", "#browse").fadeIn();
+            $(".op-dataTable-view", "#browse").fadeIn();
 
             $(".op-browse-view", "#browse").html("<i class='far fa-images'></i>&nbsp;View Gallery");
             $(".op-browse-view", "#browse").attr("title", "View sortable thumbnail gallery");
@@ -1045,12 +1045,12 @@ var o_browse = {
             if ($(`${namespace} .thumbnail-container`).first().data("obs") > data.start_obs) {
                 $(".gallery", namespace).prepend(galleryHtml);
                 if (namespace == "#browse") {   // not yet supported for cart
-                    $(".dataTable tbody").prepend(tableHtml);
+                    $(".op-dataTable-view tbody").prepend(tableHtml);
                 }
             } else {
                 $(".gallery", namespace).append(galleryHtml);
                 if (namespace == "#browse") {   // not yet supported for cart
-                    $(".dataTable tbody").append(tableHtml);
+                    $(".op-dataTable-view tbody").append(tableHtml);
                 }
             }
         }
@@ -1062,8 +1062,8 @@ var o_browse = {
 
     initTable: function(columns, columnsNoUnits) {
         // prepare table and headers...
-        $(".dataTable thead > tr > th").remove();
-        $(".dataTable tbody > tr").remove();
+        $(".op-dataTable-view thead > tr > th").remove();
+        $(".op-dataTable-view tbody > tr").remove();
 
         // NOTE:  At some point, ORDER needs to be identified in the table, as to which column we are ordering on
 
@@ -1079,7 +1079,7 @@ var o_browse = {
 
         // check all box
         //let checkbox = "<input type='checkbox' name='all' value='all' class='multichoice'>";
-        $(".dataTable thead tr").append("<th scope='col' class='sticky-header'></th>");
+        $(".op-dataTable-view thead tr").append("<th scope='col' class='sticky-header'></th>");
         $.each(columns, function(index, header) {
             let slug = slugs[index];
 
@@ -1091,7 +1091,7 @@ var o_browse = {
             let columnSorting = icon === "-down" ? "sort-asc" : icon === "-up" ? "sort-desc" : "none";
             let columnOrdering = `<a href='' data-slug='${slug}' data-label='${label}'><span>${header}</span><span data-sort='${columnSorting}' class='column_ordering fas fa-sort${icon}'></span></a>`;
 
-            $(".dataTable thead tr").append(`<th id='${slug} 'scope='col' class='sticky-header'><div>${columnOrdering}</div></th>`);
+            $(".op-dataTable-view thead tr").append(`<th id='${slug} 'scope='col' class='sticky-header'><div>${columnOrdering}</div></th>`);
         });
 
         o_browse.initResizableColumn();
@@ -1162,7 +1162,7 @@ var o_browse = {
     // set the scrollbar position in gallery / table view
     setScrollbarPosition: function(selector, obsNum) {
         $(`${selector}`).scrollTop(0);
-        $(`${selector} .dataTable`).scrollTop(0);
+        $(`${selector} .op-dataTable-view`).scrollTop(0);
     },
 
     // number of images that can be fit in current window size
@@ -1183,13 +1183,6 @@ var o_browse = {
         url += `&limit=${o_browse.getLimit() * 2}`;
 
         return url;
-    },
-
-    // return the infiniteScroll container class for either gallery or table view
-    // NOTE: the reason we don't want to use a single unified class is because we have two infiniteScroll instances.
-    // If they share a same class say "op-scroll-container", then later on $(selector).infiniteScroll("loadNextPage") will call load event handler twice (selector selects both container) and render the data twice (duplicated data).
-    getScrollContainerClass: function() {
-        return (opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable");
     },
 
     getStartObsLabel: function() {
@@ -1260,8 +1253,8 @@ var o_browse = {
     loadData: function(startObs) {
         let tab = `#${opus.prefs.view}`;
         let startObsLabel = o_browse.getStartObsLabel();
-        let contentsView = o_browse.getScrollContainerClass();
-        let selector = `${tab} ${contentsView}`;
+        // let contentsView = o_browse.getScrollContainerClass();
+        let selector = `${tab} .op-${opus.prefs.browse}-view`;
 
         startObs = (startObs === undefined ? opus.prefs[startObsLabel] : startObs);
 
@@ -1303,12 +1296,12 @@ var o_browse = {
             if (!o_browse.galleryBegun) {
                 o_browse.initTable(data.columns, data.columns_no_units);
 
-                $(`${selector}`).scrollTop(0);
-                $(`${selector} .dataTable`).scrollTop(0);
+                $(`${tab} .op-gallery-view`).scrollTop(0);
+                $(`${tab} .op-dataTable-view`).scrollTop(0);
 
                 // Instantiate infiniteScroll on gallery and table view
                 o_browse.initInfiniteScroll(`${tab} .op-gallery-view`);
-                o_browse.initInfiniteScroll(`${tab} .dataTable`);
+                o_browse.initInfiniteScroll(`${tab} .op-dataTable-view`);
             }
 
             // Because we redraw from the beginning or user inputted page, we need to remove previous drawn thumb-pages
@@ -1399,8 +1392,8 @@ var o_browse = {
         let tab = `#${opus.prefs.view}`;
         let containerWidth = $(`${tab} .gallery-contents`).width();
         let containerHeight = $(`${tab} .gallery-contents`).height() - $(".app-footer").height() + 8;
-        $(`${tab} .dataTable`).width(containerWidth);
-        $(`${tab} .dataTable`).height(containerHeight);
+        $(`${tab} .op-dataTable-view`).width(containerWidth);
+        $(`${tab} .op-dataTable-view`).height(containerHeight);
         o_browse.tableScrollbar.update();
     },
 

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1241,7 +1241,8 @@ var o_browse = {
             $(selector).on("request.infiniteScroll", function(event, path) {
                 // hide default page status loader if op-page-loading-status loader is spinning
                 // && o_browse.tableSorting
-                $(".infinite-scroll-request").hide();
+                // Comment this out so that we will have spinner displayed
+                // $(".infinite-scroll-request").hide();
             });
             $(selector).on("scrollThreshold.infiniteScroll", function(event) {
                 // console.log("=== scrollThreshold causing the load next page ===");
@@ -1265,6 +1266,7 @@ var o_browse = {
         startObs = (startObs === undefined ? opus.prefs[startObsLabel] : startObs);
 
         // TODO - need to resolve what reRenderData is vs. galleryBegun - and comment, etc...
+        // reRenderData true is corresponding to galleryBegun false
         if (!o_browse.reRenderData) {
             // if the request is a block far away from current page cache, flush the cache and start over
             let elem = $(`${tab} [data-obs="${startObs}"]`);

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -57,9 +57,9 @@ var o_browse = {
     browseBehaviors: function() {
         // note: using .on vs .click allows elements to be added dynamically w/out bind/rebind of handler
 
-        $(".gallery-contents, .dataTable").on('scroll', _.debounce(o_browse.checkScroll, 500));
+        $(".op-gallery-view, .dataTable").on('scroll', _.debounce(o_browse.checkScroll, 500));
 
-        $(".gallery-contents, .dataTable").on('wheel ps-scroll-up', function(event) {
+        $(".op-gallery-view, .dataTable").on('wheel ps-scroll-up', function(event) {
             let startobs = (opus.prefs.view === "cart" ? "cart_startobs" : "startobs");
             let tab = `#${opus.prefs.view}`;
             let contentsView = o_browse.getScrollContainerClass();
@@ -69,7 +69,6 @@ var o_browse = {
                 let prev = $(`${tab} [data-obs]`).first().data("obs") - o_browse.getLimit();
 
                 // Comment this out while working on scroll down
-                // Because now we have two infiniteScroll instances (sharing the same .op-scroll-container class), and we haven't add the feature of syncing up scrollbar positions in both gallery and table yet. $(`${tab} ${contentsView}`).scrollTop() === 0 will always be true when switching between gallery and table view, and set "loadPrevPage" to true. This will append duplicated data to the end...
                 if ($(`${tab} ${contentsView}`).scrollTop() === 0) {
                     // opus.prefs[startobs] = (prev > 0 ? prev : 1);
                     // $(`${tab} ${contentsView}`).infiniteScroll({
@@ -1187,9 +1186,10 @@ var o_browse = {
     },
 
     // return the infiniteScroll container class for either gallery or table view
-    // Maybe convert it to a global variable later...
+    // NOTE: the reason we don't want to use a single unified class is because we have two infiniteScroll instances.
+    // If they share a same class say "op-scroll-container", then later on $(selector).infiniteScroll("loadNextPage") will call load event handler twice (selector selects both container) and render the data twice (duplicated data).
     getScrollContainerClass: function() {
-        return ".op-scroll-container";
+        return (opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable");
     },
 
     // Instantiate infiniteScroll
@@ -1198,11 +1198,13 @@ var o_browse = {
         if (!$(selector).data("infiniteScroll")) {
             $(selector).infiniteScroll({
                 path: function() {
+                    // console.log(`=== PATH ON ${selector}`);
                     let startObs = opus.prefs[`${view.prefix}startobs`];
 
                     console.log(`${selector} in path - startObs: ${startObs}`);
                     let infiniteScrollData = $(selector).data("infiniteScroll");
                     if (infiniteScrollData !== undefined && infiniteScrollData.options.loadPrevPage === true) {
+                        // Direction: scroll up
                         console.log(`loadPrevPage = true`);
                         infiniteScrollData.options.loadPrevPage = false;
                     } else {

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -25,7 +25,7 @@ var o_browse = {
     tableScrollbar: new PerfectScrollbar("#browse .dataTable", {
         minScrollbarLength: opus.minimumPSLength
     }),
-    galleryScrollbar: new PerfectScrollbar("#browse .gallery-contents", {
+    galleryScrollbar: new PerfectScrollbar("#browse .op-gallery-view", {
         suppressScrollX: true,
         minScrollbarLength: opus.minimumPSLength
     }),
@@ -575,11 +575,11 @@ var o_browse = {
     setScrollbarOnSlide: function(obsNum) {
         let tab = `#${opus.prefs.view}`;
         let galleryTargetTopPosition = $(`${tab} .thumbnail-container[data-obs="${obsNum}"]`).offset().top;
-        let galleryContainerTopPosition = $(`${tab} .gallery-contents`).offset().top;
-        let galleryScrollbarPosition = $(`${tab} .gallery-contents`).scrollTop();
+        let galleryContainerTopPosition = $(`${tab} .gallery-contents .op-gallery-view`).offset().top;
+        let galleryScrollbarPosition = $(`${tab} .gallery-contents .op-gallery-view`).scrollTop();
 
         let galleryTargetFinalPosition = galleryTargetTopPosition - galleryContainerTopPosition + galleryScrollbarPosition;
-        $(`${tab} .gallery-contents`).scrollTop(galleryTargetFinalPosition);
+        $(`${tab} .gallery-contents .op-gallery-view`).scrollTop(galleryTargetFinalPosition);
 
         // TODO
         // Create a new jQuery.Event object with specified event properties.
@@ -899,8 +899,8 @@ var o_browse = {
 
     updateBrowseNav: function() {
         if (opus.prefs.browse == "gallery") {
-            $("." + "dataTable", "#browse").hide();
-            $("." + opus.prefs.browse, "#browse").fadeIn();
+            $(".dataTable", "#browse").hide();
+            $(".op-gallery-view", "#browse").fadeIn();
 
             $(".browse_view", "#browse").html("<i class='far fa-list-alt'></i>&nbsp;View Table");
             $(".browse_view", "#browse").attr("title", "View sortable metadata table");
@@ -911,12 +911,10 @@ var o_browse = {
             o_browse.galleryScrollbar.settings.suppressScrollY = false;
 
             $(".gallery-contents > .ps__rail-y").removeClass("hide_ps__rail-y");
-            if (!$(".dataTable > .ps__rail-y").hasClass("hide_ps__rail-y")) {
-                $(".dataTable > .ps__rail-y").addClass("hide_ps__rail-y");
-            }
+            $(".dataTable > .ps__rail-y").addClass("hide_ps__rail-y");
         } else {
-            $("." + "gallery", "#browse").hide();
-            $("." + opus.prefs.browse, "#browse").fadeIn();
+            $(".op-gallery-view", "#browse").hide();
+            $(".dataTable", "#browse").fadeIn();
 
             $(".browse_view", "#browse").html("<i class='far fa-images'></i>&nbsp;View Gallery");
             $(".browse_view", "#browse").attr("title", "View sortable thumbnail gallery");
@@ -927,9 +925,7 @@ var o_browse = {
 
             o_browse.galleryScrollbar.settings.suppressScrollY = true;
 
-            if (!$(".gallery-contents > .ps__rail-y").hasClass("hide_ps__rail-y")) {
-                $(".gallery-contents > .ps__rail-y").addClass("hide_ps__rail-y");
-            }
+            $(".gallery-contents > .ps__rail-y").addClass("hide_ps__rail-y");
             $(".dataTable > .ps__rail-y").removeClass("hide_ps__rail-y");
         }
     },
@@ -1377,12 +1373,13 @@ var o_browse = {
 
     adjustBrowseHeight: function() {
         let tab = `#${opus.prefs.view}`;
-        let container_height = $(window).height()-120;
-        $(`${tab} .gallery-contents`).height(container_height);
+        let containerHeight = $(window).height()-120;
+        $(`${tab} .gallery-contents`).height(containerHeight);
+        $(`${tab} .gallery-contents .op-gallery-view`).height(containerHeight);
         o_browse.galleryScrollbar.update();
         o_browse.galleryBoundingRect = o_browse.countGalleryImages();
         $("#op-observation-slider").slider("option", "step", o_browse.galleryBoundingRect.x);
-        //opus.limit =  (floor($(window).width()/thumbnailSize) * floor(container_height/thumbnailSize));
+        //opus.limit =  (floor($(window).width()/thumbnailSize) * floor(containerHeight/thumbnailSize));
     },
 
     adjustTableSize: function() {

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1245,7 +1245,6 @@ var o_browse = {
                 // $(".infinite-scroll-request").hide();
             });
             $(selector).on("scrollThreshold.infiniteScroll", function(event) {
-                // console.log("=== scrollThreshold causing the load next page ===");
                 // remove spinner when scrollThreshold is triggered and last data fetching has no data
                 // Need to revisit this one
                 if (o_browse.dataNotAvailable) {
@@ -1306,8 +1305,6 @@ var o_browse = {
 
                 $(`${tab} .op-gallery-view`).scrollTop(0);
                 $(`${tab} .op-dataTable-view`).scrollTop(0);
-                // $(`${selector}`).scrollTop(0);
-                // $(`${selector} .op-dataTable-view`).scrollTop(0);
 
                 // Instantiate infiniteScroll on gallery and table view
                 o_browse.initInfiniteScroll(`${tab} .op-gallery-view`);

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -88,7 +88,7 @@ var o_browse = {
         });
 
         // browse nav menu - the gallery/table toggle
-        $("#browse").on("click", ".browse_view", function() {
+        $("#browse").on("click", ".op-browse-view", function() {
             o_browse.hideMenu();
             opus.prefs.browse = $(this).data("view");
 
@@ -902,9 +902,9 @@ var o_browse = {
             $(".dataTable", "#browse").hide();
             $(".op-gallery-view", "#browse").fadeIn();
 
-            $(".browse_view", "#browse").html("<i class='far fa-list-alt'></i>&nbsp;View Table");
-            $(".browse_view", "#browse").attr("title", "View sortable metadata table");
-            $(".browse_view", "#browse").data("view", "dataTable");
+            $(".op-browse-view", "#browse").html("<i class='far fa-list-alt'></i>&nbsp;View Table");
+            $(".op-browse-view", "#browse").attr("title", "View sortable metadata table");
+            $(".op-browse-view", "#browse").data("view", "dataTable");
 
             // $(".justify-content-center").show();
 
@@ -916,9 +916,9 @@ var o_browse = {
             $(".op-gallery-view", "#browse").hide();
             $(".dataTable", "#browse").fadeIn();
 
-            $(".browse_view", "#browse").html("<i class='far fa-images'></i>&nbsp;View Gallery");
-            $(".browse_view", "#browse").attr("title", "View sortable thumbnail gallery");
-            $(".browse_view", "#browse").data("view", "gallery");
+            $(".op-browse-view", "#browse").html("<i class='far fa-images'></i>&nbsp;View Gallery");
+            $(".op-browse-view", "#browse").attr("title", "View sortable thumbnail gallery");
+            $(".op-browse-view", "#browse").data("view", "gallery");
 
             // remove that extra space on top when loading table page
             // $(".justify-content-center").hide();

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1187,6 +1187,7 @@ var o_browse = {
     },
 
     // return the infiniteScroll container class for either gallery or table view
+    // Maybe convert it to a global variable later...
     getScrollContainerClass: function() {
         return ".op-scroll-container";
     },
@@ -1197,7 +1198,6 @@ var o_browse = {
         if (!$(selector).data("infiniteScroll")) {
             $(selector).infiniteScroll({
                 path: function() {
-                    console.log(`====== LOAD NEW DATA ON ${selector}======`);
                     let startObs = opus.prefs[`${view.prefix}startobs`];
 
                     console.log(`${selector} in path - startObs: ${startObs}`);
@@ -1298,7 +1298,6 @@ var o_browse = {
                 $(`${selector} .dataTable`).scrollTop(0);
 
                 // Instantiate infiniteScroll on gallery and table view
-                console.log("=== Instantiate infiniteScroll ===")
                 o_browse.initInfiniteScroll(`${view.namespace} .op-gallery-view`);
                 o_browse.initInfiniteScroll(`${view.namespace} .dataTable`);
             }

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1228,7 +1228,7 @@ var o_browse = {
                     return path;
                 },
                 responseType: "text",
-                status: `${view.namespace}  .page-load-status`,
+                status: `${view.namespace} .page-load-status`,
                 elementScroll: true,
                 history: false,
                 scrollThreshold: 500,

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -27,7 +27,9 @@ var o_browse = {
     }),
     galleryScrollbar: new PerfectScrollbar("#browse .op-gallery-view", {
         suppressScrollX: true,
-        minScrollbarLength: opus.minimumPSLength
+        minScrollbarLength: opus.minimumPSLength,
+        // minScrollbarLength: $(window).height()/5,
+        // maxScrollbarLength: $(window).height()/5,
     }),
     modalScrollbar: new PerfectScrollbar("#galleryViewContents .metadata", {
         minScrollbarLength: opus.minimumPSLength
@@ -62,16 +64,17 @@ var o_browse = {
         $(".gallery-contents, .dataTable").on('wheel ps-scroll-up', function(event) {
             let startobs = (opus.prefs.view === "cart" ? "cart_startobs" : "startobs");
             let tab = `#${opus.prefs.view}`;
+            let browseView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
             if (opus.prefs[startobs] > 0) {
                 // we need something like this to see if the scroll is in the 'up' direction
                 //if (event.originalEvent.deltaY !== undefined && event.originalEvent.deltaY < 0)
                 let prev = $(`${tab} [data-obs]`).first().data("obs") - o_browse.getLimit();
                 if ($(`${tab} .gallery-contents`).scrollTop() === 0 || $(`${tab} .dataTable`).scrollTop() === 0) {
                     opus.prefs[startobs] = (prev > 0 ? prev : 1);
-                    $(`${tab} .gallery-contents`).infiniteScroll({
+                    $(`${tab} ${browseView}`).infiniteScroll({
                         "loadPrevPage": true
                     });
-                    $(`${tab} .gallery-contents`).infiniteScroll("loadNextPage");
+                    $(`${tab} ${browseView}`).infiniteScroll("loadNextPage");
                 }
             }
         });
@@ -536,6 +539,7 @@ var o_browse = {
     loadNextPageIfNeeded: function(opusId) {
         let startobs = (opus.prefs.view === "cart" ? "cart__startobs" : "startobs");
         let tab = `#${opus.prefs.view}`;
+        let browseView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
         let maxObs = (opus.prefs.view === "browse" ? opus.resultCount : parseInt($("#op-cart-count").html()));
 
         let obsNum = $(`${tab} .thumbnail-container[data-id=${opusId}]`).data("obs") + 1;
@@ -546,7 +550,7 @@ var o_browse = {
                 // this will make sure we have correct html elements displayed for prev observation
                 $("#galleryViewContents").addClass("op-disabled");
                 opus.prefs[startobs] = obsNum;
-                $(`${tab} .gallery-contents`).infiniteScroll("loadNextPage");
+                $(`${tab} ${browseView}`).infiniteScroll("loadNextPage");
             }
         }
     },
@@ -554,7 +558,7 @@ var o_browse = {
     loadPrevPageIfNeeded: function(opusId) {
         let startobs = (opus.prefs.view === "cart" ? "cart__startobs" : "startobs");
         let tab = `#${opus.prefs.view}`;
-
+        let browseView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
         o_browse.currentOpusId = opusId;
         // decrement obsNum to see if there is a previous one to retrieve
         let obsNum = $(`${tab} .thumbnail-container[data-id=${opusId}]`).data("obs") - 1;
@@ -567,7 +571,7 @@ var o_browse = {
                 $("#galleryViewContents").addClass("op-disabled");
                 let startObs = obsNum - o_browse.getLimit();
                 opus.prefs[startobs] = (startObs > 0 ? startObs : 1);
-                $(`${tab} .gallery-contents`).infiniteScroll("loadNextPage");
+                $(`${tab} ${browseView}`).infiniteScroll("loadNextPage");
             }
         }
     },
@@ -638,6 +642,7 @@ var o_browse = {
 
     checkScroll: function() {
         // infinite scroll is attached to the gallery, so we have to force a loadData when we are in table mode
+        let browseView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
         if (opus.prefs.browse == "dataTable") {
             let bottom = $("tbody").offset().top + $("tbody").height();
             if (bottom <= $(document).height()) {
@@ -646,7 +651,7 @@ var o_browse = {
                 if (o_browse.dataNotAvailable) {
                     $(".infinite-scroll-request").hide();
                 }
-                $(`#${opus.prefs.view} .gallery-contents`).infiniteScroll("loadNextPage");
+                $(`#${opus.prefs.view} ${browseView}`).infiniteScroll("loadNextPage");
             }
         }
 
@@ -1196,7 +1201,13 @@ var o_browse = {
 
     loadData: function(startObs) {
         let view = o_browse.getViewInfo();
-        let selector = `${view.namespace} .gallery-contents`;
+        // console.log("view namespace");
+        // console.log(view.namespace);
+        // console.log("opus.prefs.browse");
+        // console.log(opus.prefs.browse);
+        let browseView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
+        // let selector = `${view.namespace} .gallery-contents`;
+        let selector = `${view.namespace} ${browseView}`;
 
         startObs = (startObs === undefined ? opus.prefs[`${view.prefix}startobs`] : startObs);
 
@@ -1243,6 +1254,7 @@ var o_browse = {
                 if (!$(selector).data("infiniteScroll")) {
                     $(selector).infiniteScroll({
                         path: function() {
+                            console.log(`====== LOAD NEW DATA ON ${browseView}======`);
                             let startObs = opus.prefs[`${view.prefix}startobs`];
                             console.log(`in path - startObs: ${startObs}`);
                             let infiniteScrollData = $(selector).data("infiniteScroll");

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -642,18 +642,19 @@ var o_browse = {
 
     checkScroll: function() {
         // infinite scroll is attached to the gallery, so we have to force a loadData when we are in table mode
-        let contentsView = o_browse.getScrollContainerClass();
-        if (opus.prefs.browse == "dataTable") {
-            let bottom = $("tbody").offset().top + $("tbody").height();
-            if (bottom <= $(document).height()) {
-                // remove spinner when scrollThreshold is triggered and last data fetching has no data
-                // Need to revisit this one
-                if (o_browse.dataNotAvailable) {
-                    $(".infinite-scroll-request").hide();
-                }
-                $(`#${opus.prefs.view} ${contentsView}`).infiniteScroll("loadNextPage");
-            }
-        }
+
+        // Comment out for now. We can remove this because .dataTable now has its own infiniteScroll instance and loadNextPage will be triggered by it's own scrollThreshold event handler
+        // if (opus.prefs.browse == "dataTable") {
+        //     let bottom = $("tbody").offset().top + $("tbody").height();
+        //     if (bottom <= $(document).height()) {
+        //         // remove spinner when scrollThreshold is triggered and last data fetching has no data
+        //         // Need to revisit this one
+        //         if (o_browse.dataNotAvailable) {
+        //             $(".infinite-scroll-request").hide();
+        //         }
+        //         $(`#${opus.prefs.view} ${contentsView}`).infiniteScroll("loadNextPage");
+        //     }
+        // }
 
         o_browse.updateSliderHandle();
         return false;
@@ -1200,10 +1201,8 @@ var o_browse = {
     },
 
     // return the infiniteScroll container class for either gallery or table view
-    // Note: we didn't use a single unified class because they are two different container
-    // If we use the same class for both of them, when infiniteScroll loadNextPage is called, infiniteScrollLoadEventListener will be called twice and data will also be rendered twice (duplicated data)
     getScrollContainerClass: function() {
-        return (opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable");
+        return ".op-scroll-container";
     },
 
     // Instantiate infiniteScroll
@@ -1243,7 +1242,7 @@ var o_browse = {
                 loadPrevPage: false,
                 // TODO: store the most top left obsNum in gallery or the most top obsNum in table
                 obsNum: 1,
-                debug: false,
+                debug: true,
             });
 
             $(selector).on("request.infiniteScroll", function(event, path) {
@@ -1252,6 +1251,7 @@ var o_browse = {
                 $(".infinite-scroll-request").hide();
             });
             $(selector).on("scrollThreshold.infiniteScroll", function(event) {
+                console.log("=== scrollThreshold causing the load next page ===")
                 // remove spinner when scrollThreshold is triggered and last data fetching has no data
                 // Need to revisit this one
                 if (o_browse.dataNotAvailable) {

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -64,17 +64,17 @@ var o_browse = {
         $(".gallery-contents, .dataTable").on('wheel ps-scroll-up', function(event) {
             let startobs = (opus.prefs.view === "cart" ? "cart_startobs" : "startobs");
             let tab = `#${opus.prefs.view}`;
-            let browseView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
+            let contentsView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
             if (opus.prefs[startobs] > 0) {
                 // we need something like this to see if the scroll is in the 'up' direction
                 //if (event.originalEvent.deltaY !== undefined && event.originalEvent.deltaY < 0)
                 let prev = $(`${tab} [data-obs]`).first().data("obs") - o_browse.getLimit();
                 if ($(`${tab} .gallery-contents`).scrollTop() === 0 || $(`${tab} .dataTable`).scrollTop() === 0) {
                     opus.prefs[startobs] = (prev > 0 ? prev : 1);
-                    $(`${tab} ${browseView}`).infiniteScroll({
+                    $(`${tab} ${contentsView}`).infiniteScroll({
                         "loadPrevPage": true
                     });
-                    $(`${tab} ${browseView}`).infiniteScroll("loadNextPage");
+                    $(`${tab} ${contentsView}`).infiniteScroll("loadNextPage");
                 }
             }
         });
@@ -539,7 +539,7 @@ var o_browse = {
     loadNextPageIfNeeded: function(opusId) {
         let startobs = (opus.prefs.view === "cart" ? "cart__startobs" : "startobs");
         let tab = `#${opus.prefs.view}`;
-        let browseView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
+        let contentsView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
         let maxObs = (opus.prefs.view === "browse" ? opus.resultCount : parseInt($("#op-cart-count").html()));
 
         let obsNum = $(`${tab} .thumbnail-container[data-id=${opusId}]`).data("obs") + 1;
@@ -550,7 +550,7 @@ var o_browse = {
                 // this will make sure we have correct html elements displayed for prev observation
                 $("#galleryViewContents").addClass("op-disabled");
                 opus.prefs[startobs] = obsNum;
-                $(`${tab} ${browseView}`).infiniteScroll("loadNextPage");
+                $(`${tab} ${contentsView}`).infiniteScroll("loadNextPage");
             }
         }
     },
@@ -558,7 +558,7 @@ var o_browse = {
     loadPrevPageIfNeeded: function(opusId) {
         let startobs = (opus.prefs.view === "cart" ? "cart__startobs" : "startobs");
         let tab = `#${opus.prefs.view}`;
-        let browseView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
+        let contentsView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
         o_browse.currentOpusId = opusId;
         // decrement obsNum to see if there is a previous one to retrieve
         let obsNum = $(`${tab} .thumbnail-container[data-id=${opusId}]`).data("obs") - 1;
@@ -571,7 +571,7 @@ var o_browse = {
                 $("#galleryViewContents").addClass("op-disabled");
                 let startObs = obsNum - o_browse.getLimit();
                 opus.prefs[startobs] = (startObs > 0 ? startObs : 1);
-                $(`${tab} ${browseView}`).infiniteScroll("loadNextPage");
+                $(`${tab} ${contentsView}`).infiniteScroll("loadNextPage");
             }
         }
     },
@@ -642,7 +642,7 @@ var o_browse = {
 
     checkScroll: function() {
         // infinite scroll is attached to the gallery, so we have to force a loadData when we are in table mode
-        let browseView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
+        let contentsView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
         if (opus.prefs.browse == "dataTable") {
             let bottom = $("tbody").offset().top + $("tbody").height();
             if (bottom <= $(document).height()) {
@@ -651,7 +651,7 @@ var o_browse = {
                 if (o_browse.dataNotAvailable) {
                     $(".infinite-scroll-request").hide();
                 }
-                $(`#${opus.prefs.view} ${browseView}`).infiniteScroll("loadNextPage");
+                $(`#${opus.prefs.view} ${contentsView}`).infiniteScroll("loadNextPage");
             }
         }
 
@@ -1205,9 +1205,9 @@ var o_browse = {
         // console.log(view.namespace);
         // console.log("opus.prefs.browse");
         // console.log(opus.prefs.browse);
-        let browseView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
+        let contentsView = opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable";
         // let selector = `${view.namespace} .gallery-contents`;
-        let selector = `${view.namespace} ${browseView}`;
+        let selector = `${view.namespace} ${contentsView}`;
 
         startObs = (startObs === undefined ? opus.prefs[`${view.prefix}startobs`] : startObs);
 
@@ -1254,7 +1254,7 @@ var o_browse = {
                 if (!$(selector).data("infiniteScroll")) {
                     $(selector).infiniteScroll({
                         path: function() {
-                            console.log(`====== LOAD NEW DATA ON ${browseView}======`);
+                            console.log(`====== LOAD NEW DATA ON ${contentsView}======`);
                             let startObs = opus.prefs[`${view.prefix}startobs`];
                             console.log(`in path - startObs: ${startObs}`);
                             let infiniteScrollData = $(selector).data("infiniteScroll");

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -60,17 +60,18 @@ var o_browse = {
         $(".op-gallery-view, .op-dataTable-view").on('scroll', _.debounce(o_browse.checkScroll, 500));
 
         $(".op-gallery-view, .op-dataTable-view").on('wheel ps-scroll-up', function(event) {
-            let startobs = (opus.prefs.view === "cart" ? "cart_startobs" : "startobs");
+            // let startobs = (opus.prefs.view === "cart" ? "cart_startobs" : "startobs");
+            let startObsLabel = o_browse.getStartObsLabel();
             let tab = `#${opus.prefs.view}`;
-            // let contentsView = o_browse.getScrollContainerClass();
-            if (opus.prefs[startobs] > 0) {
+            let contentsView = o_browse.getScrollContainerClass();
+            if (opus.prefs[startObsLabel] > 0) {
                 // we need something like this to see if the scroll is in the 'up' direction
                 //if (event.originalEvent.deltaY !== undefined && event.originalEvent.deltaY < 0)
                 let prev = $(`${tab} [data-obs]`).first().data("obs") - o_browse.getLimit();
 
                 // Comment this out while working on scroll down
-                if ($(`${tab} .op-${opus.prefs.browse}-view`).scrollTop() === 0) {
-                    // opus.prefs[startobs] = (prev > 0 ? prev : 1);
+                if ($(`${tab} ${contentsView}`).scrollTop() === 0) {
+                    // opus.prefs[startObsLabel] = (prev > 0 ? prev : 1);
                     // $(`${tab} ${contentsView}`).infiniteScroll({
                     //     "loadPrevPage": true
                     // });
@@ -537,9 +538,9 @@ var o_browse = {
 
     // check if we need infiniteScroll to load next page when there is no more prefected data
     loadNextPageIfNeeded: function(opusId) {
-        let startobs = (opus.prefs.view === "cart" ? "cart__startobs" : "startobs");
+        let startObsLabel = o_browse.getStartObsLabel();
         let tab = `#${opus.prefs.view}`;
-        // let contentsView = o_browse.getScrollContainerClass();
+        let contentsView = o_browse.getScrollContainerClass();
         let maxObs = (opus.prefs.view === "browse" ? opus.resultCount : parseInt($("#op-cart-count").html()));
 
         let obsNum = $(`${tab} .thumbnail-container[data-id=${opusId}]`).data("obs") + 1;
@@ -549,16 +550,16 @@ var o_browse = {
                 // disable keydown on modal when it's loading
                 // this will make sure we have correct html elements displayed for prev observation
                 $("#galleryViewContents").addClass("op-disabled");
-                opus.prefs[startobs] = obsNum;
-                $(`${tab} .op-${opus.prefs.browse}-view`).infiniteScroll("loadNextPage");
+                opus.prefs[startObsLabel] = obsNum;
+                $(`${tab} ${contentsView}`).infiniteScroll("loadNextPage");
             }
         }
     },
 
     loadPrevPageIfNeeded: function(opusId) {
-        let startobs = (opus.prefs.view === "cart" ? "cart__startobs" : "startobs");
+        let startObsLabel = o_browse.getStartObsLabel();
         let tab = `#${opus.prefs.view}`;
-        // let contentsView = o_browse.getScrollContainerClass();
+        let contentsView = o_browse.getScrollContainerClass();
         o_browse.currentOpusId = opusId;
         // decrement obsNum to see if there is a previous one to retrieve
         let obsNum = $(`${tab} .thumbnail-container[data-id=${opusId}]`).data("obs") - 1;
@@ -570,8 +571,8 @@ var o_browse = {
                 // this will make sure we have correct html elements displayed for prev observation
                 $("#galleryViewContents").addClass("op-disabled");
                 let startObs = obsNum - o_browse.getLimit();
-                opus.prefs[startobs] = (startObs > 0 ? startObs : 1);
-                $(`${tab} .op-${opus.prefs.browse}-view`).infiniteScroll("loadNextPage");
+                opus.prefs[startObsLabel] = (startObs > 0 ? startObs : 1);
+                $(`${tab} ${contentsView}`).infiniteScroll("loadNextPage");
             }
         }
     },
@@ -1185,6 +1186,11 @@ var o_browse = {
         return url;
     },
 
+    // return the infiniteScroll container class for either gallery or table view
+    getScrollContainerClass: function() {
+        return (opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".op-dataTable-view");
+    },
+
     getStartObsLabel: function() {
         return (opus.prefs.view === "cart" ? "cart_startobs" : "startobs");
     },
@@ -1253,8 +1259,8 @@ var o_browse = {
     loadData: function(startObs) {
         let tab = `#${opus.prefs.view}`;
         let startObsLabel = o_browse.getStartObsLabel();
-        // let contentsView = o_browse.getScrollContainerClass();
-        let selector = `${tab} .op-${opus.prefs.browse}-view`;
+        let contentsView = o_browse.getScrollContainerClass();
+        let selector = `${tab} ${contentsView}`;
 
         startObs = (startObs === undefined ? opus.prefs[startObsLabel] : startObs);
 
@@ -1298,6 +1304,8 @@ var o_browse = {
 
                 $(`${tab} .op-gallery-view`).scrollTop(0);
                 $(`${tab} .op-dataTable-view`).scrollTop(0);
+                // $(`${selector}`).scrollTop(0);
+                // $(`${selector} .op-dataTable-view`).scrollTop(0);
 
                 // Instantiate infiniteScroll on gallery and table view
                 o_browse.initInfiniteScroll(`${tab} .op-gallery-view`);

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -27,9 +27,7 @@ var o_browse = {
     }),
     galleryScrollbar: new PerfectScrollbar("#browse .op-gallery-view", {
         suppressScrollX: true,
-        minScrollbarLength: opus.minimumPSLength,
-        // minScrollbarLength: $(window).height()/5,
-        // maxScrollbarLength: $(window).height()/5,
+        minScrollbarLength: opus.minimumPSLength
     }),
     modalScrollbar: new PerfectScrollbar("#galleryViewContents .metadata", {
         minScrollbarLength: opus.minimumPSLength

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -59,25 +59,26 @@ var o_browse = {
 
         $(".gallery-contents, .dataTable").on('scroll', _.debounce(o_browse.checkScroll, 500));
 
-        // Comment this out while working on scroll down
-        // Because we don't want the event handler for "wheel" to affect scroll down
-        // $(".gallery-contents, .dataTable").on('wheel ps-scroll-up', function(event) {
-        //     let startobs = (opus.prefs.view === "cart" ? "cart_startobs" : "startobs");
-        //     let tab = `#${opus.prefs.view}`;
-        //     let contentsView = o_browse.getScrollContainerClass();
-        //     if (opus.prefs[startobs] > 0) {
-        //         // we need something like this to see if the scroll is in the 'up' direction
-        //         //if (event.originalEvent.deltaY !== undefined && event.originalEvent.deltaY < 0)
-        //         let prev = $(`${tab} [data-obs]`).first().data("obs") - o_browse.getLimit();
-        //         if ($(`${tab} ${contentsView}`).scrollTop() === 0 || $(`${tab} .dataTable`).scrollTop() === 0) {
-        //             opus.prefs[startobs] = (prev > 0 ? prev : 1);
-        //             $(`${tab} ${contentsView}`).infiniteScroll({
-        //                 "loadPrevPage": true
-        //             });
-        //             $(`${tab} ${contentsView}`).infiniteScroll("loadNextPage");
-        //         }
-        //     }
-        // });
+        $(".gallery-contents, .dataTable").on('wheel ps-scroll-up', function(event) {
+            let startobs = (opus.prefs.view === "cart" ? "cart_startobs" : "startobs");
+            let tab = `#${opus.prefs.view}`;
+            let contentsView = o_browse.getScrollContainerClass();
+            if (opus.prefs[startobs] > 0) {
+                // we need something like this to see if the scroll is in the 'up' direction
+                //if (event.originalEvent.deltaY !== undefined && event.originalEvent.deltaY < 0)
+                let prev = $(`${tab} [data-obs]`).first().data("obs") - o_browse.getLimit();
+
+                // Comment this out while working on scroll down
+                // Because now we have two infiniteScroll instances (sharing the same .op-scroll-container class), and we haven't add the feature of syncing up scrollbar positions in both gallery and table yet. $(`${tab} ${contentsView}`).scrollTop() === 0 will always be true when switching between gallery and table view, and set "loadPrevPage" to true. This will append duplicated data to the end...
+                if ($(`${tab} ${contentsView}`).scrollTop() === 0) {
+                    // opus.prefs[startobs] = (prev > 0 ? prev : 1);
+                    // $(`${tab} ${contentsView}`).infiniteScroll({
+                    //     "loadPrevPage": true
+                    // });
+                    // $(`${tab} ${contentsView}`).infiniteScroll("loadNextPage");
+                }
+            }
+        });
 
         $("#browse").on("click", ".metadataModal", function() {
             o_browse.hideMenu();
@@ -641,21 +642,6 @@ var o_browse = {
     },
 
     checkScroll: function() {
-        // infinite scroll is attached to the gallery, so we have to force a loadData when we are in table mode
-
-        // Comment out for now. We can remove this because .dataTable now has its own infiniteScroll instance and loadNextPage will be triggered by it's own scrollThreshold event handler
-        // if (opus.prefs.browse == "dataTable") {
-        //     let bottom = $("tbody").offset().top + $("tbody").height();
-        //     if (bottom <= $(document).height()) {
-        //         // remove spinner when scrollThreshold is triggered and last data fetching has no data
-        //         // Need to revisit this one
-        //         if (o_browse.dataNotAvailable) {
-        //             $(".infinite-scroll-request").hide();
-        //         }
-        //         $(`#${opus.prefs.view} ${contentsView}`).infiniteScroll("loadNextPage");
-        //     }
-        // }
-
         o_browse.updateSliderHandle();
         return false;
     },
@@ -1242,7 +1228,7 @@ var o_browse = {
                 loadPrevPage: false,
                 // TODO: store the most top left obsNum in gallery or the most top obsNum in table
                 obsNum: 1,
-                debug: true,
+                debug: false,
             });
 
             $(selector).on("request.infiniteScroll", function(event, path) {
@@ -1251,7 +1237,7 @@ var o_browse = {
                 $(".infinite-scroll-request").hide();
             });
             $(selector).on("scrollThreshold.infiniteScroll", function(event) {
-                console.log("=== scrollThreshold causing the load next page ===")
+                // console.log("=== scrollThreshold causing the load next page ===");
                 // remove spinner when scrollThreshold is triggered and last data fetching has no data
                 // Need to revisit this one
                 if (o_browse.dataNotAvailable) {

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -906,12 +906,7 @@ var o_browse = {
             $(".op-browse-view", "#browse").attr("title", "View sortable metadata table");
             $(".op-browse-view", "#browse").data("view", "dataTable");
 
-            // $(".justify-content-center").show();
-
             o_browse.galleryScrollbar.settings.suppressScrollY = false;
-
-            $(".gallery-contents > .ps__rail-y").removeClass("hide_ps__rail-y");
-            $(".dataTable > .ps__rail-y").addClass("hide_ps__rail-y");
         } else {
             $(".op-gallery-view", "#browse").hide();
             $(".dataTable", "#browse").fadeIn();
@@ -920,13 +915,7 @@ var o_browse = {
             $(".op-browse-view", "#browse").attr("title", "View sortable thumbnail gallery");
             $(".op-browse-view", "#browse").data("view", "gallery");
 
-            // remove that extra space on top when loading table page
-            // $(".justify-content-center").hide();
-
             o_browse.galleryScrollbar.settings.suppressScrollY = true;
-
-            $(".gallery-contents > .ps__rail-y").addClass("hide_ps__rail-y");
-            $(".dataTable > .ps__rail-y").removeClass("hide_ps__rail-y");
         }
     },
 

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1192,14 +1192,20 @@ var o_browse = {
         return (opus.prefs.browse === "gallery" ? ".op-gallery-view" : ".dataTable");
     },
 
+    getStartObsLabel: function() {
+        return (opus.prefs.view === "cart" ? "cart_startobs" : "startobs");
+    },
+
     // Instantiate infiniteScroll
     initInfiniteScroll: function(selector) {
-        let view = o_browse.getViewInfo();
+        let tab = `#${opus.prefs.view}`;
+        let startObsLabel = o_browse.getStartObsLabel();
+
         if (!$(selector).data("infiniteScroll")) {
             $(selector).infiniteScroll({
                 path: function() {
-                    // console.log(`=== PATH ON ${selector}`);
-                    let startObs = opus.prefs[`${view.prefix}startobs`];
+                    console.log(`=== PATH ON ${selector} ===`);
+                    let startObs = opus.prefs[startObsLabel];
 
                     console.log(`${selector} in path - startObs: ${startObs}`);
                     let infiniteScrollData = $(selector).data("infiniteScroll");
@@ -1210,7 +1216,7 @@ var o_browse = {
                     } else {
                         // Direction: scroll down
                         // start from the last observation drawn; if none yet drawn, start from opus.prefs.startobs
-                        let lastObs = $(`${view.namespace} .thumbnail-container`).last().data("obs");
+                        let lastObs = $(`${tab} .thumbnail-container`).last().data("obs");
                         startObs = (lastObs !== undefined ? lastObs + 1 : startObs);
 
                         console.log(`${selector} - startObs: ${startObs}, lastObs: ${lastObs}, getLimit: ${o_browse.getLimit()}`);
@@ -1222,7 +1228,7 @@ var o_browse = {
                     return path;
                 },
                 responseType: "text",
-                status: `${view.namespace} .page-load-status`,
+                status: `${tab} .page-load-status`,
                 elementScroll: true,
                 history: false,
                 scrollThreshold: 500,
@@ -1252,18 +1258,19 @@ var o_browse = {
     },
 
     loadData: function(startObs) {
-        let view = o_browse.getViewInfo();
+        let tab = `#${opus.prefs.view}`;
+        let startObsLabel = o_browse.getStartObsLabel();
         let contentsView = o_browse.getScrollContainerClass();
-        let selector = `${view.namespace} ${contentsView}`;
+        let selector = `${tab} ${contentsView}`;
 
-        startObs = (startObs === undefined ? opus.prefs[`${view.prefix}startobs`] : startObs);
+        startObs = (startObs === undefined ? opus.prefs[startObsLabel] : startObs);
 
         // TODO - need to resolve what reRenderData is vs. galleryBegun - and comment, etc...
         if (!o_browse.reRenderData) {
             // if the request is a block far away from current page cache, flush the cache and start over
-            let elem = $(`${view.namespace} [data-obs="${startObs}"]`);
-            let lastObs = $(`${view.namespace} [data-obs]`).last().data("obs");
-            let firstObs = $(`${view.namespace} [data-obs]`).first().data("obs");
+            let elem = $(`${tab} [data-obs="${startObs}"]`);
+            let lastObs = $(`${tab} [data-obs]`).last().data("obs");
+            let firstObs = $(`${tab} [data-obs]`).first().data("obs");
 
             // if the startObs is not already rendered and is obviously not contiguous, clear the cache and start over
             if (lastObs === undefined || firstObs === undefined || elem.length === 0 ||
@@ -1300,12 +1307,12 @@ var o_browse = {
                 $(`${selector} .dataTable`).scrollTop(0);
 
                 // Instantiate infiniteScroll on gallery and table view
-                o_browse.initInfiniteScroll(`${view.namespace} .op-gallery-view`);
-                o_browse.initInfiniteScroll(`${view.namespace} .dataTable`);
+                o_browse.initInfiniteScroll(`${tab} .op-gallery-view`);
+                o_browse.initInfiniteScroll(`${tab} .dataTable`);
             }
 
             // Because we redraw from the beginning or user inputted page, we need to remove previous drawn thumb-pages
-            $(`${view.namespace} .thumbnail-container`).remove();
+            $(`${tab} .thumbnail-container`).remove();
             o_browse.renderGalleryAndTable(data, this.url);
             if (o_browse.currentOpusId != "") {
                 o_browse.metadataboxHtml(o_browse.currentOpusId);

--- a/opus/application/static_media/js/hash.js
+++ b/opus/application/static_media/js/hash.js
@@ -155,8 +155,12 @@ var o_hash = {
                         case "order":
                             opus.prefs[slug] = value.split(',');
                             break;
-                        case "startobs" || "cart_startobs":
+                        case "startobs":
                             // Make sure startobs is stored as integer in opus.prefs
+                            opus.prefs[slug] = parseInt(value);
+                            break;
+                        case "cart_startobs":
+                            // Make sure cart_startobs is stored as integer in opus.prefs
                             opus.prefs[slug] = parseInt(value);
                             break;
                         default:

--- a/opus/application/static_media/js/hash.js
+++ b/opus/application/static_media/js/hash.js
@@ -155,6 +155,10 @@ var o_hash = {
                         case "order":
                             opus.prefs[slug] = value.split(',');
                             break;
+                        case "startobs" || "cart_startobs":
+                            // Make sure startobs is stored as integer in opus.prefs
+                            opus.prefs[slug] = parseInt(value);
+                            break;
                         default:
                             opus.prefs[slug] = value;
                     }

--- a/opus/application/static_media/js/hash.js
+++ b/opus/application/static_media/js/hash.js
@@ -156,9 +156,6 @@ var o_hash = {
                             opus.prefs[slug] = value.split(',');
                             break;
                         case "startobs":
-                            // Make sure startobs is stored as integer in opus.prefs
-                            opus.prefs[slug] = parseInt(value);
-                            break;
                         case "cart_startobs":
                             // Make sure cart_startobs is stored as integer in opus.prefs
                             opus.prefs[slug] = parseInt(value);

--- a/opus/application/static_media/js/mutationObserver.js
+++ b/opus/application/static_media/js/mutationObserver.js
@@ -165,8 +165,6 @@ var o_mutationObserver = {
             let lastMutationIdx = mutationsList.length - 1;
             mutationsList.forEach((mutation, idx) => {
                 if (idx === lastMutationIdx) {
-                    console.log("gallery view")
-                    console.log(mutation)
                     adjustBrowseHeight();
                 }
             });
@@ -177,8 +175,6 @@ var o_mutationObserver = {
             let lastMutationIdx = mutationsList.length - 1;
             mutationsList.forEach((mutation, idx) => {
                 if (idx === lastMutationIdx) {
-                    console.log("table view")
-                    console.log(mutation)
                     adjustTableSize();
                 }
             });
@@ -189,8 +185,6 @@ var o_mutationObserver = {
             let lastMutationIdx = mutationsList.length - 1;
             mutationsList.forEach((mutation, idx) => {
                 if (idx === lastMutationIdx) {
-                    console.log("switch gallery and table view")
-                    console.log(mutation)
                     adjustBrowseHeight();
                     adjustTableSize();
                 }

--- a/opus/application/static_media/js/mutationObserver.js
+++ b/opus/application/static_media/js/mutationObserver.js
@@ -203,7 +203,7 @@ var o_mutationObserver = {
         let browseDialogModal = $("#galleryView.modal")[0];
         let galleryView = $(".gallery")[0];
         let tableView = $("#dataTable")[0];
-        let switchGalleryAndTable = $(".op-browse-view")[0]
+        let switchGalleryAndTable = $(".op-browse-view")[0];
 
         // Note:
         // The reason of observing sidebar and widdget content element (ps sibling) in search page instead of observing the whole page (html structure) is because:

--- a/opus/application/static_media/js/mutationObserver.js
+++ b/opus/application/static_media/js/mutationObserver.js
@@ -165,6 +165,8 @@ var o_mutationObserver = {
             let lastMutationIdx = mutationsList.length - 1;
             mutationsList.forEach((mutation, idx) => {
                 if (idx === lastMutationIdx) {
+                    console.log("gallery view")
+                    console.log(mutation)
                     adjustBrowseHeight();
                 }
             });
@@ -175,6 +177,21 @@ var o_mutationObserver = {
             let lastMutationIdx = mutationsList.length - 1;
             mutationsList.forEach((mutation, idx) => {
                 if (idx === lastMutationIdx) {
+                    console.log("table view")
+                    console.log(mutation)
+                    adjustTableSize();
+                }
+            });
+        });
+
+        // update ps when switching between gallery and table view
+        let switchGalleryAndTableObserver = new MutationObserver(function(mutationsList) {
+            let lastMutationIdx = mutationsList.length - 1;
+            mutationsList.forEach((mutation, idx) => {
+                if (idx === lastMutationIdx) {
+                    console.log("switch gallery and table view")
+                    console.log(mutation)
+                    adjustBrowseHeight();
                     adjustTableSize();
                 }
             });
@@ -190,8 +207,9 @@ var o_mutationObserver = {
         let metadataSelector = $("#metadataSelector")[0];
         let metadataSelectorContents = $("#metadataSelectorContents")[0];
         let browseDialogModal = $("#galleryView.modal")[0];
-        let galleryView = $(".op-gallery-view")[0];
+        let galleryView = $(".gallery")[0];
         let tableView = $("#dataTable")[0];
+        let switchGalleryAndTable = $(".op-browse-view")[0]
 
         // Note:
         // The reason of observing sidebar and widdget content element (ps sibling) in search page instead of observing the whole page (html structure) is because:
@@ -223,5 +241,7 @@ var o_mutationObserver = {
         galleryViewObserver.observe(galleryView, generalObserverConfig);
         // update ps in browse table view
         tableViewObserver.observe(tableView, generalObserverConfig);
+        // update ps when switching between gallery and table view
+        switchGalleryAndTableObserver.observe(switchGalleryAndTable, attrObserverConfig);
     },
 };

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -43,8 +43,8 @@ var opus = {
         "view": "search", // search, browse, cart, detail
         "browse": "gallery", // either 'gallery' or 'data'
         "cart_browse": "gallery",  // which view is showing on the cart page, gallery or data
-        "startobs": 1, // for this branch it will not get updated
-        "cart_startobs": 1, // for this branch it will not get updated
+        "startobs": 1,
+        "cart_startobs": 1,
         "detail": "", // opus_id of detail page content
      }, // pref changes do not trigger load()
 

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -279,8 +279,8 @@ var opus = {
 
             case 'browse':
                 if (opus.prefs.browse == 'dataTable') {
-                    $('.gallery','#browse').hide();
-                    $('.data','#browse').show();
+                    $('.op-gallery-view','#browse').hide();
+                    $('.dataTable','#browse').show();
                 }
                 $('#browse').fadeIn();
                 o_browse.getBrowseTab();

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -280,7 +280,7 @@ var opus = {
             case 'browse':
                 if (opus.prefs.browse == 'dataTable') {
                     $('.op-gallery-view','#browse').hide();
-                    $('.dataTable','#browse').show();
+                    $('.op-dataTable-view','#browse').show();
                 }
                 $('#browse').fadeIn();
                 o_browse.getBrowseTab();


### PR DESCRIPTION
# Update
- This is branched out from new_ui_startobs_browse_ps
- InfiniteScroll scroll down is implemented.
- Because we instantiate two infiniteScroll instances, in checkScroll, we only call updateSliderHandle. We don't need the extra logic to trigger loadNextPage for table, loadNextPage will be triggered in scrollThreshold event handler (this is setup when instantiating infiniteScroll instance on .dataTable).
 
# Todo:
- Display spinner in while infiniteScroll load event is still happening