### PR TITLE
New ui infinite scroll issues B087, B088, B089, B090

### DIFF
--- a/opus/application/apps/ui/templates/base.html
+++ b/opus/application/apps/ui/templates/base.html
@@ -169,7 +169,7 @@
                                     </li>
                                     <li class="nav-item">
                                         <div class="b-l-1">
-                                            <a href="#" class="op-browse-view nav-link" data-toggle="modal" data-target="#op-cart-view" data-view="dataTable" title="View sortable metadata table"><i class="far fa-list-alt"></i>&nbsp;View Table</a>
+                                            <a href="#" class="op-browse-view nav-link" data-toggle="modal" data-target="#op-cart-view" data-view="data" title="View sortable metadata table"><i class="far fa-list-alt"></i>&nbsp;View Table</a>
                                         </div>
                                     </li>
                                     <li class="nav-item">

--- a/opus/application/apps/ui/templates/base.html
+++ b/opus/application/apps/ui/templates/base.html
@@ -148,7 +148,7 @@
             <div id="cart" class="tab-pane fade" role="tabpanel" aria-labelledby="cart-tab">
                 <div class="row">
                     <div class="col cart_details pr-0">
-                        <div id="op-download-options-container" class="sidebar_wrapper pr-0"></div>
+                        <div id="op-download-options-container" class="sidebar_wrapper mt-0 pr-0"></div>
                     </div>
                     <div class="col pl-0 cart-gallery-side">
                         <nav class="panel-heading navbar navbar-expand-lg navbar-dark bg-dark">

--- a/opus/application/apps/ui/templates/base.html
+++ b/opus/application/apps/ui/templates/base.html
@@ -98,7 +98,7 @@
                         <div class="browse-nav-container top_navbar collapse navbar-collapse">
                             <ul class="navbar-nav mr-auto">
                                 <li class="nav-item">
-                                    <a href="#" class="op-browse-view nav-link"><i class="far fa-list-alt"></i></a>
+                                    <a href="#" class="op-browse-view nav-link" data-view="data"><i class="far fa-list-alt"></i></a>
                                 </li>
                                 <li class="nav-item">
                                     <a href="#" class="op-metadata-modal nav-link" data-toggle="modal" data-target="#op-metadata-selector" title="Select metadata to display or include in CSV files for each observation"><i class="fas fa-columns"></i>&nbsp;Select Metadata</a>

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -791,7 +791,7 @@ nav.panel-heading {
 
 .panel-body .gallery-contents {
     position: fixed !important;
-    overflow-y: auto
+    overflow-y: auto;
 }
 
 .page-load-status {

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -670,7 +670,7 @@ var o_browse = {
     },
 
     // find the first displayed observation index & id in the upper left corner
-    updateSliderHandle: function(resize=false) {
+    updateSliderHandle: function(browserResized=false) {
         let tab = opus.getViewTab();
         let browse = o_browse.getBrowseView();
         let selector = ((opus.prefs[browse] === "gallery") ?
@@ -708,7 +708,7 @@ var o_browse = {
                 // At this point of time, galleryBoundingRect is updated with new row size
                 // from countGalleryImages in adjustBrowseHeight.
                 let numToDelete = ((galleryBoundingRect.x - (firstCachedObs - 1) % galleryBoundingRect.x) %
-                galleryBoundingRect.x);
+                                   galleryBoundingRect.x);
 
                 let galleryObsElem = $(`${tab} .gallery [data-obs]`);
                 let tableObsElem = $(`${tab} .op-data-table-view [data-obs]`);
@@ -1651,9 +1651,6 @@ var o_browse = {
         let tab = opus.getViewTab(view);
         let footerHeight = $(".app-footer").outerHeight();
         let mainNavHeight = $("#op-main-nav").outerHeight();
-        // we need to specify the tab here
-        // otherwise in cart tab the selector will select the navbar in browse
-        // and outerHeight will be 0.
         let navbarHeight = $(`${tab} .panel-heading`).outerHeight();
         let totalNonGalleryHeight = footerHeight + mainNavHeight + navbarHeight;
         return  $(window).height()-totalNonGalleryHeight;
@@ -1672,7 +1669,7 @@ var o_browse = {
         return width;
     },
 
-    adjustBrowseHeight: function(resize=false) {
+    adjustBrowseHeight: function(browserResized=false) {
         let tab = opus.getViewTab();
         let containerHeight = o_browse.calculateGalleryHeight();
         $(`${tab} .gallery-contents`).height(containerHeight);
@@ -1683,7 +1680,7 @@ var o_browse = {
         namespace.galleryBoundingRect = o_browse.countGalleryImages();
 
         // make sure slider is updated when window is resized
-        o_browse.updateSliderHandle(resize);
+        o_browse.updateSliderHandle(browserResized);
     },
 
     adjustTableSize: function() {

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1406,7 +1406,7 @@ var o_browse = {
         }
     },
 
-    deleteCachedObservation: function (galleryObsElem, tableObsElem, index) {
+    deleteCachedObservation: function(galleryObsElem, tableObsElem, index) {
         // don't delete the metadata if the observation is in the cart
         if (!galleryObsElem.eq(index).hasClass("in")) {
             let delOpusId = galleryObsElem.eq(index).data("id");

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -670,9 +670,8 @@ var o_browse = {
     },
 
     // find the first displayed observation index & id in the upper left corner
-    updateSliderHandle: function() {
+    updateSliderHandle: function(resize=false) {
         let tab = opus.getViewTab();
-        let contentsView = o_browse.getScrollContainerClass();
         let browse = o_browse.getBrowseView();
         let selector = ((opus.prefs[browse] === "gallery") ?
                         `${tab} .gallery .thumbnail-container` :
@@ -699,27 +698,41 @@ var o_browse = {
 
             // table: obsNum = calculatedFirstObs + number of row
             // gallery: obsNum = calculatedFirstObs + number of row * number of obs in a row
-            let obsNumDiff = ((opus.prefs[browse] === "dataTable") ?
-                              Math.round((topBoxBoundary - firstCachedObsTop)/$(`${tab} tbody tr`).outerHeight()) :
-                              Math.round((topBoxBoundary - firstCachedObsTop)/o_browse.imageSize) * galleryBoundingRect.x);
+            let obsNumDiff = ((opus.prefs[browse] === "gallery") ?
+                              Math.round((topBoxBoundary - firstCachedObsTop)/o_browse.imageSize) *
+                              galleryBoundingRect.x :
+                              Math.round((topBoxBoundary - firstCachedObsTop)/$(`${tab} tbody tr`).outerHeight()));
             let obsNum = obsNumDiff + calculatedFirstObs;
 
-            let numToDelete = ((galleryBoundingRect.x - (firstCachedObs - 1) % galleryBoundingRect.x) %
-                               galleryBoundingRect.x);
+            if (resize) {
+                let numToDelete = ((galleryBoundingRect.x - (firstCachedObs - 1) % galleryBoundingRect.x) %
+                galleryBoundingRect.x);
 
-            let galleryObsElem = $(`${tab} .gallery [data-obs]`);
-            let tableObsElem = $(`${tab} .op-data-table-view [data-obs]`);
-            // delete first "numToDelete" obs if row size is changed
-            if (numToDelete !== 0) {
-                for (let count = 0; count < numToDelete; count++) {
-                    o_browse.deleteCachedObservation(galleryObsElem, tableObsElem, count);
+                console.log("=== numToDelete ===");
+                console.log(numToDelete);
+                let galleryObsElem = $(`${tab} .gallery [data-obs]`);
+                let tableObsElem = $(`${tab} .op-data-table-view [data-obs]`);
+                console.log(galleryObsElem);
+                // delete first "numToDelete" obs if row size is changed
+                if (numToDelete !== 0) {
+                    for (let count = 0; count < numToDelete; count++) {
+                        o_browse.deleteCachedObservation(galleryObsElem, tableObsElem, count);
+                    }
                 }
             }
+            console.log(galleryBoundingRect);
+            console.log("=== updateSliderHandle firstObs ===");
+            console.log(firstCachedObs);
+            console.log(calculatedFirstObs);
+            console.log("=== Row height ===");
+            console.log(obsNumDiff);
+            console.log("=== startObs ===");
+            console.log(obsNum);
 
             // Update obsNum in both infiniteScroll instances.
             // Store the most top left obsNum in gallery for both infiniteScroll instances
             // (this will be used to updated slider obsNum).
-            if (contentsView === ".op-data-table-view") {
+            if (opus.prefs[browse] !== "gallery") {
                 obsNum = (Math.floor((obsNum - 1)/galleryBoundingRect.x + 0.0000001) *
                           galleryBoundingRect.x + 1);
             }
@@ -1047,7 +1060,7 @@ var o_browse = {
 
             $(".op-browse-view", tab).html("<i class='far fa-list-alt'></i>&nbsp;View Table");
             $(".op-browse-view", tab).attr("title", "View sortable metadata table");
-            $(".op-browse-view", tab).data("view", "dataTable");
+            $(".op-browse-view", tab).data("view", "data");
 
             suppressScrollY = false;
         } else {
@@ -1410,6 +1423,8 @@ var o_browse = {
         }
         galleryObsElem.eq(index).remove();
         tableObsElem.eq(index).remove();
+        console.log("=== galleryObsElm id being removed ===");
+        console.log(galleryObsElem.eq(index).data("obs"));
     },
 
     getBrowseView: function () {
@@ -1675,7 +1690,7 @@ var o_browse = {
         namespace.galleryBoundingRect = o_browse.countGalleryImages();
 
         // make sure slider is updated when window is resized
-        o_browse.updateSliderHandle();
+        o_browse.updateSliderHandle(true);
     },
 
     adjustTableSize: function() {

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -667,6 +667,28 @@ var o_browse = {
         let selector = (opus.prefs.browse === "dataTable") ? `#${opus.prefs.view} #dataTable tbody tr` : `#${opus.prefs.view} .gallery .thumbnail-container`;
         let topBoxBoundary; // assign value in the each loop below to avoid getting type error in views other than #browse and #cart
         let startObsLabel = o_browse.getStartObsLabel();
+        if ($(selector).length > 0) {
+            // this will work to get the top left obsNum for gallery view
+            let firstObs = (opus.prefs.browse === "dataTable") ? $(`${tab} tbody tr`).first().data("obs") : $(`${tab} [data-obs]`).first().data("obs");
+            console.log("=== updateSliderHandle firstObs ===");
+            console.log(firstObs);
+            let calculateFirstObs = Math.floor((firstObs - 1)/o_browse.galleryBoundingRect.x) * o_browse.galleryBoundingRect.x + 1;
+            console.log(calculateFirstObs);
+            console.log("=== FirstObs top ===");
+            let firstObsTop = (opus.prefs.browse === "dataTable") ? $(`${tab} tbody tr`).first().offset().top : $(`${tab} [data-obs]`).first().offset().top;
+            console.log(firstObsTop);
+            topBoxBoundary = topBoxBoundary || (opus.prefs.browse === "dataTable") ? $(`${tab} .gallery-contents`).offset().top + $(`${tab} #dataTable thead th`).outerHeight() : $(`${tab} .gallery-contents`).offset().top;
+            console.log("=== topBoxBoundary ===");
+            console.log(topBoxBoundary);
+            // number of row * number of obs in a row
+            let obsNumDiff = (opus.prefs.browse === "dataTable") ? Math.round((topBoxBoundary - firstObsTop)/$(`${tab} tbody tr`).outerHeight()) : Math.round((topBoxBoundary - firstObsTop)/o_browse.imageSize) * o_browse.galleryBoundingRect.x;
+            console.log("=== Row height ===");
+            console.log(obsNumDiff);
+            console.log("=== startObs ===");
+            console.log(obsNumDiff + calculateFirstObs);
+
+        }
+
 
         $(selector).each(function(index, elem) {
             // Fot gallery view, the topBoxBoundary is the top of .gallery-contents

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -58,7 +58,6 @@ var o_browse = {
     browseBehaviors: function() {
         // note: using .on vs .click allows elements to be added dynamically w/out bind/rebind of handler
 
-        // $(".op-gallery-view, .op-data-table-view").on("scroll", _.debounce(o_browse.checkScroll, 500));
         $(".op-gallery-view, .op-data-table-view").on("scroll", o_browse.checkScroll);
 
         // Mouse wheel up will also trigger ps-scroll-up.
@@ -628,7 +627,8 @@ var o_browse = {
             let tableScrollbarPosition = $(`${tab} .op-data-table-view`).scrollTop();
             let tableHeaderHeight = $(`${tab} .op-data-table thead th`).outerHeight();
 
-            let tableTargetFinalPosition = tableTargetTopPosition - tableContainerTopPosition + tableScrollbarPosition - tableHeaderHeight;
+            let tableTargetFinalPosition = (tableTargetTopPosition - tableContainerTopPosition +
+                                            tableScrollbarPosition - tableHeaderHeight);
             $(`${tab} .op-data-table-view`).scrollTop(tableTargetFinalPosition);
         }
     },
@@ -646,7 +646,9 @@ var o_browse = {
         let elem = $(`${tab} .thumbnail-container[data-obs="${value}"]`);
         let startObsLabel = o_browse.getStartObsLabel();
 
-        // Update obsNum in infiniteScroll instances, and this obsNum is the first item in current page. (will be used to set scrollbar position in renderGalleryAndTable).
+        // Update obsNum in infiniteScroll instances.
+        // This obsNum is the first item in current page
+        // (will be used to set scrollbar position in renderGalleryAndTable).
         $(`${tab} .op-gallery-view`).infiniteScroll({"obsNum": value});
         $(`${tab} .op-data-table-view`).infiniteScroll({"obsNum": value});
         opus.prefs[startObsLabel] = value;
@@ -673,17 +675,19 @@ var o_browse = {
         let contentsView = o_browse.getScrollContainerClass();
         let browse = o_browse.getBrowseView();
         let selector = (opus.prefs[browse] === "gallery") ?  `${tab} .gallery .thumbnail-container` : `${tab} .op-data-table tbody tr`;
-        let topBoxBoundary; // assign value in the each loop below to avoid getting type error in views other than #browse and #cart
+        let topBoxBoundary;
         let startObsLabel = o_browse.getStartObsLabel();
 
         if ($(selector).length > 0) {
             let namespace = opus.getViewNamespace();
             let galleryBoundingRect = namespace.galleryBoundingRect;
+
             // this will get the top left obsNum for gallery view or the top obsNum for table view
             let firstCachedObs = $(selector).first().data("obs");
             let firstCachedObsTop = $(selector).first().offset().top;
             // Fot gallery view, the topBoxBoundary is the top of .gallery-contents
-            // For table view, we will set the topBoxBoundary to be the bottom of thead (account for height of thead)
+            // For table view, we will set the topBoxBoundary to be the bottom of thead
+            // (account for height of thead)
             topBoxBoundary = (topBoxBoundary ||
                               (opus.prefs[browse]  === "gallery") ?
                               $(`${tab} .gallery-contents`).offset().top :
@@ -691,13 +695,17 @@ var o_browse = {
 
             // table: obsNum = firstCachedObs + number of row
             // gallery: obsNum = firstCachedObs + number of row * number of obs in a row
-            let obsNumDiff = (opus.prefs.browse === "dataTable") ? Math.round((topBoxBoundary - firstCachedObsTop)/$(`${tab} tbody tr`).outerHeight()) : Math.round((topBoxBoundary - firstCachedObsTop)/o_browse.imageSize) * galleryBoundingRect.x;
+            let obsNumDiff = ((opus.prefs[browse] === "dataTable") ?
+                              Math.round((topBoxBoundary - firstCachedObsTop)/$(`${tab} tbody tr`).outerHeight()) :
+                              Math.round((topBoxBoundary - firstCachedObsTop)/o_browse.imageSize) * galleryBoundingRect.x);
             let obsNum = obsNumDiff + firstCachedObs;
 
-            // update obsNum in both infiniteScroll instances
-            // store the most top left obsNum in gallery for both infiniteScroll instances, this will be used to updated slider obsNum
+            // Update obsNum in both infiniteScroll instances.
+            // Store the most top left obsNum in gallery for both infiniteScroll instances
+            // (this will be used to updated slider obsNum).
             if (contentsView === ".op-data-table-view") {
-                obsNum = Math.floor((obsNum-firstCachedObs)/galleryBoundingRect.x+0.0000001)*galleryBoundingRect.x+firstCachedObs;
+                obsNum = (Math.floor((obsNum - firstCachedObs)/galleryBoundingRect.x + 0.0000001) *
+                          galleryBoundingRect.x + firstCachedObs);
             }
 
             $(`${tab} .op-gallery-view`).infiniteScroll({"obsNum": obsNum});
@@ -723,8 +731,9 @@ var o_browse = {
     },
 
     checkScroll: function() {
-        // this will make sure ps-scroll-up is triggered to prefetch previous data when scrollbar reaches to up scroll threshold point
-        let tab = `#${opus.prefs.view}`;
+        // this will make sure ps-scroll-up is triggered to prefetch
+        // previous data when scrollbar reaches to up scroll threshold point.
+        let tab = opus.getViewTab();
         let contentsView = o_browse.getScrollContainerClass();
         if ($(`${tab} ${contentsView}`).scrollTop() < infiniteScrollUpThreshold) {
             $(`${tab} ${contentsView}`).trigger("ps-scroll-up");

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -15,7 +15,7 @@ const tableSortDownArrow = "fas fa-sort-down";
 const defaultTableSortArrow = "fas fa-sort";
 const infiniteScrollUpThreshold = 100;
 // Fixed scrollbar length for gallery & table view
-const galleryAndTabPSLength = 100;
+const galleryAndTablePSLength = 100;
 
 /* jshint varstmt: false */
 var o_browse = {
@@ -25,13 +25,13 @@ var o_browse = {
     metadataSelectorDrawn: false,
 
     tableScrollbar: new PerfectScrollbar("#browse .op-dataTable-view", {
-        minScrollbarLength: galleryAndTabPSLength,
-        maxScrollbarLength: galleryAndTabPSLength,
+        minScrollbarLength: galleryAndTablePSLength,
+        maxScrollbarLength: galleryAndTablePSLength,
     }),
     galleryScrollbar: new PerfectScrollbar("#browse .op-gallery-view", {
         suppressScrollX: true,
-        minScrollbarLength: galleryAndTabPSLength,
-        maxScrollbarLength: galleryAndTabPSLength,
+        minScrollbarLength: galleryAndTablePSLength,
+        maxScrollbarLength: galleryAndTablePSLength,
     }),
     modalScrollbar: new PerfectScrollbar("#galleryViewContents .metadata", {
         minScrollbarLength: opus.minimumPSLength

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -635,12 +635,15 @@ var o_browse = {
         let elem = $(`#${opus.prefs.view} .thumbnail-container[data-obs="${value}"]`);
         let startObsLabel = o_browse.getStartObsLabel();
 
+        opus.prefs[startObsLabel] = value;
+        $(`${tab} .op-gallery-view`).infiniteScroll({"obsNum": value});
+        $(`${tab} .op-dataTable-view`).infiniteScroll({"obsNum": value});
+
         if (elem.length > 0) {
             o_browse.setScrollbarOnSlide(value);
             // Update obsNum in infiniteScroll instances, and this obsNum is the first item in current page. (will be used to set scrollbar position in renderGalleryAndTable). This is for the case when above o_browse.setScrollbarOnSlide(value) trigger infiniteScroll load event.
-            $(`${tab} .op-gallery-view`).infiniteScroll({"obsNum": value});
-            $(`${tab} .op-dataTable-view`).infiniteScroll({"obsNum": value});
-            opus.prefs[startObsLabel] = value;
+            // $(`${tab} .op-gallery-view`).infiniteScroll({"obsNum": value});
+            // $(`${tab} .op-dataTable-view`).infiniteScroll({"obsNum": value});
         } else {
             // When scrolling on slider and loadData is called, we will fetch 3 * getLimit items (one current page, one next page, and one previous page) starting from obsNum.
             // obsNum will be the very first obs for data rendering this time
@@ -650,9 +653,8 @@ var o_browse = {
             // else we render 2 * o_browse.getLimit() items.
             let customizedLimitNum = obsNum === 1 ? value - 1 + 2 * o_browse.getLimit() : 3 * o_browse.getLimit();
             // Update obsNum in infiniteScroll instances, and this obsNum is the first item in current page (will be used to set scrollbar position in renderGalleryAndTable, so need to update them before loadData).
-            $(`${tab} .op-gallery-view`).infiniteScroll({"obsNum": value});
-            $(`${tab} .op-dataTable-view`).infiniteScroll({"obsNum": value});
-            opus.prefs[startObsLabel] = value;
+            // $(`${tab} .op-gallery-view`).infiniteScroll({"obsNum": value});
+            // $(`${tab} .op-dataTable-view`).infiniteScroll({"obsNum": value});
             o_browse.galleryBegun = false;
             o_browse.loadData(obsNum, customizedLimitNum);
         }
@@ -1104,7 +1106,6 @@ var o_browse = {
             $(`${tab} .sort-order-container`).show();
 
             opus.resultCount = data.result_count;
-            opus.prefs[startobsLabel] = data.start_obs;
 
             $.each(data.page, function(index, item) {
                 let opusId = item.opusid;

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -607,7 +607,7 @@ var o_browse = {
         }
     },
 
-    setScrollbarOnSlide: function(obsNum) {
+    setScrollbarPosition: function(obsNum) {
         let tab = opus.getViewTab();
         let galleryTarget = $(`${tab} .thumbnail-container[data-obs="${obsNum}"]`);
         let tableTarget = $(`${tab} .op-data-table tbody tr[data-obs='${obsNum}']`);
@@ -654,7 +654,7 @@ var o_browse = {
         opus.prefs[startObsLabel] = value;
 
         if (elem.length > 0) {
-            o_browse.setScrollbarOnSlide(value);
+            o_browse.setScrollbarPosition(value);
         } else {
             // When scrolling on slider and loadData is called, we will fetch 3 * getLimit items
             // (one current page, one next page, and one previous page) starting from obsNum.
@@ -1066,10 +1066,13 @@ var o_browse = {
         }
         opus.getViewNamespace().galleryScrollbar.settings.suppressScrollY = suppressScrollY;
 
+        console.log(`=== switching between table and gallery in ${tab} ===`)
         // sync up scrollbar position
         if (galleryInfiniteScroll && tableInfiniteScroll) {
             let startObs = $(`${tab} ${contentsView}`).data("infiniteScroll").options.obsNum;
+            console.log(`obsNum: ${startObs}`);
             o_browse.setScrollbarPosition(startObs);
+
         }
     },
 
@@ -1340,11 +1343,6 @@ var o_browse = {
         });
         $(".sort-contents").html(listHtml);
         o_hash.updateHash();
-    },
-
-    // set the scrollbar position in gallery / table view
-    setScrollbarPosition: function(obsNum) {
-        o_browse.setScrollbarOnSlide(obsNum);
     },
 
     // number of images that can be fit in current window size

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1507,7 +1507,7 @@ var o_browse = {
 
                 if ((firstObs === 1 && infiniteScrollData.options.loadPrevPage === true) ||
                     (lastObs === opus.resultCount && infiniteScrollData.options.loadPrevPage === false) ||
-                     (lastObs === o_cart.cartCount && infiniteScrollData.options.loadPrevPage === false)) {
+                    (lastObs === o_cart.cartCount && infiniteScrollData.options.loadPrevPage === false)) {
                     $(".infinite-scroll-request").hide();
                 }
             });

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -705,7 +705,7 @@ var o_browse = {
             let obsNum = obsNumDiff + calculatedFirstObs;
 
             let numToDelete = ((galleryBoundingRect.x - (firstCachedObs - 1) % galleryBoundingRect.x) %
-            galleryBoundingRect.x);
+                               galleryBoundingRect.x);
 
             let galleryObsElem = $(`${tab} .gallery [data-obs]`);
             let tableObsElem = $(`${tab} .op-data-table-view [data-obs]`);
@@ -740,8 +740,6 @@ var o_browse = {
                 "step": o_browse.gallerySliderStep,
                 "max": opus.resultCount,
             });
-
-            // TODO: if resize, we re-render:
 
             // update startobs in url when scrolling
             o_hash.updateHash(true);
@@ -1378,16 +1376,6 @@ var o_browse = {
         let tab = opus.getViewTab();
         let galleryObsElem = $(`${tab} .gallery [data-obs]`);
         let tableObsElem = $(`${tab} .op-data-table-view [data-obs]`);
-
-        // function deleteCachedObservation(index) {
-        //     // don't delete the metadata if the observation is in the cart
-        //     if (!galleryObsElem.eq(index).hasClass("op-in-cart")) {
-        //         let delOpusId = galleryObsElem.eq(index).data("id");
-        //         delete o_browse.galleryData[delOpusId];
-        //     }
-        //     galleryObsElem.eq(index).remove();
-        //     tableObsElem.eq(index).remove();
-        // }
 
         if (galleryObsElem.length === 0) {
             // this only happens when there are no elements rendered, so why bother...

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -15,7 +15,7 @@ const tableSortDownArrow = "fas fa-sort-down";
 const defaultTableSortArrow = "fas fa-sort";
 const infiniteScrollUpThreshold = 100;
 // Fixed scrollbar length for gallery & table view
-const galleryAndTabPSLength = 75;
+const galleryAndTabPSLength = 100;
 
 /* jshint varstmt: false */
 var o_browse = {
@@ -74,22 +74,11 @@ var o_browse = {
             let startObsLabel = o_browse.getStartObsLabel();
             let tab = `#${opus.prefs.view}`;
             let contentsView = o_browse.getScrollContainerClass();
-            // if (event.originalEvent.type === "ps-scroll-up" || (event.originalEvent.type === "wheel" && event.originalEvent.deltaY < 0)) {
-            if (event.type === "ps-scroll-up" || (event.type === "wheel" && event.originalEvent.deltaY < 0)) {
-                // console.log("=== pressing page up ===");
-                if (opus.prefs[startObsLabel] > 1) {
-                    // console.log("=== scrollbar location ===");
-                    // console.log($(`${tab} ${contentsView}`).scrollTop())
-                    let firstObs = $(`${tab} [data-obs]`).first().data("obs");
-                    console.log(`FirstObs when scrolling up: ${firstObs}`);
-                    // if ($(`${tab} ${contentsView}`).scrollTop() === 0 && firstObs === opus.prefs["startobs"]) {
-                    //     console.log("=== Reach to start end, trigger another ps scroll up ===");
-                    //     $(`${tab} ${contentsView}`).trigger("ps-scroll-up");
-                    //     return;
-                    // }
 
+            if (event.type === "ps-scroll-up" || (event.type === "wheel" && event.originalEvent.deltaY < 0)) {
+                if (opus.prefs[startObsLabel] > 1) {
+                    let firstObs = $(`${tab} [data-obs]`).first().data("obs");
                     if ($(`${tab} ${contentsView}`).scrollTop() < infiniteScrollUpThreshold && firstObs !== 1) {
-                        // TODO: update the infiniteScroll instances obsNum
                         $(`${tab} ${contentsView}`).infiniteScroll({
                             "loadPrevPage": true,
                         });
@@ -722,6 +711,7 @@ var o_browse = {
     },
 
     checkScroll: function() {
+        // this will make sure ps-scroll-up is triggered to prefetch previous data when scrollbar reaches to up scroll threshold point
         let tab = `#${opus.prefs.view}`;
         let contentsView = o_browse.getScrollContainerClass();
         if ($(`${tab} ${contentsView}`).scrollTop() < infiniteScrollUpThreshold) {
@@ -1184,9 +1174,6 @@ var o_browse = {
         // - scroll up: when we scroll up and a new page is fetched, we want to keep scrollbar position at the current startObs, instead of at the first item in newly fetched page.
         // - scroll slider: when we load 3 * getLimit items, we want to keep scrollbar in the middle page.
         // - scroll down: theoretically, infiniteScroll will take care of scrollbar position, but we still have to manually set it for the case when cached data is removed so that scrollbar position is always correct (and never reaches to the end until it reaches to the end of the data)
-        console.log("=== renderGalleryAndTable set scrollbar obsNum ===");
-        console.log(infiniteScrollData.options.obsNum);
-        console.log(opus.prefs["startobs"]);
         o_browse.setScrollbarPosition(infiniteScrollData.options.obsNum);
 
         $(".op-page-loading-status > .loader").hide();
@@ -1384,16 +1371,8 @@ var o_browse = {
                     let firstCachedObs = $(`${tab} .thumbnail-container`).first().data("obs");
 
                     let infiniteScrollData = $(selector).data("infiniteScroll");
-
-                    // TODO: either move this block to ps-scroll-up handler or
-                    // find a way to trigger scroll up in ps-scroll-up handler when it reaches to the top end
-                    console.log("=== ON PATH ===");
-                    if (infiniteScrollData) {
-                        console.log(infiniteScrollData.options.loadPrevPage);
-                    }
                     if (infiniteScrollData !== undefined && infiniteScrollData.options.loadPrevPage === true) {
                         // Direction: scroll up, we prefetch 1 * o_browse.getLimit() items
-                        console.log("ON PATH SCROLL UP");
                         if (obsNum !== 1) {
                             // prefetch o_browse.getLimit() items ahead of firstCachedObs, update the startObs to be passed into url
                             obsNum = Math.max(firstCachedObs - o_browse.getLimit(), 1);
@@ -1413,7 +1392,6 @@ var o_browse = {
                             customizedLimitNum = 0;
                         }
                     } else {
-                        console.log("ON PATH SCROLL DOWN");
                         // Direction: scroll down, we prefetch 1 * o_browse.getLimit() items (symmetric to scroll up)
                         // NOTE: we can change the number of prefetch items by changing customizedLimitNum
                         // start from the last observation drawn; if none yet drawn, start from opus.prefs.startobs
@@ -1430,9 +1408,6 @@ var o_browse = {
                         }
                     }
                     let path = o_browse.getDataURL(obsNum, customizedLimitNum);
-                    console.log(`ON PATH: ${path}`);
-                    console.log(`obsNum: ${obsNum}`);
-                    console.log(`limit: ${customizedLimitNum}`);
                     return path;
                 },
                 responseType: "text",

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -685,6 +685,8 @@ var o_browse = {
             // this will get the top left obsNum for gallery view or the top obsNum for table view
             let firstCachedObs = $(selector).first().data("obs");
             let firstCachedObsTop = $(selector).first().offset().top;
+            let calculatedFirstObs = (Math.floor((firstCachedObs - 1)/o_browse.galleryBoundingRect.x + 0.0000001) *
+                                      galleryBoundingRect.x + 1);
             // Fot gallery view, the topBoxBoundary is the top of .gallery-contents
             // For table view, we will set the topBoxBoundary to be the bottom of thead
             // (account for height of thead)
@@ -693,21 +695,29 @@ var o_browse = {
                               $(`${tab} .gallery-contents`).offset().top :
                               $(`${tab} .gallery-contents`).offset().top + $(`${tab} .op-data-table thead th`).outerHeight());
 
-            // table: obsNum = firstCachedObs + number of row
-            // gallery: obsNum = firstCachedObs + number of row * number of obs in a row
+            // table: obsNum = calculatedFirstObs + number of row
+            // gallery: obsNum = calculatedFirstObs + number of row * number of obs in a row
             let obsNumDiff = ((opus.prefs[browse] === "dataTable") ?
                               Math.round((topBoxBoundary - firstCachedObsTop)/$(`${tab} tbody tr`).outerHeight()) :
                               Math.round((topBoxBoundary - firstCachedObsTop)/o_browse.imageSize) * galleryBoundingRect.x);
-            let obsNum = obsNumDiff + firstCachedObs;
+            let obsNum = obsNumDiff + calculatedFirstObs;
+            console.log("=== updateSliderHandle firstObs ===");
+            console.log(firstCachedObs);
+            console.log(calculatedFirstObs);
+            console.log("=== Row height ===");
+            console.log(obsNumDiff);
+            console.log("=== startObs ===");
+            console.log(obsNum);
 
             // Update obsNum in both infiniteScroll instances.
             // Store the most top left obsNum in gallery for both infiniteScroll instances
             // (this will be used to updated slider obsNum).
             if (contentsView === ".op-data-table-view") {
-                obsNum = (Math.floor((obsNum - firstCachedObs)/galleryBoundingRect.x + 0.0000001) *
-                          galleryBoundingRect.x + firstCachedObs);
+                obsNum = (Math.floor((obsNum - 1)/galleryBoundingRect.x + 0.0000001) *
+                          galleryBoundingRect.x + 1);
             }
-
+            console.log("=== obsNum after convert ===");
+            console.log(obsNum);
             $(`${tab} .op-gallery-view`).infiniteScroll({"obsNum": obsNum});
             $(`${tab} .op-data-table-view`).infiniteScroll({"obsNum": obsNum});
             opus.prefs[startObsLabel] = obsNum;

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -705,14 +705,13 @@ var o_browse = {
             let obsNum = obsNumDiff + calculatedFirstObs;
 
             if (resize) {
+                // At this point of time, galleryBoundingRect is updated with new row size
+                // from countGalleryImages in adjustBrowseHeight.
                 let numToDelete = ((galleryBoundingRect.x - (firstCachedObs - 1) % galleryBoundingRect.x) %
                 galleryBoundingRect.x);
 
-                console.log("=== numToDelete ===");
-                console.log(numToDelete);
                 let galleryObsElem = $(`${tab} .gallery [data-obs]`);
                 let tableObsElem = $(`${tab} .op-data-table-view [data-obs]`);
-                console.log(galleryObsElem);
                 // delete first "numToDelete" obs if row size is changed
                 if (numToDelete !== 0) {
                     for (let count = 0; count < numToDelete; count++) {
@@ -720,14 +719,6 @@ var o_browse = {
                     }
                 }
             }
-            console.log(galleryBoundingRect);
-            console.log("=== updateSliderHandle firstObs ===");
-            console.log(firstCachedObs);
-            console.log(calculatedFirstObs);
-            console.log("=== Row height ===");
-            console.log(obsNumDiff);
-            console.log("=== startObs ===");
-            console.log(obsNum);
 
             // Update obsNum in both infiniteScroll instances.
             // Store the most top left obsNum in gallery for both infiniteScroll instances
@@ -1423,8 +1414,6 @@ var o_browse = {
         }
         galleryObsElem.eq(index).remove();
         tableObsElem.eq(index).remove();
-        console.log("=== galleryObsElm id being removed ===");
-        console.log(galleryObsElem.eq(index).data("obs"));
     },
 
     getBrowseView: function () {
@@ -1679,7 +1668,7 @@ var o_browse = {
         return width;
     },
 
-    adjustBrowseHeight: function() {
+    adjustBrowseHeight: function(resize=false) {
         let tab = opus.getViewTab();
         let containerHeight = o_browse.calculateGalleryHeight;
         $(`${tab} .gallery-contents`).height(containerHeight);
@@ -1690,7 +1679,7 @@ var o_browse = {
         namespace.galleryBoundingRect = o_browse.countGalleryImages();
 
         // make sure slider is updated when window is resized
-        o_browse.updateSliderHandle(true);
+        o_browse.updateSliderHandle(resize);
     },
 
     adjustTableSize: function() {

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -724,6 +724,11 @@ var o_browse = {
                 }
             }
 
+            let dataResultCount = tab === "#browse" ? opus.resultCount : o_cart.cartCount;
+            let firstObsInLastRow = (Math.floor((dataResultCount - 1)/galleryBoundingRect.x + 0.0000001) *
+                                galleryBoundingRect.x + 1);
+            let maxSliderVal = firstObsInLastRow - galleryBoundingRect.x * (galleryBoundingRect.y - 1);
+
             // Update obsNum in both infiniteScroll instances.
             // Store the most top left obsNum in gallery for both infiniteScroll instances
             // (this will be used to updated slider obsNum).
@@ -732,23 +737,25 @@ var o_browse = {
                           galleryBoundingRect.x + 1);
             }
 
-            $(`${tab} .op-gallery-view`).infiniteScroll({"obsNum": obsNum});
-            $(`${tab} .op-data-table-view`).infiniteScroll({"obsNum": obsNum});
-            opus.prefs[startObsLabel] = obsNum;
+            if (maxSliderVal >= obsNum) {
+                $(`${tab} .op-gallery-view`).infiniteScroll({"obsNum": obsNum});
+                $(`${tab} .op-data-table-view`).infiniteScroll({"obsNum": obsNum});
+                opus.prefs[startObsLabel] = obsNum;
 
-            $("#op-observation-number").html(obsNum);
-            $(".op-slider-pointer").css("width", `${opus.resultCount.toString().length*0.7}em`);
-            // just make the step size the number of the obserations across the page...
-            // if the observations have not yet been rendered, leave the default, it will get changed later
-            if (galleryBoundingRect.x > 0) {
-                o_browse.gallerySliderStep = galleryBoundingRect.x;
+                $("#op-observation-number").html(obsNum);
+                $(".op-slider-pointer").css("width", `${maxSliderVal.toString().length*0.7}em`);
+                // $(".op-slider-pointer").css("width", `${opus.resultCount.toString().length*0.7}em`);
+                // just make the step size the number of the obserations across the page...
+                // if the observations have not yet been rendered, leave the default, it will get changed later
+                if (galleryBoundingRect.x > 0) {
+                    o_browse.gallerySliderStep = galleryBoundingRect.x;
+                }
+                $("#op-observation-slider").slider({
+                    "value": obsNum,
+                    "step": o_browse.gallerySliderStep,
+                    "max": maxSliderVal,
+                });
             }
-            $("#op-observation-slider").slider({
-                "value": obsNum,
-                "step": o_browse.gallerySliderStep,
-                "max": opus.resultCount,
-            });
-
             // update startobs in url when scrolling
             o_hash.updateHash(true);
         }
@@ -1646,7 +1653,8 @@ var o_browse = {
         let height = o_browse.calculateGalleryHeight(view);
 
         let xCount = Math.floor(width/o_browse.imageSize);
-        let yCount = Math.ceil(height/o_browse.imageSize);
+        let yCount = Math.round(height/o_browse.imageSize);
+        // let yCount = Math.ceil(height/o_browse.imageSize);
 
         return {"x": xCount, "y": yCount};
     },

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -103,7 +103,6 @@ var o_browse = {
 
             o_hash.updateHash();
             o_browse.updateBrowseNav();
-
             // reset scroll position
             window.scrollTo(0, 0); // restore previous scroll position
 
@@ -670,11 +669,10 @@ var o_browse = {
 
         if ($(selector).length > 0) {
             // this will get the top left obsNum for gallery view or the top obsNum for table view
-            // let firstObs = (opus.prefs.browse === "dataTable") ? $(`${tab} tbody tr`).first().data("obs") : $(`${tab} [data-obs]`).first().data("obs");
-            // let firstObsTop = (opus.prefs.browse === "dataTable") ? $(`${tab} tbody tr`).first().offset().top : $(`${tab} [data-obs]`).first().offset().top;
             let firstCachedObs = $(selector).first().data("obs");
             let firstCachedObsTop = $(selector).first().offset().top;
-            let calculatedFirstObs = Math.floor((firstCachedObs - 1)/o_browse.galleryBoundingRect.x+0.0000001) * o_browse.galleryBoundingRect.x + 1;
+            let calculatedFirstObs = firstCachedObs;
+            // let calculatedFirstObs = Math.floor((firstCachedObs - 1)/o_browse.galleryBoundingRect.x+0.0000001) * o_browse.galleryBoundingRect.x + 1;
             topBoxBoundary = topBoxBoundary || (opus.prefs.browse === "dataTable") ? $(`${tab} .gallery-contents`).offset().top + $(`${tab} #dataTable thead th`).outerHeight() : $(`${tab} .gallery-contents`).offset().top;
 
             // table: obsNum = calculatedFirstObs + number of row
@@ -684,6 +682,8 @@ var o_browse = {
 
             console.log("=== updateSliderHandle firstCachedObs ===");
             console.log(firstCachedObs);
+            console.log("=== galleryBoundingRect ===");
+            console.log(o_browse.galleryBoundingRect);
             console.log("=== calculateFirstObs ===");
             console.log(calculatedFirstObs);
             // console.log("=== FirstObs top ===");
@@ -694,16 +694,20 @@ var o_browse = {
             console.log(obsNumDiff);
             console.log("=== startObs ===");
             console.log(obsNum);
+            console.log(`=== slider step: ${o_browse.gallerySliderStep} ===`);
 
             // update obsNum in both infiniteScroll instances
             // store the most top left obsNum in gallery for both infiniteScroll instances, this will be used to updated slider obsNum
             if (contentsView === ".op-dataTable-view") {
-                obsNum = Math.floor((obsNum-1)/o_browse.gallerySliderStep+0.0000001)*o_browse.gallerySliderStep+1;
+                obsNum = Math.floor((obsNum-firstCachedObs)/o_browse.galleryBoundingRect.x+0.0000001)*o_browse.galleryBoundingRect.x+firstCachedObs;
+                // obsNum = Math.floor((obsNum-1)/o_browse.gallerySliderStep+0.0000001)*o_browse.gallerySliderStep+1;
             }
 
             $(`${tab} .op-gallery-view`).infiniteScroll({"obsNum": obsNum});
             $(`${tab} .op-dataTable-view`).infiniteScroll({"obsNum": obsNum});
             opus.prefs[startObsLabel] = obsNum;
+            console.log("=== startObs after convert ===");
+            console.log(obsNum);
 
             $("#op-observation-number").html(obsNum);
             $(".op-slider-pointer").css("width", `${opus.resultCount.toString().length*0.7}em`);

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -706,37 +706,15 @@ var o_browse = {
 
             let numToDelete = ((galleryBoundingRect.x - (firstCachedObs - 1) % galleryBoundingRect.x) %
             galleryBoundingRect.x);
-            console.log("=== numToDelete ===");
-            console.log(numToDelete);
-            // let tab = opus.getViewTab();
+
             let galleryObsElem = $(`${tab} .gallery [data-obs]`);
             let tableObsElem = $(`${tab} .op-data-table-view [data-obs]`);
             // delete first "numToDelete" obs if row size is changed
             if (numToDelete !== 0) {
                 for (let count = 0; count < numToDelete; count++) {
-                    // o_browse.deleteCachedObservation(i);
-
-                    // don't delete the metadata if the observation is in the cart
-                    // if (!galleryObsElem.eq(i).hasClass("op-in-cart")) {
-                    //     let delOpusId = galleryObsElem.eq(i).data("id");
-                    //     delete o_browse.galleryData[delOpusId];
-                    // }
-                    // galleryObsElem.eq(i).remove();
-                    // tableObsElem.eq(i).remove();
                     o_browse.deleteCachedObservation(galleryObsElem, tableObsElem, count);
                 }
             }
-
-            console.log("=== updateSliderHandle firstObs ===");
-            console.log(firstCachedObs);
-            console.log(calculatedFirstObs);
-            console.log("=== Row height ===");
-            console.log(obsNumDiff);
-            console.log("=== startObs ===");
-            console.log(obsNum);
-            console.log("=== galleryBoundingRect ===");
-            console.log(galleryBoundingRect);
-
 
             // Update obsNum in both infiniteScroll instances.
             // Store the most top left obsNum in gallery for both infiniteScroll instances
@@ -745,8 +723,7 @@ var o_browse = {
                 obsNum = (Math.floor((obsNum - 1)/galleryBoundingRect.x + 0.0000001) *
                           galleryBoundingRect.x + 1);
             }
-            console.log("=== obsNum after convert in table view ===");
-            console.log(obsNum);
+
             $(`${tab} .op-gallery-view`).infiniteScroll({"obsNum": obsNum});
             $(`${tab} .op-data-table-view`).infiniteScroll({"obsNum": obsNum});
             opus.prefs[startObsLabel] = obsNum;

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -704,7 +704,7 @@ var o_browse = {
                               Math.round((topBoxBoundary - firstCachedObsTop)/$(`${tab} tbody tr`).outerHeight()));
             let obsNum = obsNumDiff + calculatedFirstObs;
 
-            if (resize) {
+            if (browserResized) {
                 // At this point of time, galleryBoundingRect is updated with new row size
                 // from countGalleryImages in adjustBrowseHeight.
                 let numToDelete = ((galleryBoundingRect.x - (firstCachedObs - 1) % galleryBoundingRect.x) %

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1506,7 +1506,8 @@ var o_browse = {
                 let lastObs = $(`${tab} .thumbnail-container`).last().data("obs");
 
                 if ((firstObs === 1 && infiniteScrollData.options.loadPrevPage === true) ||
-                    (lastObs === opus.resultCount && infiniteScrollData.options.loadPrevPage === false)) {
+                    (lastObs === opus.resultCount && infiniteScrollData.options.loadPrevPage === false) ||
+                     (lastObs === o_cart.cartCount && infiniteScrollData.options.loadPrevPage === false)) {
                     $(".infinite-scroll-request").hide();
                 }
             });

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1670,7 +1670,7 @@ var o_browse = {
 
     adjustBrowseHeight: function(resize=false) {
         let tab = opus.getViewTab();
-        let containerHeight = o_browse.calculateGalleryHeight;
+        let containerHeight = o_browse.calculateGalleryHeight();
         $(`${tab} .gallery-contents`).height(containerHeight);
         $(`${tab} .gallery-contents .op-gallery-view`).height(containerHeight);
 
@@ -1685,7 +1685,8 @@ var o_browse = {
     adjustTableSize: function() {
         let tab = opus.getViewTab();
         let containerWidth = $(`${tab} .gallery-contents`).width();
-        let containerHeight = $(`${tab} .gallery-contents`).height() - $(".app-footer").outerHeight();
+        // let containerHeight = $(`${tab} .gallery-contents`).height() - $(".app-footer").outerHeight();
+        let containerHeight = $(`${tab} .gallery-contents`).height();
         $(`${tab} .op-data-table-view`).width(containerWidth);
         $(`${tab} .op-data-table-view`).height(containerHeight);
 

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1687,12 +1687,10 @@ var o_browse = {
 
     adjustTableSize: function() {
         let tab = opus.getViewTab();
-        console.log(tab);
         let containerWidth = $(`${tab} .gallery-contents`).width();
         let containerHeight = $(`${tab} .gallery-contents`).height();
         $(`${tab} .op-data-table-view`).width(containerWidth);
         $(`${tab} .op-data-table-view`).height(containerHeight);
-        console.log(opus.getViewNamespace().tableScrollbar);
         opus.getViewNamespace().tableScrollbar.update();
     },
 

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -672,7 +672,7 @@ var o_browse = {
             let firstObs = (opus.prefs.browse === "dataTable") ? $(`${tab} tbody tr`).first().data("obs") : $(`${tab} [data-obs]`).first().data("obs");
             console.log("=== updateSliderHandle firstObs ===");
             console.log(firstObs);
-            let calculateFirstObs = Math.floor((firstObs - 1)/o_browse.galleryBoundingRect.x) * o_browse.galleryBoundingRect.x + 1;
+            let calculateFirstObs = Math.floor((firstObs - 1)/o_browse.galleryBoundingRect.x+0.0000001) * o_browse.galleryBoundingRect.x + 1;
             console.log(calculateFirstObs);
             console.log("=== FirstObs top ===");
             let firstObsTop = (opus.prefs.browse === "dataTable") ? $(`${tab} tbody tr`).first().offset().top : $(`${tab} [data-obs]`).first().offset().top;
@@ -686,7 +686,6 @@ var o_browse = {
             console.log(obsNumDiff);
             console.log("=== startObs ===");
             console.log(obsNumDiff + calculateFirstObs);
-
         }
 
 
@@ -699,14 +698,16 @@ var o_browse = {
             let topBox = $(elem).offset().top + $(elem).height()/2;
             if (topBox >= topBoxBoundary) {
                 let obsNum = $(elem).data("obs");
+                console.log(`obsNum in loop: ${obsNum}`);
 
                 // update obsNum in both infiniteScroll instances
                 // store the most top left obsNum in gallery for both infiniteScroll instances, this will be used to updated slider obsNum
-                $(`${tab} .op-gallery-view`).infiniteScroll({"obsNum": obsNum});
+                // $(`${tab} .op-gallery-view`).infiniteScroll({"obsNum": obsNum});
                 if (contentsView === ".op-dataTable-view") {
                     obsNum = Math.floor((obsNum-1)/o_browse.gallerySliderStep+0.0000001)*o_browse.gallerySliderStep+1;
                 }
-
+                console.log(`obsNum after convert in loop: ${obsNum}`);
+                $(`${tab} .op-gallery-view`).infiniteScroll({"obsNum": obsNum});
                 $(`${tab} .op-dataTable-view`).infiniteScroll({"obsNum": obsNum});
                 opus.prefs[startObsLabel] = obsNum;
                 // console.log("=== obsNum in updateSliderHandle ===");
@@ -1037,6 +1038,8 @@ var o_browse = {
         // sync up scrollbar position
         if (galleryInfiniteScroll && tableInfiniteScroll) {
             let startObs = $(`${tab} ${contentsView}`).data("infiniteScroll").options.obsNum;
+            console.log("=== startObs when switching between table and gallery");
+            console.log(startObs);
             o_browse.setScrollbarPosition(startObs);
         }
     },

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -14,7 +14,7 @@ const tableSortUpArrow = "fas fa-sort-up";
 const tableSortDownArrow = "fas fa-sort-down";
 const defaultTableSortArrow = "fas fa-sort";
 const infiniteScrollUpThreshold = 100;
-// Fix scrollbar length for gallery & table view
+// Fixed scrollbar length for gallery & table view
 const galleryAndTabPSLength = 75;
 
 /* jshint varstmt: false */
@@ -59,7 +59,8 @@ var o_browse = {
     browseBehaviors: function() {
         // note: using .on vs .click allows elements to be added dynamically w/out bind/rebind of handler
 
-        $(".op-gallery-view, .op-dataTable-view").on("scroll", _.debounce(o_browse.checkScroll, 500));
+        // $(".op-gallery-view, .op-dataTable-view").on("scroll", _.debounce(o_browse.checkScroll, 500));
+        $(".op-gallery-view, .op-dataTable-view").on("scroll", o_browse.checkScroll);
 
         // Mouse wheel up will also trigger ps-scroll-up.
         // NOTE: We put both wheel and ps-scroll-up here for a corner case like this:
@@ -73,15 +74,26 @@ var o_browse = {
             let startObsLabel = o_browse.getStartObsLabel();
             let tab = `#${opus.prefs.view}`;
             let contentsView = o_browse.getScrollContainerClass();
-
-            if (event.originalEvent.type === "ps-scroll-up" || (event.originalEvent.type === "wheel" && event.originalEvent.deltaY < 0)) {
-
+            // if (event.originalEvent.type === "ps-scroll-up" || (event.originalEvent.type === "wheel" && event.originalEvent.deltaY < 0)) {
+            if (event.type === "ps-scroll-up" || (event.type === "wheel" && event.originalEvent.deltaY < 0)) {
+                // console.log("=== pressing page up ===");
                 if (opus.prefs[startObsLabel] > 1) {
+                    // console.log("=== scrollbar location ===");
+                    // console.log($(`${tab} ${contentsView}`).scrollTop())
                     let firstObs = $(`${tab} [data-obs]`).first().data("obs");
+                    console.log(`FirstObs when scrolling up: ${firstObs}`);
+                    // if ($(`${tab} ${contentsView}`).scrollTop() === 0 && firstObs === opus.prefs["startobs"]) {
+                    //     console.log("=== Reach to start end, trigger another ps scroll up ===");
+                    //     $(`${tab} ${contentsView}`).trigger("ps-scroll-up");
+                    //     return;
+                    // }
+
                     if ($(`${tab} ${contentsView}`).scrollTop() < infiniteScrollUpThreshold && firstObs !== 1) {
+                        // TODO: update the infiniteScroll instances obsNum
                         $(`${tab} ${contentsView}`).infiniteScroll({
                             "loadPrevPage": true,
                         });
+                        console.log(`=== load previous page with current startObs ${opus.prefs["startobs"]} ===`);
                         $(`${tab} ${contentsView}`).infiniteScroll("loadNextPage");
                         o_browse.updateSliderHandle();
                     }
@@ -686,6 +698,8 @@ var o_browse = {
 
                 $(`${tab} .op-dataTable-view`).infiniteScroll({"obsNum": obsNum});
                 opus.prefs[startObsLabel] = obsNum;
+                // console.log("=== obsNum in updateSliderHandle ===");
+                // console.log(obsNum);
 
                 $("#op-observation-number").html(obsNum);
                 $(".op-slider-pointer").css("width", `${opus.resultCount.toString().length*0.7}em`);
@@ -708,6 +722,11 @@ var o_browse = {
     },
 
     checkScroll: function() {
+        let tab = `#${opus.prefs.view}`;
+        let contentsView = o_browse.getScrollContainerClass();
+        if ($(`${tab} ${contentsView}`).scrollTop() < infiniteScrollUpThreshold) {
+            $(`${tab} ${contentsView}`).trigger("ps-scroll-up");
+        }
         o_browse.updateSliderHandle();
         return false;
     },
@@ -1165,6 +1184,9 @@ var o_browse = {
         // - scroll up: when we scroll up and a new page is fetched, we want to keep scrollbar position at the current startObs, instead of at the first item in newly fetched page.
         // - scroll slider: when we load 3 * getLimit items, we want to keep scrollbar in the middle page.
         // - scroll down: theoretically, infiniteScroll will take care of scrollbar position, but we still have to manually set it for the case when cached data is removed so that scrollbar position is always correct (and never reaches to the end until it reaches to the end of the data)
+        console.log("=== renderGalleryAndTable set scrollbar obsNum ===");
+        console.log(infiniteScrollData.options.obsNum);
+        console.log(opus.prefs["startobs"]);
         o_browse.setScrollbarPosition(infiniteScrollData.options.obsNum);
 
         $(".op-page-loading-status > .loader").hide();
@@ -1362,8 +1384,16 @@ var o_browse = {
                     let firstCachedObs = $(`${tab} .thumbnail-container`).first().data("obs");
 
                     let infiniteScrollData = $(selector).data("infiniteScroll");
+
+                    // TODO: either move this block to ps-scroll-up handler or
+                    // find a way to trigger scroll up in ps-scroll-up handler when it reaches to the top end
+                    console.log("=== ON PATH ===");
+                    if (infiniteScrollData) {
+                        console.log(infiniteScrollData.options.loadPrevPage);
+                    }
                     if (infiniteScrollData !== undefined && infiniteScrollData.options.loadPrevPage === true) {
                         // Direction: scroll up, we prefetch 1 * o_browse.getLimit() items
+                        console.log("ON PATH SCROLL UP");
                         if (obsNum !== 1) {
                             // prefetch o_browse.getLimit() items ahead of firstCachedObs, update the startObs to be passed into url
                             obsNum = Math.max(firstCachedObs - o_browse.getLimit(), 1);
@@ -1383,6 +1413,7 @@ var o_browse = {
                             customizedLimitNum = 0;
                         }
                     } else {
+                        console.log("ON PATH SCROLL DOWN");
                         // Direction: scroll down, we prefetch 1 * o_browse.getLimit() items (symmetric to scroll up)
                         // NOTE: we can change the number of prefetch items by changing customizedLimitNum
                         // start from the last observation drawn; if none yet drawn, start from opus.prefs.startobs
@@ -1399,6 +1430,9 @@ var o_browse = {
                         }
                     }
                     let path = o_browse.getDataURL(obsNum, customizedLimitNum);
+                    console.log(`ON PATH: ${path}`);
+                    console.log(`obsNum: ${obsNum}`);
+                    console.log(`limit: ${customizedLimitNum}`);
                     return path;
                 },
                 responseType: "text",

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -49,7 +49,7 @@ var o_browse = {
     currentOpusId: "",
     tempHash: "",
     onRenderData: false,
-
+    fading: false,  // used to prevent additional clicks until the fade animation complete
     /**
     *
     *  all the things that happen on the browse tab
@@ -99,6 +99,10 @@ var o_browse = {
 
         // browse nav menu - the gallery/table toggle
         $("#browse, #cart").on("click", ".op-browse-view", function() {
+            if (o_browse.fading) {
+                return false;
+            }
+
             o_browse.hideMenu();
             let browse = o_browse.getBrowseView();
             opus.prefs[browse] = $(this).data("view");
@@ -1047,7 +1051,7 @@ var o_browse = {
 
         if (opus.prefs[browse] == "gallery") {
             $(".op-data-table-view", tab).hide();
-            $(".op-gallery-view", tab).fadeIn();
+            $(".op-gallery-view", tab).fadeIn("done", function() {o_browse.fading = false;});
 
             $(".op-browse-view", tab).html("<i class='far fa-list-alt'></i>&nbsp;View Table");
             $(".op-browse-view", tab).attr("title", "View sortable metadata table");
@@ -1056,7 +1060,7 @@ var o_browse = {
             suppressScrollY = false;
         } else {
             $(".op-gallery-view", tab).hide();
-            $(".op-data-table-view", tab).fadeIn();
+            $(".op-data-table-view", tab).fadeIn("done", function() {o_browse.fading = false;});
 
             $(".op-browse-view", tab).html("<i class='far fa-images'></i>&nbsp;View Gallery");
             $(".op-browse-view", tab).attr("title", "View sortable thumbnail gallery");
@@ -1135,7 +1139,7 @@ var o_browse = {
     renderGalleryAndTable: function(data, url, view) {
         // render the gallery and table at the same time.
         let tab = opus.getViewTab(view);
-        let contentsView = o_browse.getScrollContainerClass();
+        let contentsView = o_browse.getScrollContainerClass(view);
         let selector = `${tab} ${contentsView}`;
         let infiniteScrollData = $(selector).data("infiniteScroll");
 
@@ -1411,13 +1415,15 @@ var o_browse = {
         tableObsElem.eq(index).remove();
     },
 
-    getBrowseView: function () {
-        return (opus.prefs.view === "cart" ? "cart_browse" : "browse");
+    getBrowseView: function(tab) {
+        tab = (tab === undefined ? opus.prefs.view : tab);
+        return (tab === "cart" ? "cart_browse" : "browse");
     },
 
     // return the infiniteScroll container class for either gallery or table view
-    getScrollContainerClass: function() {
-        let browse = o_browse.getBrowseView();
+    getScrollContainerClass: function(tab) {
+        tab = (tab === undefined ? opus.prefs.view : tab);
+        let browse = o_browse.getBrowseView(tab);
         return (opus.prefs[browse] === "gallery" ? ".op-gallery-view" : ".op-data-table-view");
     },
 
@@ -1518,8 +1524,8 @@ var o_browse = {
 
     loadData: function(view, startObs, customizedLimitNum=undefined) {
         let tab = opus.getViewTab(view);
-        let startObsLabel = o_browse.getStartObsLabel();
-        let contentsView = o_browse.getScrollContainerClass();
+        let startObsLabel = o_browse.getStartObsLabel(view);
+        let contentsView = o_browse.getScrollContainerClass(view);
 
         let galleryInfiniteScroll = $(`${tab} .op-gallery-view`).data("infiniteScroll");
         let tableInfiniteScroll = $(`${tab} .op-data-table-view`).data("infiniteScroll");

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1066,13 +1066,10 @@ var o_browse = {
         }
         opus.getViewNamespace().galleryScrollbar.settings.suppressScrollY = suppressScrollY;
 
-        console.log(`=== switching between table and gallery in ${tab} ===`)
         // sync up scrollbar position
         if (galleryInfiniteScroll && tableInfiniteScroll) {
             let startObs = $(`${tab} ${contentsView}`).data("infiniteScroll").options.obsNum;
-            console.log(`obsNum: ${startObs}`);
             o_browse.setScrollbarPosition(startObs);
-
         }
     },
 
@@ -1503,10 +1500,15 @@ var o_browse = {
                 let firstObs = $(`${tab} .thumbnail-container`).first().data("obs");
                 let lastObs = $(`${tab} .thumbnail-container`).last().data("obs");
 
-                if ((firstObs === 1 && infiniteScrollData.options.loadPrevPage === true) ||
-                    (lastObs === opus.resultCount && infiniteScrollData.options.loadPrevPage === false) ||
-                    (lastObs === o_cart.cartCount && infiniteScrollData.options.loadPrevPage === false)) {
-                    $(".infinite-scroll-request").hide();
+                if (infiniteScrollData.options.loadPrevPage === true) {
+                    if (firstObs === 1) {
+                        $(".infinite-scroll-request").hide();
+                    }
+                } else {
+                    if ((tab === "#browse" && lastObs === opus.resultCount) ||
+                        (tab === "#cart" && lastObs === o_cart.cartCount)) {
+                        $(".infinite-scroll-request").hide();
+                    }
                 }
             });
 

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -82,7 +82,6 @@ var o_browse = {
                         $(`${tab} ${contentsView}`).infiniteScroll({
                             "loadPrevPage": true,
                         });
-                        console.log(`=== load previous page with current startObs ${opus.prefs["startobs"]} ===`);
                         $(`${tab} ${contentsView}`).infiniteScroll("loadNextPage");
                         o_browse.updateSliderHandle();
                     }
@@ -671,43 +670,22 @@ var o_browse = {
             // this will get the top left obsNum for gallery view or the top obsNum for table view
             let firstCachedObs = $(selector).first().data("obs");
             let firstCachedObsTop = $(selector).first().offset().top;
-            let calculatedFirstObs = firstCachedObs;
-            // let calculatedFirstObs = Math.floor((firstCachedObs - 1)/o_browse.galleryBoundingRect.x+0.0000001) * o_browse.galleryBoundingRect.x + 1;
             topBoxBoundary = topBoxBoundary || (opus.prefs.browse === "dataTable") ? $(`${tab} .gallery-contents`).offset().top + $(`${tab} #dataTable thead th`).outerHeight() : $(`${tab} .gallery-contents`).offset().top;
 
-            // table: obsNum = calculatedFirstObs + number of row
-            // gallery: obsNum = calculatedFirstObs + number of row * number of obs in a row
+            // table: obsNum = firstCachedObs + number of row
+            // gallery: obsNum = firstCachedObs + number of row * number of obs in a row
             let obsNumDiff = (opus.prefs.browse === "dataTable") ? Math.round((topBoxBoundary - firstCachedObsTop)/$(`${tab} tbody tr`).outerHeight()) : Math.round((topBoxBoundary - firstCachedObsTop)/o_browse.imageSize) * o_browse.galleryBoundingRect.x;
-            let obsNum = obsNumDiff + calculatedFirstObs;
-
-            console.log("=== updateSliderHandle firstCachedObs ===");
-            console.log(firstCachedObs);
-            console.log("=== galleryBoundingRect ===");
-            console.log(o_browse.galleryBoundingRect);
-            console.log("=== calculateFirstObs ===");
-            console.log(calculatedFirstObs);
-            // console.log("=== FirstObs top ===");
-            // console.log(firstCachedObsTop);
-            // console.log("=== topBoxBoundary ===");
-            // console.log(topBoxBoundary);
-            console.log("=== Row height ===");
-            console.log(obsNumDiff);
-            console.log("=== startObs ===");
-            console.log(obsNum);
-            console.log(`=== slider step: ${o_browse.gallerySliderStep} ===`);
+            let obsNum = obsNumDiff + firstCachedObs;
 
             // update obsNum in both infiniteScroll instances
             // store the most top left obsNum in gallery for both infiniteScroll instances, this will be used to updated slider obsNum
             if (contentsView === ".op-dataTable-view") {
                 obsNum = Math.floor((obsNum-firstCachedObs)/o_browse.galleryBoundingRect.x+0.0000001)*o_browse.galleryBoundingRect.x+firstCachedObs;
-                // obsNum = Math.floor((obsNum-1)/o_browse.gallerySliderStep+0.0000001)*o_browse.gallerySliderStep+1;
             }
 
             $(`${tab} .op-gallery-view`).infiniteScroll({"obsNum": obsNum});
             $(`${tab} .op-dataTable-view`).infiniteScroll({"obsNum": obsNum});
             opus.prefs[startObsLabel] = obsNum;
-            console.log("=== startObs after convert ===");
-            console.log(obsNum);
 
             $("#op-observation-number").html(obsNum);
             $(".op-slider-pointer").css("width", `${opus.resultCount.toString().length*0.7}em`);
@@ -725,46 +703,6 @@ var o_browse = {
             // update startobs in url when scrolling
             o_hash.updateHash(true);
         }
-
-        // $(selector).each(function(index, elem) {
-        //     // Fot gallery view, the topBoxBoundary is the top of .gallery-contents
-        //     // For table view, we will set the topBoxBoundary to be the bottom of thead (account for height of thead)
-        //     topBoxBoundary = topBoxBoundary || (opus.prefs.browse === "dataTable") ? $(`${tab} .gallery-contents`).offset().top + $(`${tab} #dataTable thead th`).outerHeight() : $(`${tab} .gallery-contents`).offset().top;
-        //
-        //     // compare the image .top + half its height in order to make sure we account for partial images
-        //     let topBox = $(elem).offset().top + $(elem).height()/2;
-        //     if (topBox >= topBoxBoundary) {
-        //         let obsNum = $(elem).data("obs");
-        //         console.log(`obsNum in loop: ${obsNum}`);
-        //
-        //         // update obsNum in both infiniteScroll instances
-        //         // store the most top left obsNum in gallery for both infiniteScroll instances, this will be used to updated slider obsNum
-        //         if (contentsView === ".op-dataTable-view") {
-        //             obsNum = Math.floor((obsNum-1)/o_browse.gallerySliderStep+0.0000001)*o_browse.gallerySliderStep+1;
-        //         }
-        //         console.log(`obsNum after convert in loop: ${obsNum}`);
-        //         $(`${tab} .op-gallery-view`).infiniteScroll({"obsNum": obsNum});
-        //         $(`${tab} .op-dataTable-view`).infiniteScroll({"obsNum": obsNum});
-        //         opus.prefs[startObsLabel] = obsNum;
-        //
-        //         $("#op-observation-number").html(obsNum);
-        //         $(".op-slider-pointer").css("width", `${opus.resultCount.toString().length*0.7}em`);
-        //         // just make the step size the number of the obserations across the page...
-        //         // if the observations have not yet been rendered, leave the default, it will get changed later
-        //         if (o_browse.galleryBoundingRect.x > 0) {
-        //             o_browse.gallerySliderStep = o_browse.galleryBoundingRect.x;
-        //         }
-        //         $("#op-observation-slider").slider({
-        //             "value": obsNum,
-        //             "step": o_browse.gallerySliderStep,
-        //             "max": opus.resultCount,
-        //         });
-        //
-        //         // update startobs in url when scrolling
-        //         o_hash.updateHash(true);
-        //         return false;
-        //     }
-        // });
     },
 
     checkScroll: function() {
@@ -1072,8 +1010,6 @@ var o_browse = {
         // sync up scrollbar position
         if (galleryInfiniteScroll && tableInfiniteScroll) {
             let startObs = $(`${tab} ${contentsView}`).data("infiniteScroll").options.obsNum;
-            console.log("=== startObs when switching between table and gallery");
-            console.log(startObs);
             o_browse.setScrollbarPosition(startObs);
         }
     },
@@ -1165,7 +1101,6 @@ var o_browse = {
                 return;
             }
         } else {
-            let startobsLabel = o_browse.getStartObsLabel();
             let append = (data.start_obs > $(`${tab} .thumbnail-container`).last().data("obs"));
 
             o_browse.manageObservationCache(data.count, append);

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -14,6 +14,8 @@ const tableSortUpArrow = "fas fa-sort-up";
 const tableSortDownArrow = "fas fa-sort-down";
 const defaultTableSortArrow = "fas fa-sort";
 const infiniteScrollUpThreshold = 100;
+// Fix scrollbar length for gallery & table view
+const galleryAndTabPSLength = 75;
 
 /* jshint varstmt: false */
 var o_browse = {
@@ -23,11 +25,13 @@ var o_browse = {
     metadataSelectorDrawn: false,
 
     tableScrollbar: new PerfectScrollbar("#browse .op-dataTable-view", {
-        minScrollbarLength: opus.minimumPSLength
+        minScrollbarLength: galleryAndTabPSLength,
+        maxScrollbarLength: galleryAndTabPSLength,
     }),
     galleryScrollbar: new PerfectScrollbar("#browse .op-gallery-view", {
         suppressScrollX: true,
-        minScrollbarLength: opus.minimumPSLength
+        minScrollbarLength: galleryAndTabPSLength,
+        maxScrollbarLength: galleryAndTabPSLength,
     }),
     modalScrollbar: new PerfectScrollbar("#galleryViewContents .metadata", {
         minScrollbarLength: opus.minimumPSLength
@@ -635,15 +639,13 @@ var o_browse = {
         let elem = $(`#${opus.prefs.view} .thumbnail-container[data-obs="${value}"]`);
         let startObsLabel = o_browse.getStartObsLabel();
 
-        opus.prefs[startObsLabel] = value;
+        // Update obsNum in infiniteScroll instances, and this obsNum is the first item in current page. (will be used to set scrollbar position in renderGalleryAndTable).
         $(`${tab} .op-gallery-view`).infiniteScroll({"obsNum": value});
         $(`${tab} .op-dataTable-view`).infiniteScroll({"obsNum": value});
+        opus.prefs[startObsLabel] = value;
 
         if (elem.length > 0) {
             o_browse.setScrollbarOnSlide(value);
-            // Update obsNum in infiniteScroll instances, and this obsNum is the first item in current page. (will be used to set scrollbar position in renderGalleryAndTable). This is for the case when above o_browse.setScrollbarOnSlide(value) trigger infiniteScroll load event.
-            // $(`${tab} .op-gallery-view`).infiniteScroll({"obsNum": value});
-            // $(`${tab} .op-dataTable-view`).infiniteScroll({"obsNum": value});
         } else {
             // When scrolling on slider and loadData is called, we will fetch 3 * getLimit items (one current page, one next page, and one previous page) starting from obsNum.
             // obsNum will be the very first obs for data rendering this time
@@ -652,9 +654,6 @@ var o_browse = {
             // If obsNum is 1, previous page will have value - 1 items, so we render value - 1 + 2 * o_browse.getLimit() items
             // else we render 2 * o_browse.getLimit() items.
             let customizedLimitNum = obsNum === 1 ? value - 1 + 2 * o_browse.getLimit() : 3 * o_browse.getLimit();
-            // Update obsNum in infiniteScroll instances, and this obsNum is the first item in current page (will be used to set scrollbar position in renderGalleryAndTable, so need to update them before loadData).
-            // $(`${tab} .op-gallery-view`).infiniteScroll({"obsNum": value});
-            // $(`${tab} .op-dataTable-view`).infiniteScroll({"obsNum": value});
             o_browse.galleryBegun = false;
             o_browse.loadData(obsNum, customizedLimitNum);
         }

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1650,7 +1650,10 @@ var o_browse = {
         let tab = opus.getViewTab(view);
         let footerHeight = $(".app-footer").outerHeight();
         let mainNavHeight = $("#op-main-nav").outerHeight();
-        let navbarHeight = $(".panel-heading").outerHeight();
+        // we need to specify the tab here
+        // otherwise in cart tab the selector will select the navbar in browse
+        // and outerHeight will be 0.
+        let navbarHeight = $(`${tab} .panel-heading`).outerHeight();
         let totalNonGalleryHeight = footerHeight + mainNavHeight + navbarHeight;
         return  $(window).height()-totalNonGalleryHeight;
     },
@@ -1684,12 +1687,12 @@ var o_browse = {
 
     adjustTableSize: function() {
         let tab = opus.getViewTab();
+        console.log(tab);
         let containerWidth = $(`${tab} .gallery-contents`).width();
-        // let containerHeight = $(`${tab} .gallery-contents`).height() - $(".app-footer").outerHeight();
         let containerHeight = $(`${tab} .gallery-contents`).height();
         $(`${tab} .op-data-table-view`).width(containerWidth);
         $(`${tab} .op-data-table-view`).height(containerHeight);
-
+        console.log(opus.getViewNamespace().tableScrollbar);
         opus.getViewNamespace().tableScrollbar.update();
     },
 

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -72,7 +72,7 @@ var o_browse = {
 
             if (event.originalEvent.type === "ps-scroll-up" || (event.originalEvent.type === "wheel" && event.originalEvent.deltaY < 0)) {
 
-                if (opus.prefs[startObsLabel] > 0) {
+                if (opus.prefs[startObsLabel] > 1) {
                     let firstObs = $(`${tab} [data-obs]`).first().data("obs");
                     if ($(`${tab} ${contentsView}`).scrollTop() < infiniteScrollUpThreshold && firstObs !== 1) {
                         $(`${tab} ${contentsView}`).infiniteScroll({
@@ -699,7 +699,7 @@ var o_browse = {
                     "max": opus.resultCount,
                 });
 
-                // update startobs in url when scrolling 
+                // update startobs in url when scrolling
                 o_hash.updateHash(true);
                 return false;
             }

--- a/opus/application/static_media/js/cart.js
+++ b/opus/application/static_media/js/cart.js
@@ -230,7 +230,7 @@ var o_cart = {
         let buttonInfo = o_browse.cartButtonInfo("in");
         $(".thumbnail-container.op-in-cart [data-icon=cart]").html(`<i class="${buttonInfo.icon} fa-xs"></i>`);
         $(".thumbnail-container.op-in-cart").removeClass("op-in-cart");
-        $(".dataTable input").prop("checked", false);
+        $(".op-data-table-view input").prop("checked", false);
     },
 
     toggleInCart: function(fromOpusId, toOpusId) {

--- a/opus/application/static_media/js/cart.js
+++ b/opus/application/static_media/js/cart.js
@@ -127,15 +127,17 @@ var o_cart = {
     },
 
     adjustProductInfoHeight: function() {
-        let containerHeight = $(window).height()-120;
-        let downloadOptionsContainer = $(window).height()-90;
+        let containerHeight = o_browse.calculateGalleryHeight();
+        let footerHeight = $(".app-footer").outerHeight();
+        let mainNavHeight = $("#op-main-nav").outerHeight();
+        let downloadOptionsHeight = $(window).height() - (footerHeight + mainNavHeight);
         let cartSummaryHeight = $("#cart_summary").height();
-        $("#cart .sidebar_wrapper").height(downloadOptionsContainer);
         $("#cart .gallery-contents").height(containerHeight);
+        $("#cart .sidebar_wrapper").height(downloadOptionsHeight);
 
         // The following steps will hide the y-scrollbar when it's not needed.
         // Without these steps, y-scrollbar will exist at the beginning, and disappear after the first attempt of scrolling
-        if (downloadOptionsContainer > cartSummaryHeight) {
+        if (downloadOptionsHeight > cartSummaryHeight) {
             if (!$("#op-download-options-container .ps__rail-y").hasClass("hide_ps__rail-y")) {
                 $("#op-download-options-container .ps__rail-y").addClass("hide_ps__rail-y");
                 o_cart.downloadOptionsScrollbar.settings.suppressScrollY = true;

--- a/opus/application/static_media/js/hash.js
+++ b/opus/application/static_media/js/hash.js
@@ -35,7 +35,6 @@ var o_hash = {
             }
         }
         $.each(opus.prefs, function(key, value) {
-            value = (value == "dataTable" ? "data" : value);
             hash.push(key + "=" + value);
         });
 
@@ -145,9 +144,6 @@ var o_hash = {
                 // look for prefs
                 else if (slug in opus.prefs) {
                     switch (slug) {
-                        case "browse":
-                            opus.prefs[slug] = (value == "data" ? "dataTable" : value);
-                            break;
                         case "widgets":
                             opus.prefs[slug] = value.replace(/\s+/g, '').split(',');
                             break;

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -430,7 +430,6 @@ var opus = {
         let adjustHelpPanelHeightDB = _.debounce(opus.adjustHelpPanelHeight, 200);
 
         $(window).on("resize", function() {
-            console.log("@@@@ window resize is triggered @@@");
             adjustSearchHeightDB();
             adjustBrowseHeightDB();
             adjustTableSizeDB();

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -432,7 +432,7 @@ var opus = {
         }
 
         let adjustSearchHeightDB = _.debounce(o_search.adjustSearchHeight, 200);
-        let adjustBrowseHeightDB = _.debounce(o_browse.adjustBrowseHeight, 200);
+        let adjustBrowseHeightDB = _.debounce(function() {o_browse.adjustBrowseHeight(true);}, 200);
         let adjustTableSizeDB = _.debounce(o_browse.adjustTableSize, 200);
         let adjustProductInfoHeightDB = _.debounce(o_cart.adjustProductInfoHeight, 200);
         let adjustDetailHeightDB = _.debounce(o_detail.adjustDetailHeight, 200);

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -430,6 +430,7 @@ var opus = {
         let adjustHelpPanelHeightDB = _.debounce(opus.adjustHelpPanelHeight, 200);
 
         $(window).on("resize", function() {
+            console.log("@@@@ window resize is triggered @@@");
             adjustSearchHeightDB();
             adjustBrowseHeightDB();
             adjustTableSizeDB();

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -383,7 +383,7 @@ var o_widgets = {
         opus.widgets_fetching.push(slug);
 
         // add the div that will hold the widget
-        if ($.inArray(slug,opus.widget_elements_drawn) < 0) {
+        if ($.inArray(slug, opus.widget_elements_drawn) < 0) {
 
             opus.prefs.widgets.unshift(slug);
 


### PR DESCRIPTION
# Update
- B087: After resizing window and toggling between table & gallery, slider value will not change now.
- B088: InfiniteScroll scroll up:
    - The previous scroll up issue:
        1. When we scroll the slider to the middle, and hold down pageUp key to scroll up.
        2. When scrollbar reaches to the up scroll threshold point, in "ps-scroll-up" event handler function, infiniteScroll loadNextPage will be triggered with the standard steps:
            a. infiniteScroll request
            b. infiniteScroll load
            c. infiniteScroll load event handler (renderGalleryAndTable is called here)
        3. And after that it will only have one loadNextPage triggered (in step 2), and scrollbar will be stuck at the top end. No more data will be prefetched unless we use the wheel or lower the scroll bar a bit and move it up again.
    - The Reason:
        In step 2, we are still holding down pageUp key, and still getting into "ps-scroll-up" event to call the handler function to perform loadNextPage for a second time. However, when we try to call loadNextPage for the 2nd time, the first trigger of loadNextPage is still in the middle of 2-a and 2-b. Therefore, the 2nd time loadNextPage will not be called because infiniteScroll thinks it's already been doing loadNextPage (in the middle of 2-a and 2-b). And the scrollbar will be stuck at the top end.
    - Now in checkScroll, we will trigger "ps-scroll-up" when scrollbar reaches to up scroll threshold point.
- B089: We set the fixed PS scrollbar length to 100 for now.
- B090: 0.5S debounce time is removed.