### PR TITLE
C103 fix cart flushing browse data and clean up code (#3)

### DIFF
--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -328,7 +328,6 @@ var o_browse = {
             let isDescending = true;
             let orderIndicator = $(this).find("span:last");
             let pillOrderIndicator = $(`.sort-contents span[data-slug="${orderBy}"] .flip-sort`);
-            o_browse.galleryBegun = false;
 
             if (orderIndicator.data("sort") === "sort-asc") {
                 // currently ascending, change to descending order
@@ -357,7 +356,6 @@ var o_browse = {
             $(".op-page-loading-status > .loader").show();
             let slug = $(this).parent().attr("data-slug");
             let descending = $(this).parent().attr("data-descending");
-            o_browse.galleryBegun = false;
 
             if (descending == "true") {
                 slug = "-"+slug;
@@ -387,7 +385,6 @@ var o_browse = {
             let descending = $(this).parent().attr("data-descending");
             let headerOrderIndicator = $(`.op-data-table-view th a[data-slug="${slug}"]`).find("span:last");
             let pillOrderIndicator = $(this);
-            o_browse.galleryBegun = false;
 
             let new_slug = slug;
             if (descending == "true") {

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -552,13 +552,7 @@ var o_browse = {
     },
 
     renderSortedDataFromBeginning: function() {
-        opus.prefs.startobs = 1; // reset startobs to 1 when col ordering changes
-        opus.prefs.cart_startobs = 1;
-
-        o_cart.reloadObservationData = true;  // forces redraw of cart tab
-        o_cart.observationData = {};
-        o_browse.reloadObservationData = true;  // forces redraw of browse tab
-        o_browse.observationData = {};
+        o_browse.clearObservationData();
         o_browse.loadData(opus.prefs.view);
     },
 
@@ -921,7 +915,8 @@ var o_browse = {
             // update the data table w/the new columns
             if (!o_utils.areObjectsEqual(opus.prefs.cols, currentSelectedMetadata)) {
                 let tab = opus.getViewTab();
-                o_browse.resetData();
+                o_browse.clearObservationData();
+                o_hash.updateHash(); // This makes the changes visible to the user
                 o_browse.initTable(tab, opus.colLabels, opus.colLabelsNoUnits);
                 o_browse.loadData(opus.prefs.view);
             } else {
@@ -1544,7 +1539,7 @@ var o_browse = {
 
         startObs = (startObs === undefined ? opus.prefs[startObsLabel] : startObs);
 
-        if (viewNamespace.reloadObservationData) {
+        if (!viewNamespace.reloadObservationData) {
             // if the request is a block far away from current page cache, flush the cache and start over
             let elem = $(`${tab} [data-obs="${startObs}"]`);
             let lastObs = $(`${tab} [data-obs]`).last().data("obs");
@@ -1661,15 +1656,10 @@ var o_browse = {
         o_browse.loadData(opus.prefs.view, startObs);
     },
 
-<<<<<<< HEAD
-    countGalleryImages: function(view) {
-        let viewNamespace = opus.getViewNamespace(view);
-=======
     countTableRows: function(view) {
         let tab = opus.getViewTab(view);
         let height = o_browse.calculateGalleryHeight(view);
         let trCount = 1;
->>>>>>> new_ui
 
         if ($(`${tab} .op-data-table tbody tr[data-obs]`).length > 0) {
             trCount = o_utils.floor((height-$("th").outerHeight())/$(`${tab} .op-data-table tbody tr[data-obs]`).outerHeight());
@@ -1680,6 +1670,7 @@ var o_browse = {
 
     countGalleryImages: function(view) {
         let tab = opus.getViewTab(view);
+        let viewNamespace = opus.getViewNamespace(view);
         let width = o_browse.calculateGalleryWidth(view);
         let height = o_browse.calculateGalleryHeight(view);
 
@@ -1882,14 +1873,12 @@ var o_browse = {
         o_browse.metadataboxHtml(opusId);
     },
 
-
-    resetData: function() {
-        $(".op-data-table > tbody").empty();  // yes all namespaces
-        $(".gallery").empty();
+    clearObservationData: function() {
+        opus.prefs.startobs = 1; // reset startobs to 1 when data is flushed
+        opus.prefs.cart_startobs = 1;
         o_cart.reloadObservationData = true;  // forces redraw of cart tab
         o_cart.observationData = {};
         o_browse.reloadObservationData = true;  // forces redraw of browse tab
         o_browse.observationData = {};
-        o_hash.updateHash();
     },
 };

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -557,8 +557,9 @@ var o_browse = {
         opus.prefs.cart_startobs = 1;
 
         o_browse.galleryBegun = false;     // so that we redraw from the beginning
+        o_cart.cartChange = true;
         o_browse.galleryData = {};
-        o_browse.loadData(opus.prefs.view, 1);
+        o_browse.loadData(opus.prefs.view);
     },
 
     // check if we need infiniteScroll to load next page when there is no more prefected data

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -3,9 +3,8 @@
 /* jshint latedef: true, leanswitch: true, noarg: true, nocomma: true */
 /* jshint nonbsp: true, nonew: true */
 /* jshint varstmt: true */
-/* globals $, _, PerfectScrollbar */
+/* globals $, PerfectScrollbar */
 /* globals o_cart, o_hash, o_menu, o_utils, opus */
-/* globals DEFAULT_COLUMNS */
 
 // font awesome icon class
 const pillSortUpArrow = "fas fa-arrow-circle-up";
@@ -560,7 +559,6 @@ var o_browse = {
         if (opusId === "") {
             return;
         }
-        let startObsLabel = o_browse.getStartObsLabel();
         let tab = opus.getViewTab();
         let contentsView = o_browse.getScrollContainerClass();
         o_browse.metadataDetailOpusId = opusId;
@@ -577,7 +575,6 @@ var o_browse = {
                 let galleryBoundingRect = opus.getViewNamespace().galleryBoundingRect;
 
                 let startObs = $(`${tab} ${contentsView}`).data("infiniteScroll").options.obsNum;
-                let rowCount = galleryBoundingRect.x;
 
                 // if the binoculars have scrolled up, then reset the screen to the top;
                 // if the binoculars have scrolled down off the screen, then scroll up just until the they are visible in bottom row
@@ -655,7 +652,6 @@ var o_browse = {
     // find the first displayed observation index & id in the upper left corner
     updateSliderHandle: function(browserResized=false) {
         let tab = opus.getViewTab();
-        let viewNamespace = opus.getViewNamespace();
         let selector = (o_browse.isGalleryView() ?
                         `${tab} .gallery .thumbnail-container` :
                         `${tab} .op-data-table tbody tr`);
@@ -1655,7 +1651,6 @@ var o_browse = {
     },
 
     countGalleryImages: function(view) {
-        let tab = opus.getViewTab(view);
         let viewNamespace = opus.getViewNamespace(view);
 
         let width = o_browse.calculateGalleryWidth(view);

--- a/opus/application/static_media/js/cart.js
+++ b/opus/application/static_media/js/cart.js
@@ -10,7 +10,10 @@
 var o_cart = {
 /* jshint varstmt: true */
     // cart
-    cartChange: true, // cart has changed since last load of cart_tab
+    reloadObservationData: true, // start over by reloading all data
+    observationData: {},  // holds observation column data
+    cachedObservationFactor: 4,     // this is the factor times the screen size to determine cache size
+    maxCachedObservations: 1000,    // max number of observations to store in cache, will be updated based on screen size
     lastRequestNo: 0,
     downloadInProcess: false,
     cartCount: 0,
@@ -181,7 +184,7 @@ var o_cart = {
     activateCartTab: function() {
         let view = opus.prefs.view;
         o_browse.renderMetadataSelector();   // just do this in background so there's no delay when we want it...
-        if (o_cart.cartChange) {
+        if (o_cart.reloadObservationData) {
             let zippedFiles_html = $(".zippedFiles", "#cart").html();
 
             // don't forget to remove existing stuff before append
@@ -219,7 +222,8 @@ var o_cart = {
         // change indicator to zero and let the server know:
         $.getJSON("/opus/__cart/reset.json", function(data) {
             $("#op-cart-count").html("0");
-            o_cart.cartChange = true;
+            o_cart.reloadObservationData = true;
+            o_cart.observationData = {};
             $("#cart .navbar").hide();
             $("#cart .sort-order-container").hide();
             if (!returnToSearch) {
@@ -305,7 +309,15 @@ var o_cart = {
         // This is used when we want to do a lot of cart operations in a row and only update
         // at the end
         let view = opus.prefs.view;
-        o_cart.cartChange = true;
+        o_cart.reloadObservationData = true;
+        // Note we intentionally don't set o_cart.observationData = {} here.
+        // This is because we allow users to add/remove while on the cart page
+        // without updating the window. If we erased the cached data, then
+        // the user would be unable to click on an obs they had removed and
+        // see the metadata dialog. The penalty we pay for this is there will
+        // be old cruft in the cache table that won't go away easily until there's
+        // a hard flush like a page reload. Yes, manageObservationCache will try,
+        // but if the browser has been resized it may not get it all.
 
         let url = "/opus/__cart/" + action + ".json?";
         switch (action) {

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -183,7 +183,7 @@ var opus = {
             } else {
                 // Otherwise, this was just a user change to one of the search criteria inside
                 // the UI, so erase the previous data and reload the results.
-                o_browse.resetData();
+                o_browse.clearObservationData();
             }
         }
 
@@ -422,7 +422,7 @@ var opus = {
         // Reset the search query and return to the Search tab
         opus.selections = {};
         opus.extras = {};
-        o_browse.resetData();
+        o_browse.clearObservationData();
         opus.changeTab('search');
 
         // Enable or disable the 'Reset Search' and 'Reset Search and Metadata' buttons


### PR DESCRIPTION
- Change galleryData to observationData and make copies in browse and cart
- Replace galleryBegun and cartChanged with reloadObservationData and make copies in browse and cart
- Make separate cache sizes for browse and cart
- Fix a couple of other bugs along the way

This is based off new_ui