### PR TITLE
Various bug fixes

### DIFF
--- a/opus/application/apps/results/templates/results/detail_metadata_internal.html
+++ b/opus/application/apps/results/templates/results/detail_metadata_internal.html
@@ -1,18 +1,20 @@
 {% for cat, d in data.items %}
-    <ul id="detail__data_{{ cat.lower.split|join:"_" }}" class="op-detail-category-metadata">
+    <ul id="detail__data_{{ cat.lower.split|join:"_" }}" class="op-detail-list">
         {% for param, val in d.items %}
-            <li>
+            <li class="op-detail-entry">
                 {% for name, param_info in all_info.items %}
                     {% if name == param %}
                         {% if param_info.get_tooltip_results %}
-                            <i class="fa fa-info-circle" data-toggle="tooltip"
-                                title="{{ param_info.get_tooltip_results|striptags }}"></i>
+                            <i class="fa fa-info-circle op-detail-entry-icon" data-toggle="tooltip"
+                                title="{{ param_info.get_tooltip_results|striptags }}"></i>&nbsp;
                         {% endif %}
-                        {% if param_info.get_units %}
-                            {{ param_info.label_results }} {{ param_info.get_units }}: {{ val }}
-                        {% else %}
-                            {{ param_info.label_results }}: {{ val }}
-                        {% endif %}
+                        <div>
+                            {% if param_info.get_units %}
+                                {{ param_info.label_results }} {{ param_info.get_units }}: {{ val }}
+                            {% else %}
+                                {{ param_info.label_results }}: {{ val }}
+                            {% endif %}
+                        </div>
                     {% endif %}
                 {% endfor %}
             </li>

--- a/opus/application/apps/results/templates/results/detail_metadata_slugs_internal.html
+++ b/opus/application/apps/results/templates/results/detail_metadata_slugs_internal.html
@@ -1,12 +1,14 @@
-<ul class="op-detail-category-metadata">
+<ul class="op-detail-list">
     {% for entry in data %}
-        <li>
+        <li class="op-detail-entry">
             {% for param, values in entry.items %}
                 {% if values.1.get_tooltip_results %}
-                    <i class="fa fa-info-circle" data-toggle="tooltip"
-                        title="{{ values.1.get_tooltip_results|striptags }}"></i>
+                    <i class="fa fa-info-circle op-detail-entry-icon" data-toggle="tooltip"
+                        title="{{ values.1.get_tooltip_results|striptags }}"></i>&nbsp;
                 {% endif %}
-                {{ param }}: {{ values.0 }}
+                <div>
+                    {{ param }}: {{ values.0 }}
+                </div>
             {% endfor %}
         </li>
     {% endfor %}

--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -229,7 +229,7 @@
                 </div>
                 <div id="op-cart-download-panel" class="card w-75">
                     <div class="card-header align-items-center h-auto pb-0 bg-secondary">
-                        <h3 class='op-header-text'></h3>
+                        <h3 class="op-header-text"></h3>
                         <a class="close" aria-label="Close"><i class="far fa-times-circle fa-lg"></i></a>
                      </div>
                     <div class="card-body bg-light">
@@ -416,7 +416,7 @@
         <div class="card-header align-items-center h-auto pb-0 bg-secondary">
             <h3 class='op-header-text'></h3>
             <a class="close" aria-label="Close"><i class="far fa-times-circle fa-lg"></i></a>
-         </div>
+        </div>
         <div class="card-body bg-light">
             <div class="op-card-contents">
                 Loading... please wait.

--- a/opus/application/apps/ui/templates/ui/detail.html
+++ b/opus/application/apps/ui/templates/ui/detail.html
@@ -10,12 +10,12 @@
                     <p>Download zipped <a data-action="downloadData" href="#" download>data archive</a> or <a data-action="downloadURL" href="#" download>URL archive</a> for this observation (all products, current version only).</a></p>
                     <p>Click on any "Index" type to see the entry for this observation in that table.</p>
                     {% for version, version_items in products.items %}
-                        <ul class="op-detail-product-list">
+                        <ul class="op-detail-list">
                             <h4>Version: {{ version }}</h4>
                             {% for product_type, product_type_info in version_items.items %}
-                                <li class="op-detail-product-entry">
+                                <li class="op-detail-entry">
                                     {% if product_type_info.tooltip %}
-                                        <i class="fa fa-info-circle op-detail-product-entry-icon" title="{{ product_type_info.tooltip }}"></i>&nbsp;
+                                        <i class="fa fa-info-circle op-detail-entry-icon" title="{{ product_type_info.tooltip }}"></i>&nbsp;
                                     {% endif %}
                                     <div>
                                         {% if product_type_info.product_link %}

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -1374,18 +1374,18 @@ is wide enough */
 /* For the individual metadata categories - removes list bullet and
    makes indent look like it did with bullet. Same for the product
    type list. */
-.op-detail-category-metadata, .op-detail-product-list {
+.op-detail-list {
     list-style: none;
     padding-left: 22px;
 }
 
 /* For the product type list at the top of the detail page -
    make each line wrap with the name of the product, not the tooltip. */
-.op-detail-product-entry {
+.op-detail-entry {
     display: flex;
 }
 
-.op-detail-product-entry-icon {
+.op-detail-entry-icon {
     line-height: 21px;
 }
 

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -270,16 +270,16 @@ ul.searchMenu {
 }
 
 /* Remove hyperlink underlines from chevron and X on widget title */
-.card-header a {
+.widget .card-header a {
     text-decoration: none;
 }
 
 /* Rotate the chevron on a widget header to indicate its open/closed status */
-.card-header .icon-action {
+.widget .card-header .icon-action {
     transition: .3s;
 }
 
-.card-header .collapsed .icon-action {
+.widget .card-header .collapsed .icon-action {
     -ms-transform: rotate(-90deg); /* IE 9 */
     -ms-transform-origin: 80% 43%; /* IE 9 */
     -webkit-transform: rotate(-90deg); /* Safari 3-8 */
@@ -688,18 +688,19 @@ th.sticky-header {
 }
 
 @media (min-width: 1200px) {
+    /* This covers the metadata selector and slideshow */
     .modal-lg {
         max-width: 1100px !important;
         max-height: 1100px !important;
     }
-    img.preview {
+    img.op-slideshow-image-preview {
         max-width: 600px !important;
         max-height: 600px !important;
     }
 }
 
-/* make image preview in the modal strechable when screen is resized */
-img.preview {
+/* make image preview in the modal stretchable when screen is resized */
+img.op-slideshow-image-preview {
     /* make image responsive to horizontal shrinking */
     max-width: 100% !important;
     /* make image responsive to vertical shrinking */

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -1518,7 +1518,7 @@ footer {
     transition: all 0.5s ease-in-out;
 }
 
-/* display .overlay when it has the .active class */
+/* display .op-overlay when it has the .active class */
 .op-overlay.active {
     display: block;
     opacity: 1;

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -553,7 +553,7 @@ var o_browse = {
             // The browse and cart sort pills will always be identical so we just get the one from browse
             // here. If we don't specify one, we end up getting two elements.
             let label = ($(`.op-data-table-view th a[data-slug="${orderEntrySlug}"]`).data("label") ||
-                         $(`#browse .sort-contents span[data-slug="${orderEntrySlug}"] .flip-sort`).first().text());
+                         $(`#browse .sort-contents span[data-slug="${orderEntrySlug}"] .flip-sort`).text());
             listHtml += "<li class='list-inline-item'>";
             listHtml += `<span class='badge badge-pill badge-light' data-slug="${orderEntrySlug}" data-descending="${isPillOrderDesc}">`;
             if (orderEntrySlug !== "opusid") {

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -549,9 +549,11 @@ var o_browse = {
             let pillOrderArrow = orderEntry[0] === "-" ? pillSortUpArrow : pillSortDownArrow;
             let orderEntrySlug = orderEntry[0] === "-" ? orderEntry.slice(1) : orderEntry;
 
-            // retrieve label from either displayed header's data-label attribute or displayed pill's text
-            let label = $(`.op-data-table-view th a[data-slug="${orderEntrySlug}"]`).data("label") || $(`.sort-contents span[data-slug="${orderEntrySlug}"] .flip-sort`).text();
-
+            // Retrieve label from either displayed header's data-label attribute or displayed pill's text
+            // The browse and cart sort pills will always be identical so we just get the one from browse
+            // here. If we don't specify one, we end up getting two elements.
+            let label = ($(`.op-data-table-view th a[data-slug="${orderEntrySlug}"]`).data("label") ||
+                         $(`#browse .sort-contents span[data-slug="${orderEntrySlug}"] .flip-sort`).first().text());
             listHtml += "<li class='list-inline-item'>";
             listHtml += `<span class='badge badge-pill badge-light' data-slug="${orderEntrySlug}" data-descending="${isPillOrderDesc}">`;
             if (orderEntrySlug !== "opusid") {

--- a/opus/application/static_media/js/cart.js
+++ b/opus/application/static_media/js/cart.js
@@ -97,13 +97,13 @@ var o_cart = {
             o_cart.displayCartLeftPane();
             $("#op-cart-download-panel").toggle("slide", {direction:"left"}, function() {
                 $(".op-overlay").addClass("active");
+                $("#op-cart-download-panel").addClass("active");
             });
         });
 
         // Clicking on the "X" in the corner of the download options panel
         $("#op-cart-download-panel .close, .op-overlay").on("click", function() {
-            $("#op-cart-download-panel").toggle("slide", {direction: "left"});
-            $(".op-overlay").removeClass("active");
+            opus.hideHelpAndCartPanels();
             return false;
         });
     },
@@ -174,7 +174,7 @@ var o_cart = {
         let cartSummaryHeight = $("#cart_summary").height();
         let cardHeaderHeight = $("#op-cart-download-panel .card-header").outerHeight();
         $("#cart .gallery-contents").height(containerHeight);
-        
+
         if ($(window).width() < cartLeftPaneThreshold) {
             downloadOptionsHeight = downloadOptionsHeight - cardHeaderHeight;
         }

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -83,9 +83,6 @@ var opus = {
     widgetElementsDrawn: [], // the element is drawn but the widget might not be fetched yet
     menuState: {"cats": ["obs_general"]},
 
-    // Help panel
-    helpPanelOpen: false,
-
     // these are for the process that detects there was a change in the selection criteria and
     // updates things
     mainTimer: false,
@@ -384,15 +381,20 @@ var opus = {
 
     },
 
-    hideHelpPanel: function() {
+    hideHelpAndCartPanels: function() {
         /**
-         * If the "Help" panel is currently open, close it.
+         * If the "Help" panel or cart download panel is currently open, close it.
          */
-        if (opus.helpPanelOpen) {
+        if ($("#op-help-panel").hasClass("active")) {
             $("#op-help-panel").toggle("slide", {direction: "right"});
+            $("#op-help-panel").removeClass("active");
             $(".op-overlay").removeClass("active");
         }
-        opus.helpPanelOpen = false;
+        if ($("#op-cart-download-panel").hasClass("active")) {
+            $("#op-cart-download-panel").toggle("slide", {direction: "left"});
+            $("#op-cart-download-panel").removeClass("active");
+            $(".op-overlay").removeClass("active");
+        }
     },
 
     adjustHelpPanelHeight: function() {
@@ -600,7 +602,7 @@ var opus = {
 
         // Clicking on the "X" in the corner of the help pane
         $("#op-help-panel .close, .op-overlay").on("click", function() {
-            opus.hideHelpPanel();
+            opus.hideHelpAndCartPanels();
             return false;
         });
 
@@ -625,7 +627,7 @@ var opus = {
                     }
                 });
 
-                opus.hideHelpPanel();
+                opus.hideHelpAndCartPanels();
             }
         });
 
@@ -714,7 +716,8 @@ var opus = {
             });
         }
         $("#op-help-panel").toggle("slide", {direction:"right"}, function() {
-            $(".op-overlay").addClass("active");
+            $(".op-overlay").addClass("active"); // This shows the panel
+            $("#op-help-panel").addClass("active"); // This is for keeping track of what's open
         });
         $.ajax({
             url: url,
@@ -722,7 +725,6 @@ var opus = {
             success: function(page) {
                 $("#op-help-panel .loader").hide();
                 $("#op-help-panel .op-card-contents").html(page);
-                opus.helpPanelOpen = true;
             }
         });
     },


### PR DESCRIPTION
- I broke parts of the metadata selector when I changed the location of the tooltips in the previous pull. Discard changes didn't work, among other things. I fixed the problems, eliminated redundant code, and did general cleanup.
- I improved tooltips in many places, including giving instructions on how to use ctrl+click, etc.
- There was an obscure bug where if you were sorting on a field that was no longer in your selected metadata (and thus you couldn't get the sort label from the table), when you clicked on a sort pill or table header it would momentarily double-up the text in each sort pill. This was because there are two .sort-container now, one for browse and one for cart, and when we retrieved the label from the existing pill we got two copies. Fixed by just taking the element from #browse, since they will always be identical.
- Unified handling of the help pane and cart overlay pane. This means that ESC will now close whichever one is open. To do this I got rid of the opus.helpPanelOpen and instead store an "active" class on the appropriate #container. Note there are now *two* active classes - one on the op-overlay div for the CSS to enable its viewing, and one on the div for the appropriate pane. The latter is so we can tell which pane is open to get the slide direction right. I could've added a second global variable instead but this seemed cleaner.
- I fixed an obscure bug on the detail page where text wrap wasn't as pretty as it could be for very narrow browsers. The metadata now wraps like the filenames in the product type list do.
- I renamed various classes and did other cosmetic cleanup. There's much more than needs to be done.
