### PR TITLE
New ui provide info or warning messages to users, related to A095/A098/A096/S055

### DIFF
--- a/opus/application/apps/help/templates/help/about.html
+++ b/opus/application/apps/help/templates/help/about.html
@@ -177,7 +177,7 @@
 </p>
 
 <p>Please note that OPUS works best with a browser size of at least 1280 by 720. We
-	support Firefox (66+), Chrome (74+), Safari (12.1+), Opera (58+), and Microsoft Edge (18+).
+	support Firefox (59+), Chrome (56+), Safari (10.1+), and Opera (42+).
 </p>
 
 <p>Updates are announced on

--- a/opus/application/apps/help/templates/help/about.html
+++ b/opus/application/apps/help/templates/help/about.html
@@ -176,7 +176,7 @@
     We would also appreciate if you would drop us a note to let us know about it.
 </p>
 
-<p>Please note that OPUS works best with a browser size of at least 1280 by 720. We
+<p>Please note that OPUS works best with a browser size of at least 600 by 200. We
 	support Firefox (59+), Chrome (56+), Safari (10.1+), and Opera (42+).
 </p>
 

--- a/opus/application/apps/help/templates/help/about.html
+++ b/opus/application/apps/help/templates/help/about.html
@@ -176,7 +176,7 @@
     We would also appreciate if you would drop us a note to let us know about it.
 </p>
 
-<p>Please note that OPUS works best with a browser size of at least 1280 by 275. We
+<p>Please note that OPUS works best with a browser size of at least 1280 by 720. We
 	support Firefox (66+), Chrome (74+), Safari (12.1+), Opera (58+), and Microsoft Edge (18+).
 </p>
 

--- a/opus/application/apps/help/templates/help/about.html
+++ b/opus/application/apps/help/templates/help/about.html
@@ -176,7 +176,7 @@
     We would also appreciate if you would drop us a note to let us know about it.
 </p>
 
-<p>Please note that OPUS works best with a browser size of at least 1280 by 720. We
+<p>Please note that OPUS works best with a browser size of at least 1280 by 275. We
 	support Firefox (66+), Chrome (74+), Safari (12.1+), Opera (58+), and Microsoft Edge (18+).
 </p>
 

--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -356,6 +356,14 @@
             target="op-browser-size-msg"
             allow_close=False
         %}
+        {% include "ui/confirm_modal.html" with
+            id_name="op-guide"
+            confirm_title="Welcome to OPUS3"
+            confirm_msg="Please see the FAQ section from help menu or <a href='https://ringsnodesearchtool.blogspot.com/' target='_blank'>our blog</a> for details."
+            target="op-guide"
+            yes_text="OK"
+            allow_close=True
+        %}
 
         {% endblock %}
 

--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -306,6 +306,7 @@
             yes_text="Yes"
             no_text="No"
             allow_close=True
+            close_by_keyboard="esc"
         %}
         {% include "ui/confirm_modal.html" with
             id_name="op-reset-search-metadata-modal"
@@ -315,6 +316,7 @@
             yes_text="Yes"
             no_text="No"
             allow_close=True
+            close_by_keyboard="esc"
         %}
         {% include "ui/confirm_modal.html" with
             id_name="op-empty-cart"
@@ -324,6 +326,7 @@
             yes_text="Yes"
             no_text="No"
             allow_close=True
+            close_by_keyboard="esc"
         %}
         {% include "ui/confirm_modal.html" with
             id_name="op-cart-status-error-msg"
@@ -332,6 +335,7 @@
             target="op-cart-status-error-msg"
             yes_text="OK"
             allow_close=True
+            close_by_keyboard="esc"
         %}
         {% include "ui/confirm_modal.html" with
             id_name="op-update-url"
@@ -341,6 +345,7 @@
             yes_text="Keep Message"
             no_text="Discard Message"
             allow_close=True
+            close_by_keyboard="esc"
         %}
         {% include "ui/confirm_modal.html" with
             id_name="op-browser-version-msg"
@@ -363,6 +368,7 @@
             target="op-guide"
             yes_text="OK"
             allow_close=True
+            close_by_keyboard="esc"
         %}
 
         {% endblock %}

--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -343,10 +343,17 @@
             allow_close=True
         %}
         {% include "ui/confirm_modal.html" with
-            id_name="op-browser-warning"
+            id_name="op-browser-version-msg"
             confirm_title="Message About Your Browser Version"
-            confirm_msg="Please update your browser. We support Firefox (66+), Chrome (74+), Safari (12.1+), Opera (58+), and Microsoft Edge (18+)."
-            target="op-browser-warning"
+            confirm_msg="Please update your browser. OPUS supports Firefox (66+), Chrome (74+), Safari (12.1+), Opera (58+), and Microsoft Edge (18+)."
+            target="op-browser-version-msg"
+            allow_close=False
+        %}
+        {% include "ui/confirm_modal.html" with
+            id_name="op-browser-size-msg"
+            confirm_title="Message About Your Browser Size"
+            confirm_msg="Please resize your browser. OPUS works best with a browser width of at least 1280px."
+            target="op-browser-size-msg"
             allow_close=False
         %}
 

--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -305,6 +305,7 @@
             target="op-reset-search-modal"
             yes_text="Yes"
             no_text="No"
+            allow_close=True
         %}
         {% include "ui/confirm_modal.html" with
             id_name="op-reset-search-metadata-modal"
@@ -313,6 +314,7 @@
             target="op-reset-search-metadata-modal"
             yes_text="Yes"
             no_text="No"
+            allow_close=True
         %}
         {% include "ui/confirm_modal.html" with
             id_name="op-empty-cart"
@@ -321,6 +323,7 @@
             target="op-empty-cart"
             yes_text="Yes"
             no_text="No"
+            allow_close=True
         %}
         {% include "ui/confirm_modal.html" with
             id_name="op-cart-status-error-msg"
@@ -328,6 +331,7 @@
             confirm_msg=""
             target="op-cart-status-error-msg"
             yes_text="OK"
+            allow_close=True
         %}
         {% include "ui/confirm_modal.html" with
             id_name="op-update-url"
@@ -336,6 +340,14 @@
             target="op-update-url"
             yes_text="Keep Message"
             no_text="Discard Message"
+            allow_close=True
+        %}
+        {% include "ui/confirm_modal.html" with
+            id_name="op-browser-warning"
+            confirm_title="Message About Your Browser Version"
+            confirm_msg="Please update your browser. We support Firefox (66+), Chrome (74+), Safari (12.1+), Opera (58+), and Microsoft Edge (18+)."
+            target="op-browser-warning"
+            allow_close=False
         %}
 
         {% endblock %}

--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -352,7 +352,7 @@
         {% include "ui/confirm_modal.html" with
             id_name="op-browser-size-msg"
             confirm_title="Message About Your Browser Size"
-            confirm_msg="Please resize your browser. OPUS works best with a browser width of at least 1280px."
+            confirm_msg="Please resize your browser. OPUS works best with a browser size of at least 1280 pixels by 275 pixels."
             target="op-browser-size-msg"
             allow_close=False
         %}

--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -352,7 +352,7 @@
         {% include "ui/confirm_modal.html" with
             id_name="op-browser-size-msg"
             confirm_title="Message About Your Browser Size"
-            confirm_msg="Please resize your browser. OPUS works best with a browser size of at least 1280 pixels by 275 pixels."
+            confirm_msg=""
             target="op-browser-size-msg"
             allow_close=False
         %}

--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -345,7 +345,7 @@
         {% include "ui/confirm_modal.html" with
             id_name="op-browser-version-msg"
             confirm_title="Message About Your Browser Version"
-            confirm_msg="Please update your browser. OPUS supports Firefox (66+), Chrome (74+), Safari (12.1+), Opera (58+), and Microsoft Edge (18+)."
+            confirm_msg=""
             target="op-browser-version-msg"
             allow_close=False
         %}

--- a/opus/application/apps/ui/templates/ui/confirm_modal.html
+++ b/opus/application/apps/ui/templates/ui/confirm_modal.html
@@ -1,5 +1,5 @@
 <!-- generic confirmation Modal -->
-<div class="modal op-confirm-modal fade" id={{id_name}} tabindex="-1" data-backdrop="static" data-keyboard="false" role="dialog" aria-labelledby="confirm-modalLabel" aria-hidden="true">
+<div class="modal op-confirm-modal fade" id={{id_name}} tabindex="-1" data-action="{{close_by_keyboard}}" data-backdrop="static" data-keyboard="false" role="dialog" aria-labelledby="confirm-modalLabel" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered" role="document">
         <div id="op-confirm-modal" class="modal-content border-light">
             <div class="modal-header bg-dark text-light font-weight-bold font-lg py-3">

--- a/opus/application/apps/ui/templates/ui/confirm_modal.html
+++ b/opus/application/apps/ui/templates/ui/confirm_modal.html
@@ -1,5 +1,5 @@
 <!-- generic confirmation Modal -->
-<div class="modal op-confirm-modal fade" id={{id_name}} tabindex="-1" data-backdrop="false" data-keyboard="false" role="dialog" aria-labelledby="confirm-modalLabel" aria-hidden="true">
+<div class="modal op-confirm-modal fade" id={{id_name}} tabindex="-1" data-backdrop="static" data-keyboard="false" role="dialog" aria-labelledby="confirm-modalLabel" aria-hidden="true">
     <div class="modal-dialog" role="document">
         <div id="op-confirm-modal" class="modal-content border-light">
             <div class="modal-header bg-dark text-light font-weight-bold font-lg py-3">

--- a/opus/application/apps/ui/templates/ui/confirm_modal.html
+++ b/opus/application/apps/ui/templates/ui/confirm_modal.html
@@ -4,21 +4,25 @@
         <div id="op-confirm-modal" class="modal-content border-light">
             <div class="modal-header bg-dark text-light font-weight-bold font-lg py-3">
                 <div>{{confirm_title}}</div>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <i class="far fa-times-circle fa-lg text-light"></i>
-                </button>
+                {% if allow_close %}
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <i class="far fa-times-circle fa-lg text-light"></i>
+                    </button>
+                {% endif %}
             </div>
             <div class="modal-body">
                 {{confirm_msg}}
             </div>
-            <div class="modal-footer">
-                {% if yes_text %}
-                    <button type="submit" class="btn btn-primary" data-dismiss="modal" data-target={{target}}>{{yes_text}}</button>
-                {% endif %}
-                {% if no_text %}
-                    <button type="cancel" class="btn btn-danger" data-target={{target}}>{{no_text}}</button>
-                {% endif %}
-            </div>
+            {% if yes_text or no_text %}
+                <div class="modal-footer">
+                    {% if yes_text %}
+                        <button type="submit" class="btn btn-primary" data-dismiss="modal" data-target={{target}}>{{yes_text}}</button>
+                    {% endif %}
+                    {% if no_text %}
+                        <button type="cancel" class="btn btn-danger" data-target={{target}}>{{no_text}}</button>
+                    {% endif %}
+                </div>
+            {% endif %}
         </div>
     </div>
 </div>

--- a/opus/application/apps/ui/templates/ui/confirm_modal.html
+++ b/opus/application/apps/ui/templates/ui/confirm_modal.html
@@ -1,6 +1,6 @@
 <!-- generic confirmation Modal -->
 <div class="modal op-confirm-modal fade" id={{id_name}} tabindex="-1" data-backdrop="static" data-keyboard="false" role="dialog" aria-labelledby="confirm-modalLabel" aria-hidden="true">
-    <div class="modal-dialog" role="document">
+    <div class="modal-dialog modal-dialog-centered" role="document">
         <div id="op-confirm-modal" class="modal-content border-light">
             <div class="modal-header bg-dark text-light font-weight-bold font-lg py-3">
                 <div>{{confirm_title}}</div>

--- a/opus/application/apps/ui/templates/ui/menu.html
+++ b/opus/application/apps/ui/templates/ui/menu.html
@@ -19,7 +19,7 @@
                 {% for name, info in menu.data.items %}
                     {% if name == div.table_name %}  {# this param_name IS contained in this div #}
                         {% if info.menu_help %}
-                            <li class="list-group-item list-group-item-action py-0 pl-0"><div class="menu_help text-info">{{ info.menu_help }}</div></li>
+                            <li class="list-group-item list-group-item-action py-0 pl-0 bg-white"><div class="menu_help text-info">{{ info.menu_help }}</div></li>
                         {% endif %}
 
                         {% if info.has_sub_heading %}

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -14,8 +14,6 @@ const tableSortUpArrow = "fas fa-sort-up";
 const tableSortDownArrow = "fas fa-sort-down";
 const defaultTableSortArrow = "fas fa-sort";
 const infiniteScrollUpThreshold = 100;
-// Fixed scrollbar length for gallery & table view
-const galleryAndTablePSLength = 100;
 
 /* jshint varstmt: false */
 var o_browse = {
@@ -25,13 +23,13 @@ var o_browse = {
     metadataSelectorDrawn: false,
 
     tableScrollbar: new PerfectScrollbar("#browse .op-data-table-view", {
-        minScrollbarLength: galleryAndTablePSLength,
-        maxScrollbarLength: galleryAndTablePSLength,
+        minScrollbarLength: opus.galleryAndTablePSLength,
+        maxScrollbarLength: opus.galleryAndTablePSLength,
     }),
     galleryScrollbar: new PerfectScrollbar("#browse .op-gallery-view", {
         suppressScrollX: true,
-        minScrollbarLength: galleryAndTablePSLength,
-        maxScrollbarLength: galleryAndTablePSLength,
+        minScrollbarLength: opus.galleryAndTablePSLength,
+        maxScrollbarLength: opus.galleryAndTablePSLength,
     }),
     modalScrollbar: new PerfectScrollbar("#galleryViewContents .metadata", {
         minScrollbarLength: opus.minimumPSLength

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -275,6 +275,12 @@ var o_browse = {
             }
         });
 
+        // Disable draggable for these infomation modals
+        // If draggable is enabled, once modal is dragged, it will not stay in the center.
+        for (let id of ["#op-browser-version-msg", "#op-browser-size-msg", "#op-guide"]) {
+            $(`${id} .modal-dialog`).draggable("disable");
+        }
+
         $(".app-body").on("hide.bs.modal", "#galleryView", function(e) {
             let namespace = o_browse.getViewInfo().namespace;
             $(namespace).find(".modal-show").removeClass("modal-show");

--- a/opus/application/static_media/js/cart.js
+++ b/opus/application/static_media/js/cart.js
@@ -20,11 +20,13 @@ var o_cart = {
     galleryBoundingRect: {'x': 0, 'y': 0},
 
     tableScrollbar: new PerfectScrollbar("#cart .op-data-table-view", {
-        minScrollbarLength: opus.minimumPSLength
+        minScrollbarLength: opus.galleryAndTablePSLength,
+        maxScrollbarLength: opus.galleryAndTablePSLength,
     }),
     galleryScrollbar: new PerfectScrollbar("#cart .op-gallery-view", {
         suppressScrollX: true,
-        minScrollbarLength: opus.minimumPSLength
+        minScrollbarLength: opus.galleryAndTablePSLength,
+        maxScrollbarLength: opus.galleryAndTablePSLength,
     }),
     downloadOptionsScrollbar: new PerfectScrollbar("#op-download-options-container", {
         minScrollbarLength: opus.minimumPSLength

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -99,6 +99,7 @@ var opus = {
         "edge": 18,
         "safari": 12.1,
         "width": 1280,
+        "height": 275
     },
 
     //------------------------------------------------------------------------------------
@@ -795,10 +796,12 @@ var opus = {
 
     checkBrowserSize: function() {
         /**
-         * Check if browser width is less than 1280px. If so, display a
-         * modal to inform the user to resize the browser width.
+         * Check if browser width is less than 1280px or height is less
+         * than 275px. If so, display a modal to inform the user to
+         * resize the browser size.
          */
-        if ($(window).width() < opus.browserSupport.width) {
+        if ($(window).width() < opus.browserSupport.width ||
+            $(window).height() < opus.browserSupport.height) {
             $("#op-browser-size-msg").modal("show");
         } else {
             $("#op-browser-size-msg").modal("hide");
@@ -820,6 +823,7 @@ var opus = {
 
 $(document).ready(function() {
     opus.checkBrowserVersion();
+    opus.checkBrowserSize();
     opus.checkCookies();
     // Call normalized url api first
     // Rest of initialization prcoess will be performed afterwards

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -93,13 +93,12 @@ var opus = {
 
     // store the browser version and width supported by OPUS
     browserSupport: {
-        "firefox": 66,
-        "chrome": 74,
-        "opera": 58,
-        "edge": 18,
-        "safari": 12.1,
-        "width": 1280,
-        "height": 720
+        "firefox": 59,
+        "chrome": 56,
+        "opera": 42,
+        "safari": 10.1,
+        "width": 600,
+        "height": 200
     },
 
     //------------------------------------------------------------------------------------
@@ -752,21 +751,13 @@ var opus = {
          */
         let browserName, browserVersion, matchObj;
         let userAgent = navigator.userAgent;
+
         if (userAgent.indexOf("Firefox") > -1) {
             // Example output:
             // Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:66.0)
             // Gecko/20100101 Firefox/66.0
             matchObj = userAgent.match(/Firefox\/(\d+.\d+)/);
             browserName = "Firefox";
-            browserVersion = matchObj[1];
-        } else if (userAgent.indexOf("Edge") > -1 || userAgent.indexOf("Edg") > -1) {
-            // userAgent example output:
-            // Windows: Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36
-            // (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10136
-            // Mac: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36
-            // (KHTML, like Gecko) Chrome/76.0.3800.0 Safari/537.36 Edg/76.0.167.0
-            matchObj = userAgent.match(/Edge\/(\d+.\d+)/) || userAgent.match(/Edg\/(\d+.\d+)/);
-            browserName = "Edge";
             browserVersion = matchObj[1];
         } else if (userAgent.indexOf("OPR") > -1) {
             // userAgent example output:
@@ -775,7 +766,8 @@ var opus = {
             matchObj = userAgent.match(/OPR\/(\d+.\d+)/);
             browserName = "Opera";
             browserVersion = matchObj[1];
-        } else if (userAgent.indexOf("Chrome") > -1) {
+        } else if (userAgent.indexOf("Chrome") > -1 && userAgent.indexOf("Edge") === -1 &&
+                   userAgent.indexOf("Edg") === -1) {
             // userAgent example output:
             // Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36
             // (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36
@@ -794,10 +786,16 @@ var opus = {
             browserVersion = "0.0";
         }
 
-        let modalMsg = (`Your current browser is ${browserName} ${browserVersion}.
-                        Please update the browser. OPUS supports Firefox (66+),
-                        Chrome (74+), Safari (12.1+), Opera (58+), and Microsoft Edge
-                        (18+).`);
+        let browser = `${browserName} ${browserVersion}`;
+        if (browserName === "unsupported") {
+            browser = browserName;
+        }
+        let modalMsg = (`Your current browser is ${browser}.
+                        Please update the browser. OPUS supports
+                        Firefox (${opus.browserSupport.firefox}+),
+                        Chrome (${opus.browserSupport.chrome}+),
+                        Safari (${opus.browserSupport.safari}+),
+                        and Opera (${opus.browserSupport.opera}+).`);
         $("#op-browser-version-msg .modal-body").html(modalMsg);
         browserName = browserName.toLowerCase();
 

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -552,6 +552,7 @@ var opus = {
             adjustProductInfoHeightDB();
             adjustDetailHeightDB();
             adjustHelpPanelHeightDB();
+            opus.checkBrowserSize();
         });
 
         // Add the navbar clicking behaviors, selecting which tab to view
@@ -727,6 +728,10 @@ var opus = {
     },
 
     checkBrowserVersion: function() {
+        /**
+         * Check supported browser versions and display a modal to
+         * inform the user if that version is not supprted.
+         */
         let browserName, browserVersion, matchObj;
         let userAgent = navigator.userAgent;
         if (userAgent.indexOf("Firefox") > -1) {
@@ -771,39 +776,49 @@ var opus = {
         switch (browserName) {
             case "Firefox":
                 if (parseFloat(browserVersion) < 66) {
-                    $("#op-browser-warning").modal("show");
+                    $("#op-browser-version-msg").modal("show");
                 }
                 break;
             case "Edge":
                 if (parseFloat(browserVersion) < 18) {
-                    $("#op-browser-warning").modal("show");
+                    $("#op-browser-version-msg").modal("show");
                 }
                 break;
             case "Opera":
                 if (parseFloat(browserVersion) < 58) {
-                    $("#op-browser-warning").modal("show");
+                    $("#op-browser-version-msg").modal("show");
                 }
                 break;
             case "Chrome":
                 if (parseFloat(browserVersion) < 74) {
-                    $("#op-browser-warning").modal("show");
+                    $("#op-browser-version-msg").modal("show");
                 }
                 break;
             case "Safari":
                 if (parseFloat(browserVersion) < 12.1) {
-                    $("#op-browser-warning").modal("show");
+                    $("#op-browser-version-msg").modal("show");
                 }
                 break;
             default:
-                $("#op-browser-warning").modal("show");
+                $("#op-browser-version-msg").modal("show");
+        }
+    },
+
+    checkBrowserSize: function() {
+        /**
+         * Check if browser width is less than 1280px. If so, display a
+         * modal to inform the user to resize the browser width.
+         */
+        if ($(window).width() < 1280) {
+            $("#op-browser-size-msg").modal("show");
+        } else {
+            $("#op-browser-size-msg").modal("hide");
         }
     }
 
 }; // end opus namespace
 
 $(document).ready(function() {
-    // check supported browser version and display a modal if version is
-    // not supprted. 
     opus.checkBrowserVersion();
     // Call normalized url api first
     // Rest of initialization prcoess will be performed afterwards

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -724,11 +724,87 @@ var opus = {
         };
 
         opus.triggerNavbarClick();
+    },
+
+    checkBrowserVersion: function() {
+        let browserName, browserVersion, matchObj;
+        let userAgent = navigator.userAgent;
+        if (userAgent.indexOf("Firefox") > -1) {
+            // Example output:
+            // Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:66.0)
+            // Gecko/20100101 Firefox/66.0
+            matchObj = userAgent.match(/Firefox\/(\d+.\d+)/);
+            browserName = "Firefox";
+            browserVersion = matchObj[1];
+        } else if (userAgent.indexOf("Edge") > -1 || userAgent.indexOf("Edg") > -1) {
+            // userAgent example output:
+            // Windows: Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko)
+            // Chrome/42.0.2311.135 Safari/537.36 Edge/12.10136
+            // Mac: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36
+            // (KHTML, like Gecko) Chrome/76.0.3800.0 Safari/537.36 Edg/76.0.167.0
+            matchObj = userAgent.match(/Edge\/(\d+.\d+)/) || userAgent.match(/Edg\/(\d+.\d+)/);
+            browserName = "Edge";
+            browserVersion = matchObj[1];
+        } else if (userAgent.indexOf("OPR") > -1) {
+            // userAgent example output:
+            // Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36
+            // (KHTML, like Gecko) Chrome/73.0.3683.103 Safari/537.36 OPR/60.0.3255.95
+            matchObj = userAgent.match(/OPR\/(\d+.\d+)/);
+            browserName = "Opera";
+            browserVersion = matchObj[1];
+        } else if (userAgent.indexOf("Chrome") > -1) {
+            // userAgent example output:
+            // Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36
+            // (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36
+            matchObj = userAgent.match(/Chrome\/(\d+.\d+)/);
+            browserName = "Chrome";
+            browserVersion = matchObj[1];
+        } else if (userAgent.indexOf("Version") > -1) {
+            // userAgent example output:
+            // Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/605.1.15
+            // (KHTML, like Gecko) Version/12.1 Safari/605.1.15
+            matchObj = userAgent.match(/Version\/(\d+.\d+)/);
+            browserName = "Safari";
+            browserVersion = matchObj[1];
+        }
+
+        switch (browserName) {
+            case "Firefox":
+                if (parseFloat(browserVersion) < 66) {
+                    $("#op-browser-warning").modal("show");
+                }
+                break;
+            case "Edge":
+                if (parseFloat(browserVersion) < 18) {
+                    $("#op-browser-warning").modal("show");
+                }
+                break;
+            case "Opera":
+                if (parseFloat(browserVersion) < 58) {
+                    $("#op-browser-warning").modal("show");
+                }
+                break;
+            case "Chrome":
+                if (parseFloat(browserVersion) < 74) {
+                    $("#op-browser-warning").modal("show");
+                }
+                break;
+            case "Safari":
+                if (parseFloat(browserVersion) < 12.1) {
+                    $("#op-browser-warning").modal("show");
+                }
+                break;
+            default:
+                $("#op-browser-warning").modal("show");
+        }
     }
 
 }; // end opus namespace
 
 $(document).ready(function() {
+    // check supported browser version and display a modal if version is
+    // not supprted. 
+    opus.checkBrowserVersion();
     // Call normalized url api first
     // Rest of initialization prcoess will be performed afterwards
     opus.normalizedURLAPICall();

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -29,6 +29,8 @@ var opus = {
 
     // Minimum height of any scrollbar
     minimumPSLength: 30,
+    // Fixed scrollbar length for gallery & table view
+    galleryAndTablePSLength: 100,
 
     qtypeRangeDefault: "any",
     qtypeStringDefault: "contains",

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -739,7 +739,7 @@ var opus = {
         opus.triggerNavbarClick();
     },
 
-    checkBrowserVersion: function() {
+    isBrowserSupported: function() {
         /**
          * Check supported browser versions and display a modal to
          * inform the user if that version is not supprted.
@@ -751,7 +751,7 @@ var opus = {
             // Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:66.0)
             // Gecko/20100101 Firefox/66.0
             matchObj = userAgent.match(/Firefox\/(\d+.\d+)/);
-            browserName = "firefox";
+            browserName = "Firefox";
             browserVersion = matchObj[1];
         } else if (userAgent.indexOf("Edge") > -1 || userAgent.indexOf("Edg") > -1) {
             // userAgent example output:
@@ -760,30 +760,37 @@ var opus = {
             // Mac: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36
             // (KHTML, like Gecko) Chrome/76.0.3800.0 Safari/537.36 Edg/76.0.167.0
             matchObj = userAgent.match(/Edge\/(\d+.\d+)/) || userAgent.match(/Edg\/(\d+.\d+)/);
-            browserName = "edge";
+            browserName = "Edge";
             browserVersion = matchObj[1];
         } else if (userAgent.indexOf("OPR") > -1) {
             // userAgent example output:
             // Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36
             // (KHTML, like Gecko) Chrome/73.0.3683.103 Safari/537.36 OPR/60.0.3255.95
             matchObj = userAgent.match(/OPR\/(\d+.\d+)/);
-            browserName = "opera";
+            browserName = "Opera";
             browserVersion = matchObj[1];
         } else if (userAgent.indexOf("Chrome") > -1) {
             // userAgent example output:
             // Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36
             // (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36
             matchObj = userAgent.match(/Chrome\/(\d+.\d+)/);
-            browserName = "chrome";
+            browserName = "Chrome";
             browserVersion = matchObj[1];
         } else if (userAgent.indexOf("Version") > -1) {
             // userAgent example output:
             // Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/605.1.15
             // (KHTML, like Gecko) Version/12.1 Safari/605.1.15
             matchObj = userAgent.match(/Version\/(\d+.\d+)/);
-            browserName = "safari";
+            browserName = "Safari";
             browserVersion = matchObj[1];
         }
+
+        let modalMsg = (`Your current browser is ${browserName} ${browserVersion}.
+                        Please update the browser. OPUS supports Firefox (66+),
+                        Chrome (74+), Safari (12.1+), Opera (58+), and Microsoft Edge
+                        (18+).`);
+        $("#op-browser-version-msg .modal-body").html(modalMsg);
+        browserName = browserName.toLowerCase();
 
         if (opus.browserSupport[browserName] === undefined) {
             $("#op-browser-version-msg").modal("show");
@@ -825,9 +832,9 @@ var opus = {
 }; // end opus namespace
 
 $(document).ready(function() {
-    if (opus.checkBrowserVersion()) {
-        opus.checkBrowserSize();
+    if (opus.isBrowserSupported()) {
         opus.checkCookies();
+        opus.checkBrowserSize();
         // Call normalized url api first
         // Rest of initialization prcoess will be performed afterwards
         opus.normalizedURLAPICall();

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -659,13 +659,17 @@ var opus = {
         $(document).on("keydown click", function(e) {
             if ((e.which || e.keyCode) == 27) {
                 // ESC key - close modals and help panel
-                $(".op-confirm-modal").modal('hide');
+                // But don't close "#op-browser-version-msg" and "#op-browser-size-msg"
+                if (!$(".op-confirm-modal").is("#op-browser-version-msg") &&
+                    !$(".op-confirm-modal").is("#op-browser-size-msg")) {
+                    $(".op-confirm-modal").modal("hide");
+                }
                 opus.hideHelpPanel();
             }
         });
 
         // Handle the Submit or Cancel buttons for the various confirm modals we can pop up
-        $(".op-confirm-modal").on("click", ".btn", function() {
+        $(".op-confirm-modal").on("click", ".btn", function(event) {
             let target = $(this).data("target");
             switch ($(this).attr("type")) {
                 case "submit":
@@ -680,7 +684,7 @@ var opus = {
                             o_cart.emptyCart();
                             break;
                     }
-                    $(".modal").modal("hide");
+                    $(`#${target}`).modal("hide");
                     break;
 
                 case "cancel":
@@ -825,7 +829,9 @@ var opus = {
          * Note: we will call __help/splash.html api in the future to
          * display the guide page. For now, we just show a modal.
          */
-        if ($.cookie("widgets") === undefined) {
+        if ($.cookie("visited") === undefined) {
+            // set the cookie for the first time user
+            $.cookie("visited", true, { expires: 28});  // days
             $("#op-guide").modal("show");
         }
     }

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -801,12 +801,24 @@ var opus = {
         } else {
             $("#op-browser-size-msg").modal("hide");
         }
-    }
+    },
 
+    checkCookies: function() {
+        /**
+         * Check widgets cookie to determine if the user is a first time
+         * visitor. If so, we display a guide page.
+         * Note: we will call __help/splash.html api in the future to
+         * display the guide page. For now, we just show a modal.
+         */
+        if ($.cookie("widgets") === undefined) {
+            $("#op-guide").modal("show");
+        }
+    }
 }; // end opus namespace
 
 $(document).ready(function() {
     opus.checkBrowserVersion();
+    opus.checkCookies();
     // Call normalized url api first
     // Rest of initialization prcoess will be performed afterwards
     opus.normalizedURLAPICall();

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -787,11 +787,14 @@ var opus = {
 
         if (opus.browserSupport[browserName] === undefined) {
             $("#op-browser-version-msg").modal("show");
+            return false;
         } else {
             if (parseFloat(browserVersion) < opus.browserSupport[browserName]) {
                 $("#op-browser-version-msg").modal("show");
+                return false;
             }
         }
+        return true;
     },
 
     checkBrowserSize: function() {
@@ -822,10 +825,11 @@ var opus = {
 }; // end opus namespace
 
 $(document).ready(function() {
-    opus.checkBrowserVersion();
-    opus.checkBrowserSize();
-    opus.checkCookies();
-    // Call normalized url api first
-    // Rest of initialization prcoess will be performed afterwards
-    opus.normalizedURLAPICall();
+    if (opus.checkBrowserVersion()) {
+        opus.checkBrowserSize();
+        opus.checkCookies();
+        // Call normalized url api first
+        // Rest of initialization prcoess will be performed afterwards
+        opus.normalizedURLAPICall();
+    }
 });

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -786,12 +786,11 @@ var opus = {
             browserVersion = "0.0";
         }
 
-        let browser = `${browserName} ${browserVersion}`;
+        let browser = `${browserName} ${browserVersion}. Please update your browser`;
         if (browserName === "unsupported") {
             browser = browserName;
         }
-        let modalMsg = (`Your current browser is ${browser}.
-                        Please update the browser. OPUS supports
+        let modalMsg = (`Your current browser is ${browser}. OPUS supports
                         Firefox (${opus.browserSupport.firefox}+),
                         Chrome (${opus.browserSupport.chrome}+),
                         Safari (${opus.browserSupport.safari}+),

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -659,17 +659,19 @@ var opus = {
         $(document).on("keydown click", function(e) {
             if ((e.which || e.keyCode) == 27) {
                 // ESC key - close modals and help panel
-                // But don't close "#op-browser-version-msg" and "#op-browser-size-msg"
-                if (!$(".op-confirm-modal").is("#op-browser-version-msg") &&
-                    !$(".op-confirm-modal").is("#op-browser-size-msg")) {
-                    $(".op-confirm-modal").modal("hide");
-                }
+                // Don't close "#op-browser-version-msg" and "#op-browser-size-msg"
+                $.each($(".op-confirm-modal"), function(idx, confirmModal) {
+                    if ($(confirmModal).data("action") === "esc") {
+                        $(confirmModal).modal("hide");
+                    }
+                });
+
                 opus.hideHelpPanel();
             }
         });
 
         // Handle the Submit or Cancel buttons for the various confirm modals we can pop up
-        $(".op-confirm-modal").on("click", ".btn", function(event) {
+        $(".op-confirm-modal").on("click", ".btn", function() {
             let target = $(this).data("target");
             switch ($(this).attr("type")) {
                 case "submit":
@@ -695,7 +697,7 @@ var opus = {
                             $(".op-user-msg").removeClass("op-show-msg");
                             break;
                     }
-                    $(".modal").modal("hide");
+                    $(`#${target}`).modal("hide");
                     break;
             }
         });
@@ -787,6 +789,9 @@ var opus = {
             matchObj = userAgent.match(/Version\/(\d+.\d+)/);
             browserName = "Safari";
             browserVersion = matchObj[1];
+        } else {
+            browserName = "unsupported";
+            browserVersion = "0.0";
         }
 
         let modalMsg = (`Your current browser is ${browserName} ${browserVersion}.

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -99,7 +99,7 @@ var opus = {
         "edge": 18,
         "safari": 12.1,
         "width": 1280,
-        "height": 275
+        "height": 720
     },
 
     //------------------------------------------------------------------------------------
@@ -814,6 +814,10 @@ var opus = {
          * than 275px. If so, display a modal to inform the user to
          * resize the browser size.
          */
+        let modalMsg = (`Please resize your browser. OPUS works best with a browser
+                        size of at least ${opus.browserSupport.width} pixels by
+                        ${opus.browserSupport.height} pixels.`);
+        $("#op-browser-size-msg .modal-body").html(modalMsg);
         if ($(window).width() < opus.browserSupport.width ||
             $(window).height() < opus.browserSupport.height) {
             $("#op-browser-size-msg").modal("show");
@@ -831,7 +835,7 @@ var opus = {
          */
         if ($.cookie("visited") === undefined) {
             // set the cookie for the first time user
-            $.cookie("visited", true, { expires: 28});  // days
+            $.cookie("visited", true);
             $("#op-guide").modal("show");
         }
     }

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -89,6 +89,15 @@ var opus = {
     // updates things
     mainTimer: false,
 
+    // store the browser version and width supported by OPUS
+    browserSupport: {
+        "firefox": 66,
+        "chrome": 74,
+        "opera": 58,
+        "edge": 18,
+        "safari": 12.1,
+        "width": 1280,
+    },
 
     //------------------------------------------------------------------------------------
     // Debugging support
@@ -739,68 +748,46 @@ var opus = {
             // Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:66.0)
             // Gecko/20100101 Firefox/66.0
             matchObj = userAgent.match(/Firefox\/(\d+.\d+)/);
-            browserName = "Firefox";
+            browserName = "firefox";
             browserVersion = matchObj[1];
         } else if (userAgent.indexOf("Edge") > -1 || userAgent.indexOf("Edg") > -1) {
             // userAgent example output:
-            // Windows: Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko)
-            // Chrome/42.0.2311.135 Safari/537.36 Edge/12.10136
+            // Windows: Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36
+            // (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10136
             // Mac: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36
             // (KHTML, like Gecko) Chrome/76.0.3800.0 Safari/537.36 Edg/76.0.167.0
             matchObj = userAgent.match(/Edge\/(\d+.\d+)/) || userAgent.match(/Edg\/(\d+.\d+)/);
-            browserName = "Edge";
+            browserName = "edge";
             browserVersion = matchObj[1];
         } else if (userAgent.indexOf("OPR") > -1) {
             // userAgent example output:
             // Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36
             // (KHTML, like Gecko) Chrome/73.0.3683.103 Safari/537.36 OPR/60.0.3255.95
             matchObj = userAgent.match(/OPR\/(\d+.\d+)/);
-            browserName = "Opera";
+            browserName = "opera";
             browserVersion = matchObj[1];
         } else if (userAgent.indexOf("Chrome") > -1) {
             // userAgent example output:
             // Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36
             // (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36
             matchObj = userAgent.match(/Chrome\/(\d+.\d+)/);
-            browserName = "Chrome";
+            browserName = "chrome";
             browserVersion = matchObj[1];
         } else if (userAgent.indexOf("Version") > -1) {
             // userAgent example output:
             // Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/605.1.15
             // (KHTML, like Gecko) Version/12.1 Safari/605.1.15
             matchObj = userAgent.match(/Version\/(\d+.\d+)/);
-            browserName = "Safari";
+            browserName = "safari";
             browserVersion = matchObj[1];
         }
 
-        switch (browserName) {
-            case "Firefox":
-                if (parseFloat(browserVersion) < 66) {
-                    $("#op-browser-version-msg").modal("show");
-                }
-                break;
-            case "Edge":
-                if (parseFloat(browserVersion) < 18) {
-                    $("#op-browser-version-msg").modal("show");
-                }
-                break;
-            case "Opera":
-                if (parseFloat(browserVersion) < 58) {
-                    $("#op-browser-version-msg").modal("show");
-                }
-                break;
-            case "Chrome":
-                if (parseFloat(browserVersion) < 74) {
-                    $("#op-browser-version-msg").modal("show");
-                }
-                break;
-            case "Safari":
-                if (parseFloat(browserVersion) < 12.1) {
-                    $("#op-browser-version-msg").modal("show");
-                }
-                break;
-            default:
+        if (opus.browserSupport[browserName] === undefined) {
+            $("#op-browser-version-msg").modal("show");
+        } else {
+            if (parseFloat(browserVersion) < opus.browserSupport[browserName]) {
                 $("#op-browser-version-msg").modal("show");
+            }
         }
     },
 
@@ -809,7 +796,7 @@ var opus = {
          * Check if browser width is less than 1280px. If so, display a
          * modal to inform the user to resize the browser width.
          */
-        if ($(window).width() < 1280) {
+        if ($(window).width() < opus.browserSupport.width) {
             $("#op-browser-size-msg").modal("show");
         } else {
             $("#op-browser-size-msg").modal("hide");


### PR DESCRIPTION
# Update:
- A095:
  - If user's browser is older than the following version: Firefox (66+), Chrome (74+), Safari (12.1+), Opera (58+), and Microsoft Edge (18+), we display a modal to inform the user to update the browser version. The modal is not closable, so the user cannot proceed to use OPUS until he/she updates the browser version.
- A098:
  - If browser window width is less than 1280px, we display a modal to inform the user to resize it. The modal will not go away and user cannot click anywhere in OPUS until the browser width is resized to some values larger than 1280px.
- A096:
  - If the widget cookies is undefined, we know the user is a first time visitor. We display a welcome modal for now, but will update to display the real guide page in the future.