### PR TITLE
Fake API calls for log_analyzer

### DIFF
--- a/log_analyzer/opus/query_handler.py
+++ b/log_analyzer/opus/query_handler.py
@@ -48,6 +48,7 @@ class QueryHandler:
         self._previous_sort_order = self.DEFAULT_SORT_ORDER
         self._previous_pages = ['', '']
         self._previous_startobss = ['', '']
+        self._previous_browses = ['', '']
         self._previous_state = State.RESET
 
     def handle_query(self, query: Dict[str, str], query_type: str) -> Tuple[List[str], Optional[str]]:
@@ -106,6 +107,7 @@ class QueryHandler:
             page = query.get('page', '')
             startobs = query.get('cart_startobs', ''), query.get('startobs', '')
             browse = query.get('cart_browse', ''), query.get('browse', '')
+            previous_browse = self._previous_browses[is_browsing]
 
             if startobs[is_browsing]:
                 page_type, info, previous_info = 'Starting Observation', startobs[is_browsing], self._previous_startobss
@@ -114,15 +116,16 @@ class QueryHandler:
             else:
                 page_type, info, previous_info = 'Page', '???', ['???', '???']
             browse_or_cart = 'Browse' if is_browsing else 'Cart'
-            if current_state != previous_state:
+            if current_state != previous_state or browse != previous_browse:
                 viewed = 'Table' if browse[is_browsing] == 'data' else 'Gallery'
-                result.append(f'View {viewed}: {browse_or_cart} {page_type} {info}')
+                result.append(f'View {browse_or_cart} {viewed}: {page_type} {info}')
             elif info:
                 what = f'{browse_or_cart} Data {page_type}'
                 limit = query.get('limit', '???')
                 result.append(f'Fetch {what.title()} {info} Limit {limit}')
 
             previous_info[is_browsing] = info
+            self._previous_browses[is_browsing] = browse[is_browsing]
 
         self._previous_state = current_state
 
@@ -372,4 +375,3 @@ class QueryHandler:
 
     def safe_format(self, format_string: str, *args: Any) -> str:
         return cast(str, self._session_info.safe_format(format_string, *args))
-

--- a/log_analyzer/opus/query_handler.py
+++ b/log_analyzer/opus/query_handler.py
@@ -116,7 +116,7 @@ class QueryHandler:
             else:
                 page_type, info, previous_info = 'Page', '???', ['???', '???']
             browse_or_cart = 'Browse' if is_browsing else 'Cart'
-            if current_state != previous_state or browse != previous_browse:
+            if current_state != previous_state or browse[is_browsing] != previous_browse:
                 viewed = 'Table' if browse[is_browsing] == 'data' else 'Gallery'
                 result.append(f'View {browse_or_cart} {viewed}: {page_type} {info}')
             elif info:

--- a/log_analyzer/opus/query_handler.py
+++ b/log_analyzer/opus/query_handler.py
@@ -116,11 +116,11 @@ class QueryHandler:
             else:
                 page_type, info, previous_info = 'Page', '???', ['???', '???']
             browse_or_cart = 'Browse' if is_browsing else 'Cart'
+            viewed = 'Table' if browse[is_browsing] == 'data' else 'Gallery'
             if current_state != previous_state or browse[is_browsing] != previous_browse:
-                viewed = 'Table' if browse[is_browsing] == 'data' else 'Gallery'
                 result.append(f'View {browse_or_cart} {viewed}: {page_type} {info}')
             elif info:
-                what = f'{browse_or_cart} Data {page_type}'
+                what = f'{browse_or_cart} {viewed} {page_type}'
                 limit = query.get('limit', '???')
                 result.append(f'Fetch {what.title()} {info} Limit {limit}')
 

--- a/log_analyzer/opus/session_info.py
+++ b/log_analyzer/opus/session_info.py
@@ -188,7 +188,7 @@ class SessionInfo(AbstractSessionInfo):
         return self._query_handler.handle_query(query, match.group(1))
 
     @pattern_registry.register(r'/__api/image/med/(.*)\.json')
-    @pattern_registry.register(r'/__api/viewmetadatamodal/(.*)\.json')
+    @pattern_registry.register(r'/__viewmetadatamodal/(.*)\.json')
     def __view_metadata(self, _: Dict[str, str], match: Match[str]) -> SESSION_INFO:
         metadata = match.group(1)
         return [f'View Metadata: {metadata}'], self.__create_opus_url(metadata)
@@ -322,7 +322,7 @@ class SessionInfo(AbstractSessionInfo):
     #
 
     @pattern_registry.register(r'/__forms/column_chooser\.html')
-    @pattern_registry.register(r'/__api/selectmetadatamodal\.json')
+    @pattern_registry.register(r'/__selectmetadatamodal\.json')
     def __column_chooser(self, _query: Dict[str, str], _match: Match[str]) -> SESSION_INFO:
         return ['Metadata Selector'], None
 

--- a/log_analyzer/opus/session_info.py
+++ b/log_analyzer/opus/session_info.py
@@ -179,8 +179,8 @@ class SessionInfo(AbstractSessionInfo):
     # API
     #
 
-    @pattern_registry.register(r'/__api/(data)\.json')  # is this correct?
-    @pattern_registry.register(r'/__api/(data)\.html')  # is this correct?
+    @pattern_registry.register(r'/__api/(data)\.json')
+    @pattern_registry.register(r'/__api/(data)\.html')
     @pattern_registry.register(r'/__api/(images)\.html')
     @pattern_registry.register(r'/__api/(dataimages)\.json')
     @pattern_registry.register(r'/__api/meta/(result_count)\.json')
@@ -229,14 +229,15 @@ class SessionInfo(AbstractSessionInfo):
     def __collections_view_cart(self, _query: Dict[str, str], _match: Match[str]) -> SESSION_INFO:
         return ['View Cart'], None
 
-    @pattern_registry.register(r'/__collections/data.csv')
-    @pattern_registry.register(r'/__cart/data.csv')
+    @pattern_registry.register(r'/__collections/data\.csv')
+    @pattern_registry.register(r'/__cart/data\.csv')
     def __download_cart_metadata_csv(self, _query: Dict[str, str], _match: Match[str]) -> SESSION_INFO:
         self.performed_download()
         return ["Download CSV of Selected Metadata for Cart"], None
 
-    @pattern_registry.register(r'/__collections/download.json')
-    @pattern_registry.register(r'/__cart/download.json')
+    @pattern_registry.register(r'/__collections/download\.(json|zip)')
+    @pattern_registry.register(r'/__collections/download/default\.zip')
+    @pattern_registry.register(r'/__cart/download\.json')
     def __create_archive(self, query: Dict[str, str], _match: Match[str]) -> SESSION_INFO:
         self.performed_download()
         has_url = query.get('urlonly') not in [None, '0']
@@ -248,6 +249,7 @@ class SessionInfo(AbstractSessionInfo):
 
     # Note that the __collections/ and the __cart/ are different.
     @pattern_registry.register(r'/__collections/(view)\.json')
+    @pattern_registry.register(r'/__collections/default/(view)\.json')
     @pattern_registry.register(r'/__cart/(status)\.json')
     def __download_product_types(self, query: Dict[str, str], match: Match[str]) -> SESSION_INFO:
         if match.group(1) == 'status' and query.get('download') != '1':
@@ -280,11 +282,13 @@ class SessionInfo(AbstractSessionInfo):
         return result, None
 
     @pattern_registry.register(r'/__collections/reset\.(html|json)')
+    @pattern_registry.register(r'/__collections/default/reset\.(html|json)')
     @pattern_registry.register(r'/__cart/reset\.(html|json)')
     def __reset_cart(self, _query: Dict[str, str], _match: Match[str]) -> SESSION_INFO:
         return ['Empty Cart'], None
 
     @pattern_registry.register(r'/__collections/(add|remove)\.json')
+    @pattern_registry.register(r'/__collections/default/(add|remove)\.json')
     @pattern_registry.register(r'/__cart/(add|remove)\.json')
     def __add_remove_cart(self, query: Dict[str, str], match: Match[str]) -> SESSION_INFO:
         opus_id = query.get('opusid') or query.get('opus_id')  # opusid is new name, opus_id is old
@@ -294,15 +298,17 @@ class SessionInfo(AbstractSessionInfo):
         else:
             return [f'Cart {selection.title() + ":":<7} {opus_id or "???"}'], None
 
-    @pattern_registry.register(r'/__collections/(add|remove)range.json')
-    @pattern_registry.register(r'/__cart/(add|remove)range.json')
+    @pattern_registry.register(r'/__collections/(add|remove)range\.json')
+    @pattern_registry.register(r'/__collections/default/(add|remove)range\.json')
+    @pattern_registry.register(r'/__cart/(add|remove)range\.json')
     def __add_remove_range_to_cart(self, query: Dict[str, str], match: Match[str]) -> SESSION_INFO:
         selection = match.group(1).title()
         query_range = query.get('range', '???').replace(',', ', ')
         return [f'Cart {selection} Range: {query_range}'], None
 
-    @pattern_registry.register(r'/__collections/addall.json')
-    @pattern_registry.register(r'/__cart/addall.json')
+    @pattern_registry.register(r'/__collections/addall\.json')
+    @pattern_registry.register(r'/__collections/default/addall\.json')
+    @pattern_registry.register(r'/__cart/addall\.json')
     def __add_all_to_cart(self, query: Dict[str, str], _match: Match[str]) -> SESSION_INFO:
         query_range = query.get('range', None)
         if query_range:
@@ -316,6 +322,7 @@ class SessionInfo(AbstractSessionInfo):
     #
 
     @pattern_registry.register(r'/__forms/column_chooser\.html')
+    @pattern_registry.register(r'/__api/selectmetadatamodal\.json')
     def __column_chooser(self, _query: Dict[str, str], _match: Match[str]) -> SESSION_INFO:
         return ['Metadata Selector'], None
 

--- a/log_analyzer/opus/session_info.py
+++ b/log_analyzer/opus/session_info.py
@@ -188,6 +188,7 @@ class SessionInfo(AbstractSessionInfo):
         return self._query_handler.handle_query(query, match.group(1))
 
     @pattern_registry.register(r'/__api/image/med/(.*)\.json')
+    @pattern_registry.register(r'/__api/viewmetadatamodal/(.*)\.json')
     def __view_metadata(self, _: Dict[str, str], match: Match[str]) -> SESSION_INFO:
         metadata = match.group(1)
         return [f'View Metadata: {metadata}'], self.__create_opus_url(metadata)

--- a/opus/application/apps/metadata/views.py
+++ b/opus/application/apps/metadata/views.py
@@ -29,6 +29,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Max, Min, Count
 from django.http import Http404, HttpResponse, HttpResponseServerError
 from django.shortcuts import render_to_response
+from django.views.decorators.cache import never_cache
 
 from paraminfo.models import ParamInfo
 from search.models import *
@@ -49,6 +50,7 @@ log = logging.getLogger(__name__)
 #
 ################################################################################
 
+@never_cache
 def api_get_result_count(request, fmt, internal=False):
     """Return the result count for a given search.
 
@@ -120,6 +122,7 @@ def api_get_result_count_internal(request):
     return api_get_result_count(request, 'json', internal=True)
 
 
+@never_cache
 def api_get_mult_counts(request, slug, fmt, internal=False):
     """Return the mults for a given slug along with result counts.
 
@@ -304,6 +307,7 @@ def api_get_mult_counts_internal(request, slug):
     return api_get_mult_counts(request, slug, 'json', internal=True)
 
 
+@never_cache
 def api_get_range_endpoints(request, slug, fmt, internal=False):
     """Compute and return range widget endpoints (min, max, nulls)
 
@@ -499,6 +503,7 @@ def api_get_range_endpoints_internal(request, slug):
     return api_get_range_endpoints(request, slug, 'json', internal=True)
 
 
+@never_cache
 def api_get_fields(request, fmt='json', slug=None):
     """Return information about fields in the database (slugs).
 

--- a/opus/application/apps/results/urls.py
+++ b/opus/application/apps/results/urls.py
@@ -14,9 +14,11 @@ from results.views import (
     api_get_categories_for_opus_id,
     api_get_categories_for_search,
 )
+from ui.views import api_dummy
 
 urlpatterns = [
     url(r'^__api/dataimages.json$', api_get_data_and_images),
+    url(r'^__fake/__api/dataimages.json$', api_dummy),
     url(r'^api/data.(?P<fmt>json|html|csv)$', api_get_data),
     url(r'^__api/data.(?P<fmt>csv)$', api_get_data),
     url(r'^api/metadata/(?P<opus_id>[-\w]+).(?P<fmt>json|html|csv)$', api_get_metadata),

--- a/opus/application/apps/results/views.py
+++ b/opus/application/apps/results/views.py
@@ -58,6 +58,7 @@ log = logging.getLogger(__name__)
 #
 ################################################################################
 
+@never_cache
 def api_get_data_and_images(request):
     """Return a page of data and images for a given search.
 
@@ -232,6 +233,7 @@ def api_get_data_and_images(request):
     return ret
 
 
+@never_cache
 def api_get_data(request, fmt):
     """Return a page of data for a given search.
 
@@ -345,6 +347,7 @@ def api_get_data(request, fmt):
     return ret
 
 
+@never_cache
 def api_get_metadata(request, opus_id, fmt):
     """Return all metadata, sorted by category, for this opus_id.
 
@@ -371,6 +374,7 @@ def api_get_metadata(request, opus_id, fmt):
     return get_metadata(request, opus_id, fmt,
                         'api_get_metadata', True, False)
 
+@never_cache
 def api_get_metadata_v2(request, opus_id, fmt):
     """Return all metadata, sorted by category, for this opus_id.
 
@@ -750,6 +754,7 @@ def api_get_images(request, fmt):
     return ret
 
 
+@never_cache
 def api_get_image(request, opus_id, size='med', fmt='raw'):
     """Return info about a preview image for the given opus_id and size.
 
@@ -805,6 +810,7 @@ def api_get_image(request, opus_id, size='med', fmt='raw'):
     return ret
 
 
+@never_cache
 def api_get_files(request, opus_id=None):
     """Return all files for a given opus_id or search results.
 
@@ -879,6 +885,7 @@ def api_get_files(request, opus_id=None):
     return ret
 
 
+@never_cache
 def api_get_categories_for_opus_id(request, opus_id):
     """Return a JSON list of all cateories (tables) this opus_id appears in.
 
@@ -932,6 +939,7 @@ def api_get_categories_for_opus_id(request, opus_id):
     return ret
 
 
+@never_cache
 def api_get_categories_for_search(request):
     """Return a JSON list of all cateories (tables) triggered by this search.
 

--- a/opus/application/apps/ui/urls.py
+++ b/opus/application/apps/ui/urls.py
@@ -23,6 +23,6 @@ urlpatterns = [
     url(r'^__initdetail/(?P<opus_id>[-\w]+).html$', api_init_detail_page),
     url(r'^__normalizeurl.json$', api_normalize_url),
     url(r'^__dummy.json$', api_dummy),
-    url(r'^__fake/__api/viewmetadatamodal/(?P<opus_id>[-\w]+).json$', api_dummy),
-    url(r'^__fake/__api/selectmetadatamodal.json$', api_dummy)
+    url(r'^__fake/__viewmetadatamodal/(?P<opus_id>[-\w]+).json$', api_dummy),
+    url(r'^__fake/__selectmetadatamodal.json$', api_dummy)
 ]

--- a/opus/application/apps/ui/urls.py
+++ b/opus/application/apps/ui/urls.py
@@ -22,5 +22,6 @@ urlpatterns = [
     url(r'^__forms/metadata_selector.html$', api_get_metadata_selector),
     url(r'^__initdetail/(?P<opus_id>[-\w]+).html$', api_init_detail_page),
     url(r'^__normalizeurl.json$', api_normalize_url),
-    url(r'^__dummy.json$', api_dummy)
+    url(r'^__dummy.json$', api_dummy),
+    url(r'^__fake/__api/viewmetadatamodal/(?P<opus_id>[-\w]+).json$', api_dummy)
 ]

--- a/opus/application/apps/ui/urls.py
+++ b/opus/application/apps/ui/urls.py
@@ -24,5 +24,5 @@ urlpatterns = [
     url(r'^__normalizeurl.json$', api_normalize_url),
     url(r'^__dummy.json$', api_dummy),
     url(r'^__fake/__api/viewmetadatamodal/(?P<opus_id>[-\w]+).json$', api_dummy),
-    url(r'^__fake/__api/selectmetadatamodal.json$', api_dummy')
+    url(r'^__fake/__api/selectmetadatamodal.json$', api_dummy)
 ]

--- a/opus/application/apps/ui/urls.py
+++ b/opus/application/apps/ui/urls.py
@@ -23,5 +23,6 @@ urlpatterns = [
     url(r'^__initdetail/(?P<opus_id>[-\w]+).html$', api_init_detail_page),
     url(r'^__normalizeurl.json$', api_normalize_url),
     url(r'^__dummy.json$', api_dummy),
-    url(r'^__fake/__api/viewmetadatamodal/(?P<opus_id>[-\w]+).json$', api_dummy)
+    url(r'^__fake/__api/viewmetadatamodal/(?P<opus_id>[-\w]+).json$', api_dummy),
+    url(r'^__fake/__api/selectmetadatamodal.json$', api_dummy')
 ]

--- a/opus/application/apps/ui/views.py
+++ b/opus/application/apps/ui/views.py
@@ -87,7 +87,6 @@ def api_last_blog_update(request):
 
 
 @render_to('menu.html')
-@never_cache
 def api_get_menu(request):
     """Return the left side menu of the search page.
 

--- a/opus/application/apps/ui/views.py
+++ b/opus/application/apps/ui/views.py
@@ -87,6 +87,7 @@ def api_last_blog_update(request):
 
 
 @render_to('menu.html')
+@never_cache
 def api_get_menu(request):
     """Return the left side menu of the search page.
 
@@ -102,6 +103,7 @@ def api_get_menu(request):
     return ret
 
 
+@never_cache
 def api_get_widget(request, **kwargs):
     """Create a search widget and return its HTML.
 
@@ -299,6 +301,7 @@ def api_get_widget(request, **kwargs):
     return ret
 
 
+@never_cache
 def api_get_metadata_selector(request):
     """Create the metadata selector list.
 
@@ -330,6 +333,7 @@ def api_get_metadata_selector(request):
     return ret
 
 
+@never_cache
 def api_init_detail_page(request, **kwargs):
     """Render the top part of the Details tab.
 

--- a/opus/application/apps/ui/views.py
+++ b/opus/application/apps/ui/views.py
@@ -1109,7 +1109,7 @@ def api_normalize_url(request):
 
 
 @never_cache
-def api_dummy(request):
+def api_dummy(request, *args, **kwargs):
     """This API does nothing and is used for network performance testing.
 
     This is a PRIVATE API.

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -96,7 +96,6 @@ var o_browse = {
             let fakeUrl = "/opus/__fake/__api/selectmetadatamodal.json";
             $.getJSON(fakeUrl, function(data) {
             });
-
         });
 
         $("#metadataSelector").modal({

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -86,9 +86,6 @@ var o_browse = {
             }
         });
 
-        $("#browse").on("click", ".metadataModal", function() {
-        });
-
         $("#metadataSelector").modal({
             keyboard: false,
             backdrop: 'static',

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -108,6 +108,13 @@ var o_browse = {
             // reset scroll position
             window.scrollTo(0, 0); // restore previous scroll position
 
+            // Do the fake API call to write in the Apache log files that
+            // we changed views so log_analyzer has something to go on
+            let hashString = o_hash.getHash();
+            let fakeUrl = `/opus/__fake/__api/dataimages.json?${hashString}`
+            $.getJSON(fakeUrl, function(data) {
+            });
+
             return false;
         });
 
@@ -710,6 +717,17 @@ var o_browse = {
         o_browse.loadPrevPageIfNeeded(opusId);
         o_browse.updateGalleryView(opusId);
         $("#galleryView").modal("show");
+
+        // Do the fake API call to write in the Apache log files that
+        // we showed the modal for this OPUSID. This is what the previous
+        // version of OPUS did so the log_analyzer already handles it. Note that
+        // we won't get separate log entries as the user navigates through
+        // the obs using the arrows because we don't want to overload the
+        // network with an entry for each opus id.
+        let fakeUrl = `/opus/__fake/__api/viewmetadatamodal/${opusId}.json`
+        $.getJSON(fakeUrl, function(data) {
+        });
+
     },
 
     hideMenu: function() {

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -87,15 +87,6 @@ var o_browse = {
         });
 
         $("#browse").on("click", ".metadataModal", function() {
-            o_browse.hideMenu();
-            o_browse.renderMetadataSelector();
-
-            // Do the fake API call to write in the Apache log files that
-            // we invoked the metadata selector so log_analyzer has something to
-            // go on
-            let fakeUrl = "/opus/__fake/__selectmetadatamodal.json";
-            $.getJSON(fakeUrl, function(data) {
-            });
         });
 
         $("#metadataSelector").modal({
@@ -889,6 +880,16 @@ var o_browse = {
         $("#metadataSelector").on("show.bs.modal", function(e) {
             // save current column state so we can look for changes
             currentSelectedMetadata = opus.prefs.cols.slice();
+
+            o_browse.hideMenu();
+            o_browse.renderMetadataSelector();
+
+            // Do the fake API call to write in the Apache log files that
+            // we invoked the metadata selector so log_analyzer has something to
+            // go on
+            let fakeUrl = "/opus/__fake/__selectmetadatamodal.json";
+            $.getJSON(fakeUrl, function(data) {
+            });
         });
 
         $('#metadataSelector .allMetadata').on("click", '.submenu li a', function() {

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -93,7 +93,7 @@ var o_browse = {
             // Do the fake API call to write in the Apache log files that
             // we invoked the metadata selector so log_analyzer has something to
             // go on
-            let fakeUrl = "/opus/__fake/__api/selectmetadatamodal.json";
+            let fakeUrl = "/opus/__fake/__selectmetadatamodal.json";
             $.getJSON(fakeUrl, function(data) {
             });
         });
@@ -731,7 +731,7 @@ var o_browse = {
         // we won't get separate log entries as the user navigates through
         // the obs using the arrows because we don't want to overload the
         // network with an entry for each opus id.
-        let fakeUrl = `/opus/__fake/__api/viewmetadatamodal/${opusId}.json`;
+        let fakeUrl = `/opus/__fake/__viewmetadatamodal/${opusId}.json`;
         $.getJSON(fakeUrl, function(data) {
         });
 

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -89,6 +89,14 @@ var o_browse = {
         $("#browse").on("click", ".metadataModal", function() {
             o_browse.hideMenu();
             o_browse.renderMetadataSelector();
+
+            // Do the fake API call to write in the Apache log files that
+            // we invoked the metadata selector so log_analyzer has something to
+            // go on
+            let fakeUrl = "/opus/__fake/__api/selectmetadatamodal.json";
+            $.getJSON(fakeUrl, function(data) {
+            });
+
         });
 
         $("#metadataSelector").modal({
@@ -111,7 +119,7 @@ var o_browse = {
             // Do the fake API call to write in the Apache log files that
             // we changed views so log_analyzer has something to go on
             let hashString = o_hash.getHash();
-            let fakeUrl = `/opus/__fake/__api/dataimages.json?${hashString}`
+            let fakeUrl = `/opus/__fake/__api/dataimages.json?${hashString}`;
             $.getJSON(fakeUrl, function(data) {
             });
 
@@ -724,7 +732,7 @@ var o_browse = {
         // we won't get separate log entries as the user navigates through
         // the obs using the arrows because we don't want to overload the
         // network with an entry for each opus id.
-        let fakeUrl = `/opus/__fake/__api/viewmetadatamodal/${opusId}.json`
+        let fakeUrl = `/opus/__fake/__api/viewmetadatamodal/${opusId}.json`;
         $.getJSON(fakeUrl, function(data) {
         });
 

--- a/opus/application/static_media/js/cart.js
+++ b/opus/application/static_media/js/cart.js
@@ -45,7 +45,12 @@ var o_cart = {
         });
 
         $("#cart").on("click", ".metadataModal", function(e) {
-
+            // Do the fake API call to write in the Apache log files that
+            // we invoked the metadata selector so log_analyzer has something to
+            // go on
+            let fakeUrl = "/opus/__fake/__api/selectmetadatamodal.json";
+            $.getJSON(fakeUrl, function(data) {
+            });
         });
 
         // check an input on selected products and images updates file_info

--- a/opus/application/static_media/js/cart.js
+++ b/opus/application/static_media/js/cart.js
@@ -45,10 +45,13 @@ var o_cart = {
         });
 
         $("#cart").on("click", ".metadataModal", function(e) {
+            o_browse.hideMenu();
+            o_browse.renderMetadataSelector();
+
             // Do the fake API call to write in the Apache log files that
             // we invoked the metadata selector so log_analyzer has something to
             // go on
-            let fakeUrl = "/opus/__fake/__api/selectmetadatamodal.json";
+            let fakeUrl = "/opus/__fake/__selectmetadatamodal.json";
             $.getJSON(fakeUrl, function(data) {
             });
         });

--- a/opus/application/static_media/js/cart.js
+++ b/opus/application/static_media/js/cart.js
@@ -45,15 +45,6 @@ var o_cart = {
         });
 
         $("#cart").on("click", ".metadataModal", function(e) {
-            o_browse.hideMenu();
-            o_browse.renderMetadataSelector();
-
-            // Do the fake API call to write in the Apache log files that
-            // we invoked the metadata selector so log_analyzer has something to
-            // go on
-            let fakeUrl = "/opus/__fake/__selectmetadatamodal.json";
-            $.getJSON(fakeUrl, function(data) {
-            });
         });
 
         // check an input on selected products and images updates file_info

--- a/opus/application/static_media/js/cart.js
+++ b/opus/application/static_media/js/cart.js
@@ -44,9 +44,6 @@ var o_cart = {
             o_cart.downloadZip("create_zip_url_file", "Internal error creating URL zip file");
         });
 
-        $("#cart").on("click", ".metadataModal", function(e) {
-        });
-
         // check an input on selected products and images updates file_info
         $("#cart").on("click","#download_options input", function() {
             $("#op-total-download-size").hide();

--- a/opus/application/test_api/test_results_api.py
+++ b/opus/application/test_api/test_results_api.py
@@ -36,24 +36,30 @@ class ApiResultsTests(TestCase, ApiTestHelper):
     # reqno
 
     def test__api_dataimages_no_results_default(self):
-        "/__api/dataimages: no results default cols"
+        "[test_results_api.py] /__api/dataimages: no results default cols"
         url = '/opus/__api/dataimages.json?opusid=notgoodid'
         self._run_status_equal(url, 404, settings.HTTP404_MISSING_REQNO)
 
     def test__api_dataimages_no_results_default_reqno(self):
-        "/__api/dataimages: no results default cols reqno"
+        "[test_results_api.py] /__api/dataimages: no results default cols reqno"
         url = '/opus/__api/dataimages.json?opusid=notgoodid&reqno=5'
         self._run_status_equal(url, 200)
 
     def test__api_dataimages_no_results_default_reqno_bad(self):
-        "/__api/dataimages: no results default cols reqno bad"
+        "[test_results_api.py] /__api/dataimages: no results default cols reqno bad"
         url = '/opus/__api/dataimages.json?opusid=notgoodid&reqno=-1'
         self._run_status_equal(url, 404, settings.HTTP404_MISSING_REQNO)
 
     def test__api_dataimages_no_results_default_reqno_bad_2(self):
-        "/__api/dataimages: no results default cols reqno bad 2"
+        "[test_results_api.py] /__api/dataimages: no results default cols reqno bad 2"
         url = '/opus/__api/dataimages.json?opusid=notgoodid&reqno=1.0'
         self._run_status_equal(url, 404, settings.HTTP404_MISSING_REQNO)
+
+    # fake
+    def test__api_dataimages_no_results_default_reqno(self):
+        "[test_results_api.py] /__fake/__api/dataimages: no results default cols reqno"
+        url = '/opus/__fake/__api/dataimages.json?opusid=notgoodid&reqno=5'
+        self._run_status_equal(url, 200)
 
 
             #######################################

--- a/opus/application/test_api/test_return_formats.py
+++ b/opus/application/test_api/test_return_formats.py
@@ -171,6 +171,10 @@ class ApiReturnFormatTests(TestCase, ApiTestHelper):
         "[test_return_formats.py] return formats /__api/dataimages.[fmt]"
         self._test_return_formats('/__api/dataimages.[fmt]?target=Jupiter&limit=2&reqno=1', ('json',))
 
+    def test__api_retfmt_results_dataimages_fake_pvt(self):
+        "[test_return_formats.py] return formats /__fake/__api/dataimages.[fmt]"
+        self._test_return_formats('/__fake/__api/dataimages.[fmt]?target=Jupiter&limit=2&reqno=1', ('json',))
+
     def test__api_retfmt_results_data(self):
         "[test_return_formats.py] return formats /api/data.[fmt]"
         self._test_return_formats('/api/data.[fmt]', ('json', 'html', 'csv'))
@@ -254,3 +258,11 @@ class ApiReturnFormatTests(TestCase, ApiTestHelper):
     def test__api_retfmt_ui_normalizeurl_pvt(self):
         "[test_return_formats.py] return formats /__normalizeurl.[fmt]"
         self._test_return_formats('/__normalizeurl.[fmt]', ('json',))
+
+    def test__api_retfmt_ui_fake_viewmetadatamodal_pvt(self):
+        "[test_return_formats.py] return formats /__fake/__viewmetadatamodal/opusid.[fmt]"
+        self._test_return_formats('/__fake/__viewmetadatamodal/vg-iss-2-s-c4362550.[fmt]', ('json',))
+
+    def test__api_retfmt_ui_fake_selectmetadatamodal_pvt(self):
+        "[test_return_formats.py] return formats /__fake/__selectmetadatamodal.[fmt]"
+        self._test_return_formats('/__fake/__selectmetadatamodal.[fmt]', ('json',))


### PR DESCRIPTION
- Prevent caching of most API calls so we get Apache log entries
- Add fake API calls when switching gallery/table, viewing metadata on an obs, and popping up metadata selector
- Update log_analyzer to better handle old log files and to clean up browse/cart gallery/data handling
- This fixes #620 