### PR TITLE
New ui: update startobs in url (B085)

### DIFF
--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -698,6 +698,8 @@ var o_browse = {
                     "step": o_browse.gallerySliderStep,
                     "max": opus.resultCount,
                 });
+
+                // update startobs in url when scrolling 
                 o_hash.updateHash(true);
                 return false;
             }

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1246,8 +1246,6 @@ var o_browse = {
 
     // number of images that can be fit in current window size
     getLimit: function() {
-        // o_browse.limit = (o_browse.galleryBoundingRect.x !== 0 ? (o_browse.galleryBoundingRect.x * o_browse.galleryBoundingRect.y) : o_browse.limit);
-        // return o_browse.limit;
         return (o_browse.galleryBoundingRect.x * o_browse.galleryBoundingRect.y);
     },
 

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1320,6 +1320,7 @@ var o_browse = {
         if (!$(selector).data("infiniteScroll")) {
             $(selector).infiniteScroll({
                 path: function() {
+                    // startObs is the starting obs that we will pass into url, the starting obsNum we will get from this batch of returned data
                     let startObs = opus.prefs[startObsLabel];
                     let customizedLimitNum;
                     let lastObs = $(`${tab} .thumbnail-container`).last().data("obs");
@@ -1329,8 +1330,11 @@ var o_browse = {
                     if (infiniteScrollData !== undefined && infiniteScrollData.options.loadPrevPage === true) {
                         // Direction: scroll up, we prefetch 1 * o_browse.getLimit() items
                         if (startObs !== 1) {
-                            // prefetch o_browse.getLimit() items ahead of current startObs
+                            // prefetch o_browse.getLimit() items ahead of firstCachedObs, update the startObs to be passed into url
                             startObs = Math.max(firstCachedObs - o_browse.getLimit(), 1);
+
+                            // If startObs to be passed into url is 1, we will pass firstCachedObs - 1 as limit in url
+                            // else we'll pass o_browse.getLimit() as limit in url
                             customizedLimitNum = startObs === 1 ? firstCachedObs - 1 : o_browse.getLimit();
 
                             // Update the obsNum in infiniteScroll instances with firstCachedObs

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -37,8 +37,6 @@ var o_browse = {
     imageSize: 100,     // default
     maxCachedObservations: 1000,    // max number of obserations to store in cache; at some point, we can probably figure this out dynamically
 
-    // set default to 200 so loadData will fetch enough number of data for the first time in large screen
-    // limit: 200,  // results per page
     lastLoadDataRequestNo: 0,
 
     galleryBoundingRect: {'x': 0, 'y': 0},

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -698,7 +698,7 @@ var o_browse = {
                     "step": o_browse.gallerySliderStep,
                     "max": opus.resultCount,
                 });
-
+                o_hash.updateHash(true);
                 return false;
             }
         });


### PR DESCRIPTION
# Update 
- Update startobs in url when we scroll the scrollbar. 
- Update opus.prefs.startobs whenever we update obsNum in infiniteScroll instances (obsNum in infiniteScroll instance is used to set scrollbar position, so it will be the top left obs in gallery).

# Test cases:
- When scrolling in gallery view, startobs in url will get updated.
- When scrolling in table view, startobs in url will get updated based on gallery row boundary.
- When scrolling slider, startobs in url will get updated.