### PR TITLE
Metadata selector fixes and other general cleanup

### DIFF
--- a/opus/application/apps/cart/templates/cart/cart.html
+++ b/opus/application/apps/cart/templates/cart/cart.html
@@ -27,7 +27,7 @@
                                 {% endif %}
                             >
                                 {% if product_info.tooltip %}
-                                    &nbsp;&nbsp;<i class="fa fa-info-circle" title="{{ product_info.tooltip }}"></i>
+                                    &nbsp;&nbsp;<i class="fas fa-info-circle" title="{{ product_info.tooltip }}"></i>
                                 {% endif %}
                                 {{ product_info.product_type }}
                                 <!-- ({{ product_info.product_count }}, {{ product_info.download_count }}, {{ product_info.download_size_pretty }}) -->

--- a/opus/application/apps/help/faq.yaml
+++ b/opus/application/apps/help/faq.yaml
@@ -100,7 +100,7 @@ General Questions:
             <li>On the Cart tab, you now have the ability to change the sort
             order of the displayed thumbnails or table rows.</li>
             <li>On the Cart tab, the available products include tooltips
-            (<i class="fa fa-info-circle"></i>) that give details about each
+            (<i class="fas fa-info-circle"></i>) that give details about each
             file type.</li>
             </ul>
 

--- a/opus/application/apps/results/templates/results/detail_metadata_internal.html
+++ b/opus/application/apps/results/templates/results/detail_metadata_internal.html
@@ -5,7 +5,7 @@
                 {% for name, param_info in all_info.items %}
                     {% if name == param %}
                         {% if param_info.get_tooltip_results %}
-                            <i class="fa fa-info-circle op-detail-entry-icon" data-toggle="tooltip"
+                            <i class="fas fa-info-circle op-detail-entry-icon" data-toggle="tooltip"
                                 title="{{ param_info.get_tooltip_results|striptags }}"></i>&nbsp;
                         {% endif %}
                         <div>

--- a/opus/application/apps/results/templates/results/detail_metadata_slugs_internal.html
+++ b/opus/application/apps/results/templates/results/detail_metadata_slugs_internal.html
@@ -3,7 +3,7 @@
         <li class="op-detail-entry">
             {% for param, values in entry.items %}
                 {% if values.1.get_tooltip_results %}
-                    <i class="fa fa-info-circle op-detail-entry-icon" data-toggle="tooltip"
+                    <i class="fas fa-info-circle op-detail-entry-icon" data-toggle="tooltip"
                         title="{{ values.1.get_tooltip_results|striptags }}"></i>&nbsp;
                 {% endif %}
                 <div>

--- a/opus/application/apps/ui/templates/ui/detail.html
+++ b/opus/application/apps/ui/templates/ui/detail.html
@@ -15,7 +15,7 @@
                             {% for product_type, product_type_info in version_items.items %}
                                 <li class="op-detail-entry">
                                     {% if product_type_info.tooltip %}
-                                        <i class="fa fa-info-circle op-detail-entry-icon" title="{{ product_type_info.tooltip }}"></i>&nbsp;
+                                        <i class="fas fa-info-circle op-detail-entry-icon" title="{{ product_type_info.tooltip }}"></i>&nbsp;
                                     {% endif %}
                                     <div>
                                         {% if product_type_info.product_link %}

--- a/opus/application/apps/ui/templates/ui/menu.html
+++ b/opus/application/apps/ui/templates/ui/menu.html
@@ -4,18 +4,18 @@
             <li class="list-group-item py-2">
                 {#  Each div has a top-level catgory  #}
                 {% if div.table_name == 'obs_general' %}
-                    <a href="#submenu-{{ div.table_name }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle" data-cat="{{ div.table_name }}">
+                    <a href="#{{ which }}-submenu-{{ div.table_name }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle" data-cat="{{ div.table_name }}">
                 {% else %}
-                    <a href="#submenu-{{ div.table_name }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle collapsed" data-cat="{{ div.table_name }}">
+                    <a href="#{{ which }}-submenu-{{ div.table_name }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle collapsed" data-cat="{{ div.table_name }}">
                 {% endif %}
                     <span class="title">{{ div.label }}</span>
                 </a>
 
                 {% if div.table_name == 'obs_general' %}
                     <span class="op-menu-text spinner">&nbsp;</span>
-                    <ul class="list-group list-group-flush submenu collapse show" id="submenu-{{ div.table_name }}">
+                    <ul class="list-group list-group-flush submenu collapse show" id="{{ which }}-submenu-{{ div.table_name }}">
                 {% else %}
-                    <ul class="list-group list-group-flush submenu collapse" id="submenu-{{ div.table_name }}">
+                    <ul class="list-group list-group-flush submenu collapse" id="{{ which }}-submenu-{{ div.table_name }}">
                 {% endif %}
 
                 <!-- all div labels have level 2 submenu to list params-->
@@ -30,21 +30,21 @@
                             {#  this div has sub_headings, level-3 menu sections... start sub_heading loop  #}
                             {% for sub_head,params in info.data.items %}
                                 <li class="list-group-item py-0 pl-0">
-                                    <a href="#submenu-{{ sub_head|slugify }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle collapsed" data-cat="{{ sub_head|slugify }}">
+                                    <a href="#{{ which }}-submenu-{{ sub_head|slugify }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle collapsed" data-cat="{{ sub_head|slugify }}">
                                         <span class="menu-text title">{{ sub_head }}</span>
                                     </a>
-                                    <ul class="list-group list-group-flush submenu collapse" id="submenu-{{ sub_head|slugify }}">
+                                    <ul class="list-group list-group-flush submenu collapse" id="{{ which }}-submenu-{{ sub_head|slugify }}">
                                         {% for p in params %}
                                             {% if p.cat_name == sub_head.slugify %}
                                                 <li class="list-group-item py-0 pl-0">
                                                     <a data-label="
-                                                        {% if menu.data.labels_view == 'results' %}
+                                                        {% if menu.data.labels_view == 'selector' %}
                                                             {{ p.label_results }}
                                                         {% else %}
                                                             {{ p.label }}
                                                         {% endif %}
                                                         " data-qualifiedlabel="
-                                                        {% if menu.data.labels_view == 'results' %}
+                                                        {% if menu.data.labels_view == 'selector' %}
                                                             {{ p.body_qualified_label_results }}
                                                         {% else %}
                                                             {{ p.body_qualified_label }}
@@ -53,7 +53,7 @@
                                                         <span class="op-search-param-checkmark">
                                                             <i class="fa fa-check"></i>
                                                         </span>
-                                                        {% if menu.data.labels_view == 'results' %}
+                                                        {% if menu.data.labels_view == 'selector' %}
                                                             {% if p.get_tooltip_results %}
                                                                 <i class="fa fa-info-circle" title="{{ p.get_tooltip_results }}"></i>
                                                             {% endif %}
@@ -78,13 +78,13 @@
                             {% for p in info.data %}
                                 <li class="list-group-item py-0 pl-0">
                                     <a data-label="
-                                        {% if menu.data.labels_view == 'results' %}
+                                        {% if menu.data.labels_view == 'selector' %}
                                             {{ p.label_results }}
                                         {% else %}
                                             {{ p.label }}
                                         {% endif %}
                                       " data-qualifiedlabel="
-                                        {% if menu.data.labels_view == 'results' %}
+                                        {% if menu.data.labels_view == 'selector' %}
                                             {{ p.body_qualified_label_results }}
                                         {% else %}
                                             {{ p.body_qualified_label }}
@@ -93,7 +93,7 @@
                                         <span class="op-search-param-checkmark">
                                             <i class = "fa fa-check"></i>
                                         </span>
-                                        {% if menu.data.labels_view == 'results' %}
+                                        {% if menu.data.labels_view == 'selector' %}
                                             {% if p.get_tooltip_results %}
                                                 <i class="fa fa-info-circle" title="{{ p.get_tooltip_results }}"></i>
                                             {% endif %}

--- a/opus/application/apps/ui/templates/ui/menu.html
+++ b/opus/application/apps/ui/templates/ui/menu.html
@@ -55,12 +55,12 @@
                                                         </span>
                                                         {% if menu.data.labels_view == 'selector' %}
                                                             {% if p.get_tooltip_results %}
-                                                                <i class="fa fa-info-circle" title="{{ p.get_tooltip_results }}"></i>
+                                                                <i class="fas fa-info-circle" title="{{ p.get_tooltip_results }}"></i>
                                                             {% endif %}
                                                             {{ p.label_results }}
                                                         {% else %}
                                                             {% if p.get_tooltip %}
-                                                                <i class="fa fa-info-circle" title="{{ p.get_tooltip }}"></i>
+                                                                <i class="fas fa-info-circle" title="{{ p.get_tooltip }}"></i>
                                                             {% endif %}
                                                             {{ p.label }}
                                                         {% endif %}
@@ -95,12 +95,12 @@
                                         </span>
                                         {% if menu.data.labels_view == 'selector' %}
                                             {% if p.get_tooltip_results %}
-                                                <i class="fa fa-info-circle" title="{{ p.get_tooltip_results }}"></i>
+                                                <i class="fas fa-info-circle" title="{{ p.get_tooltip_results }}"></i>
                                             {% endif %}
                                             {{ p.label_results }}
                                         {% else %}
                                             {% if p.get_tooltip %}
-                                                <i class="fa fa-info-circle" title="{{ p.get_tooltip }}"></i>
+                                                <i class="fas fa-info-circle" title="{{ p.get_tooltip }}"></i>
                                             {% endif %}
                                             {{ p.label }}
                                         {% endif %}

--- a/opus/application/apps/ui/templates/ui/select_metadata.html
+++ b/opus/application/apps/ui/templates/ui/select_metadata.html
@@ -10,7 +10,7 @@
   	    <ul>
             {% for slug, param_info in all_slugs_info.items %}
   		        <li id="cchoose__{{ slug }}">
-                    <span class="info">&nbsp;<i class="fa fa-info-circle" title = "
+                    <span class="info">&nbsp;<i class="fas fa-info-circle" title = "
                         {% if param_info.get_tooltip %}
                             {{ param_info.get_tooltip|striptags }}
                         {% else  %}
@@ -18,7 +18,6 @@
                         {% endif %}
                     "></i></span>
                     {{ param_info.body_qualified_label_results }}
-                    <!-- "remove this column" x button -->
                     <span class="unselect"><i class="far fa-trash-alt"></i></span>
 	            </li>
             {% endfor %}

--- a/opus/application/apps/ui/templates/ui/select_metadata.html
+++ b/opus/application/apps/ui/templates/ui/select_metadata.html
@@ -3,9 +3,7 @@
 {% block menu %}
 <div class="row">
     <div class="op-all-metadata-column col">
-        {% with 'menu' as expectedVarName %}
-            {{ block.super }} {# renders ui/menu.html #}
-        {% endwith %}
+        {{ block.super }} {# renders ui/menu.html #}
     </div>
 
     <div class="op-selected-metadata-column col">

--- a/opus/application/apps/ui/templates/ui/widget.html
+++ b/opus/application/apps/ui/templates/ui/widget.html
@@ -7,7 +7,7 @@
 <div class="card">
     <header class="card-header">
         <h6 class="card-title mt-0">
-                    <i class = "fa fa-info-circle" title = "{{tooltip|safe }}"></i>
+                    <i class = "fas fa-info-circle" title = "{{tooltip|safe }}"></i>
                     {{ label }} {{ units }}
                     <span class="spinner">&nbsp;</span>
                     <span class="float-right border-left border-dark">

--- a/opus/application/apps/ui/views.py
+++ b/opus/application/apps/ui/views.py
@@ -86,7 +86,6 @@ def api_last_blog_update(request):
     return ret
 
 
-@render_to('ui/menu.html')
 def api_get_menu(request):
     """Return the left side menu of the search page.
 
@@ -97,7 +96,11 @@ def api_get_menu(request):
     Format: __menu.html
     """
     api_code = enter_api_call('api_get_menu', request)
-    ret = _get_menu_labels(request, 'search')
+
+    menu = _get_menu_labels(request, 'search')
+    menu['which'] = 'search' # Used to create DOM IDs
+    ret = render(request, "ui/menu.html", menu)
+
     exit_api_call(api_code, ret)
     return ret
 
@@ -320,13 +323,11 @@ def api_get_metadata_selector(request):
     all_slugs_info = OrderedDict()
     for slug in slugs:
         all_slugs_info[slug] = get_param_info_by_slug(slug, 'col')
-    menu = _get_menu_labels(request, 'results')['menu']
+    menu = _get_menu_labels(request, 'selector')
 
-    context = {
-        "all_slugs_info": all_slugs_info,
-        "menu": menu
-    }
-    ret = render(request, "ui/select_metadata.html", context)
+    menu['all_slugs_info'] = all_slugs_info
+    menu['which'] = 'selector'
+    ret = render(request, "ui/select_metadata.html", menu)
 
     exit_api_call(api_code, ret)
     return ret
@@ -1123,7 +1124,7 @@ def api_dummy(request, *args, **kwargs):
 
 def _get_menu_labels(request, labels_view):
     "Return the categories in the menu for the search form."
-    labels_view = 'results' if labels_view == 'results' else 'search'
+    labels_view = 'selector' if labels_view == 'selector' else 'search'
     if labels_view == 'search':
         filter = "display"
     else:
@@ -1140,7 +1141,7 @@ def _get_menu_labels(request, labels_view):
     else:
         triggered_tables = get_triggered_tables(selections, extras) # Needs api_code
 
-    if labels_view == 'results':
+    if labels_view == 'selector':
         if 'obs_surface_geometry' in triggered_tables:
             triggered_tables.remove('obs_surface_geometry')
 

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -539,7 +539,7 @@ var o_browse = {
             // let headers = $(`.op-data-table-view th a:not([data-slug="opusid"], [data-slug=${slug}])`).find("span:last");
             let headers = $(`.op-data-table-view th a:not([data-slug=${slug}])`).find("span:last");
             headers.data("sort", "none");
-            headers.attr("class", defaultTableSortArrow);
+            headers.attr("class", `column_ordering ${defaultTableSortArrow}`);
         }
 
         // Re-render each pill

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -957,7 +957,7 @@ var o_browse = {
             // update the data table w/the new columns
             if (!o_utils.areObjectsEqual(opus.prefs.cols, currentSelectedMetadata)) {
                 let tab = opus.getViewTab();
-                o_browse.clearObservationData();
+                o_browse.clearObservationData(true); // Leave startobs alone
                 o_hash.updateHash(); // This makes the changes visible to the user
                 o_browse.initTable(tab, opus.colLabels, opus.colLabelsNoUnits);
                 o_browse.loadData(opus.prefs.view);
@@ -1956,9 +1956,15 @@ var o_browse = {
         o_browse.metadataboxHtml(opusId);
     },
 
-    clearObservationData: function() {
-        opus.prefs.startobs = 1; // reset startobs to 1 when data is flushed
-        opus.prefs.cart_startobs = 1;
+    clearObservationData: function(leaveStartObs) {
+        if (!leaveStartObs) {
+            // Normally when we delete all the data we want to force a return to the top because
+            // we don't know what data is going to be loaded. But in some circumstances
+            // (like updating metadata columns) we know we're going to reload exactly the same
+            // data so we can keep our place.
+            opus.prefs.startobs = 1; // reset startobs to 1 when data is flushed
+            opus.prefs.cart_startobs = 1;
+        }
         o_cart.reloadObservationData = true;  // forces redraw of cart tab
         o_cart.observationData = {};
         o_browse.reloadObservationData = true;  // forces redraw of browse tab

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -923,7 +923,7 @@ var o_browse = {
 
         let label = $(menuSelector).data("qualifiedlabel");
         let info = `<i class="fas fa-info-circle" title="${$(menuSelector).find('*[title]').attr("title")}"></i>`;
-        let html = `<li id="cchoose__${slug}">${info}${label}<span class="unselect"><i class="far fa-trash-alt"></span></li>`;
+        let html = `<li id="cchoose__${slug}" class="ui-sortable-handle"><span class="info">&nbsp;${info}</span>${label}<span class="unselect"><i class="far fa-trash-alt"></span></li>`;
         $(".op-selected-metadata-column > ul").append(html);
     },
 
@@ -1000,7 +1000,9 @@ var o_browse = {
                 // slug had been checked, remove from the chosen
                 o_menu.markMenuItem(menuSelector, "unselected");
                 opus.prefs.cols.splice($.inArray(slug,opus.prefs.cols), 1);
-                $(chosenSlugSelector).remove();
+                $(chosenSlugSelector).fadeOut(200, function() {
+                    $(this).remove();
+                });
             }
             return false;
         });
@@ -1160,8 +1162,7 @@ var o_browse = {
                     minScrollbarLength: opus.minimumPSLength
                 });
 
-                // dragging to reorder the chosen
-                $( ".op-selected-metadata-column > ul").sortable({
+                $(".op-selected-metadata-column > ul").sortable({
                     items: "li",
                     cursor: "grab",
                     stop: function(event, ui) { o_browse.metadataDragged(this); }

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1971,7 +1971,7 @@ var o_browse = {
         o_browse.observationData = {};
     },
 
-    clearBrowseObservationDataAndEraseDOM: function(leaveStartObs) {
+    clearBrowseObservationDataAndEraseDOM: function(leaveStartObs=false) {
         if (!leaveStartObs) {
             opus.prefs.startobs = 1; // reset startobs to 1 when data is flushed
         }

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1970,4 +1970,15 @@ var o_browse = {
         o_browse.reloadObservationData = true;  // forces redraw of browse tab
         o_browse.observationData = {};
     },
+
+    clearBrowseObservationDataAndEraseDOM: function(leaveStartObs) {
+        if (!leaveStartObs) {
+            opus.prefs.startobs = 1; // reset startobs to 1 when data is flushed
+        }
+        o_browse.reloadObservationData = true;  // forces redraw of browse tab
+        o_browse.observationData = {};
+        // Just so the user doesn't see old data lying around while waiting for a reload
+        $("#browse .gallery").empty();
+        $("#browse .op-data-table tbody").empty();
+    },
 };

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -590,7 +590,7 @@ var o_browse = {
 
         if (checkView) {
             // make sure the current element that the modal is displaying is viewable
-            if (!element.isOnScreen($(`${tab} .gallery-contents`))) {
+            if (!element.isOnScreen($(`${tab} .gallery-contents`), 0.5)) {
                 let galleryBoundingRect = opus.getViewNamespace().galleryBoundingRect;
 
                 let startObs = $(`${tab} ${contentsView}`).data("infiniteScroll").options.sliderObsNum;
@@ -751,7 +751,7 @@ var o_browse = {
             if (maxSliderVal >= obsNum) {
                 // "sliderObsNum" will be the startObs.
                 // "scrollbarObsNum" will be the obsNum at current scrollbar location.
-                // In table view, it's the top obsNum. In gallery view, it's one of obsNums in the top row. 
+                // In table view, it's the top obsNum. In gallery view, it's one of obsNums in the top row.
                 $(`${tab} .op-gallery-view`).infiniteScroll({
                     "sliderObsNum": obsNum,
                     "scrollbarObsNum": tableCurrentObsNum
@@ -1124,6 +1124,14 @@ var o_browse = {
 
         url += `&${slug}=${view}`;
         return url;
+    },
+
+    metadataSelectorMenuContainerHeight: function() {
+        return $(".op-all-metadata-column").outerHeight();
+    },
+
+    selectedMetadataContainerHeight: function() {
+        return $(".op-selected-metadata-column").outerHeight();
     },
 
     renderMetadataSelector: function() {

--- a/opus/application/static_media/js/menu.js
+++ b/opus/application/static_media/js/menu.js
@@ -49,7 +49,7 @@ var o_menu = {
             // for opus: keeping track of menu state, since menu is constantly refreshed
             // menu cats
             let category = $(this).data( "cat" );
-            let groupElem = $(`#sidebar #submenu-${category}`);
+            let groupElem = $(`#sidebar #search-submenu-${category}`);
             if ($(groupElem).hasClass("show")) {
                 opus.menuState.cats.splice(opus.menuState.cats.indexOf(category), 1);
             } else {
@@ -71,8 +71,8 @@ var o_menu = {
             // open menu items that were open before
             $("#sidebar").toggleClass("op-redraw-menu");
             $.each(opus.menuState.cats, function(key, category) {
-                if ($(`#submenu-${category}`).length != 0) {
-                    $(`#submenu-${category}`).collapse("show");
+                if ($(`#sidebar #search-submenu-${category}`).length != 0) {
+                    $(`#sidebar #search-submenu-${category}`).collapse("show");
                 } else {
                     // this is if the surface geometry target is no longer applicable so it's not
                     // on the menu, remove from the menuState

--- a/opus/application/static_media/js/mutationObserver.js
+++ b/opus/application/static_media/js/mutationObserver.js
@@ -37,9 +37,9 @@ var o_mutationObserver = {
             subtree: true,
         };
 
-        let adjustSearchSideBarHeight = _.debounce(o_search.adjustSearchSideBarHeight, 200);
-        let adjustSearchWidgetHeight = _.debounce(o_search.adjustSearchHeight, 200);
-        let adjustSearchHeight = _.debounce(o_search.adjustSearchHeight, 200);
+        let searchSideBarHeightChanged = _.debounce(o_search.searchSideBarHeightChanged, 200);
+        let searchWidgetHeightChanged = _.debounce(o_search.searchHeightChanged, 200);
+        let searchHeightChanged = _.debounce(o_search.searchHeightChanged, 200);
         let adjustBrowseHeight = _.debounce(o_browse.adjustBrowseHeight, 200);
         let adjustTableSize = _.debounce(o_browse.adjustTableSize, 200);
         let adjustProductInfoHeight = _.debounce(o_cart.adjustProductInfoHeight, 200);
@@ -51,7 +51,7 @@ var o_mutationObserver = {
         // Init MutationObserver with a callback function. Callback will be called when changes are detected.
         let switchTabObserver = new MutationObserver(function(mutationsList) {
             // this is for switch from other tabs to target page
-            adjustSearchHeight();
+            searchHeightChanged();
             adjustBrowseHeight();
             adjustTableSize();
             adjustProductInfoHeight();
@@ -62,20 +62,24 @@ var o_mutationObserver = {
             let lastMutationIdx = mutationsList.length - 1;
             mutationsList.forEach((mutation, idx) => {
                 if (mutation.type === "childList") {
-                    // update ps when there is any children added/removed
-                    adjustSearchSideBarHeight();
+                    // update ps when there are any children added/removed
+                    searchSideBarHeightChanged();
                 } else if (mutation.type === "attributes") {
                     // at the last mutation
                     if (idx === lastMutationIdx) {
                         if (mutation.target.classList.value.match(/collapse/)) {
-                            // If there is a collapse/expand happened (attribute changes), we only update ps at the last mutation when the animation finishes and class/style are finalized
-                            o_search.adjustSearchSideBarHeight();
-
+                            // If a collapse/expand happened (attribute changes),
+                            // we only update ps at the last mutation when the animation
+                            // finishes and class/style are finalized.
+                            // Note we call the original version here, not the debounced
+                            // version, because we need the PS to be visible instantly in
+                            // order for scrollTop to work below.
+                            o_search.searchSideBarHeightChanged();
                             // if the collapse opens below the viewable area, move the scrollbar
                             // only move the scrollbar if we open the menu item
                             let lastElement = $(mutation.target).children().last();
                             if (mutation.target.classList.value.match(/show/) &&
-                                !lastElement.isOnScreen("#sidebar-container")) {
+                                !lastElement.isOnScreen("#sidebar-container", 1)) {
                                 let containerHeight = o_search.searchBarContainerHeight();
                                 let containerTop = $("#sidebar-container").offset().top;
                                 let containerBottom = containerHeight + containerTop;
@@ -86,7 +90,7 @@ var o_mutationObserver = {
                             }
                         } else if (mutation.target.classList.value.match(/spinner/)) {
                             // If new submenu is added but spinner is still running, we update ps after spinner is done
-                            adjustSearchSideBarHeight();
+                            searchSideBarHeightChanged();
                         }
                     }
                 }
@@ -99,19 +103,19 @@ var o_mutationObserver = {
             mutationsList.forEach((mutation, idx) => {
                 if (mutation.type === "childList") {
                     // update ps when there is any children added/removed
-                    adjustSearchWidgetHeight();
+                    searchWidgetHeightChanged();
                 } else if (mutation.type === "attributes") {
                     // at the last mutation
                     if (idx === lastMutationIdx) {
                         if (mutation.target.classList.value.match(/collapse/)) {
                             // If there is a collapse/expand happened (attribute changes), we only update ps when the animation finishes and class/style are finalized
-                            adjustSearchWidgetHeight();
+                            searchWidgetHeightChanged();
                         } else if (mutation.target.classList.value.match(/spinner/)) {
                             // If new widget is added but spinner is still spinning, we update ps after spinner is done
-                            adjustSearchWidgetHeight();
+                            searchWidgetHeightChanged();
                         } else if (mutation.target.classList.value.match(/mult_group/)) {
                             // If new mult_group is open inside widgets, we update ps
-                            adjustSearchWidgetHeight();
+                            searchWidgetHeightChanged();
                         }
                     }
                 }
@@ -120,12 +124,7 @@ var o_mutationObserver = {
 
         // ps in cart page
         let cartObserver = new MutationObserver(function(mutationsList) {
-            let lastMutationIdx = mutationsList.length - 1;
-            mutationsList.forEach((mutation, idx) => {
-                if (idx === lastMutationIdx) {
-                    adjustProductInfoHeight();
-                }
-            });
+            adjustProductInfoHeight();
         });
 
         // ps in help page
@@ -140,10 +139,8 @@ var o_mutationObserver = {
 
         // ps in select metadata modal
         let metadataSelectorObserver = new MutationObserver(function(mutationsList) {
-            mutationsList.forEach((mutation, idx) => {
-                adjustMetadataSelectorMenuPS();
-                adjustSelectedMetadataPS();
-            });
+            adjustMetadataSelectorMenuPS();
+            adjustSelectedMetadataPS();
         });
 
         let metadataSelectorMenuObserver = new MutationObserver(function(mutationsList) {
@@ -151,7 +148,26 @@ var o_mutationObserver = {
             mutationsList.forEach((mutation, idx) => {
                 if (idx === lastMutationIdx) {
                     if (mutation.target.classList.value.match(/submenu.collapse/)) {
-                        adjustMetadataSelectorMenuPS();
+                        // If a collapse/expand happened (attribute changes),
+                        // we only update ps at the last mutation when the animation
+                        // finishes and class/style are finalized.
+                        // Note we call the original version here, not the debounced
+                        // version, because we need the PS to be visible instantly in
+                        // order for scrollTop to work below.
+                        o_browse.adjustMetadataSelectorMenuPS();
+                        // if the collapse opens below the viewable area, move the scrollbar
+                        // only move the scrollbar if we open the menu item
+                        let lastElement = $(mutation.target).children().last();
+                        if (mutation.target.classList.value.match(/show/) &&
+                            !lastElement.isOnScreen(".op-all-metadata-column", 1)) {
+                            let containerHeight = o_browse.metadataSelectorMenuContainerHeight();
+                            let containerTop = $(".op-all-metadata-column").offset().top;
+                            let containerBottom = containerHeight + containerTop;
+                            let elementTop = lastElement.offset().top;
+                            let elementHeight = lastElement.outerHeight();
+                            let newScrollPosition = $(".op-all-metadata-column").scrollTop() + (elementTop + elementHeight - containerBottom);
+                            $(".op-all-metadata-column").scrollTop(newScrollPosition);
+                        }
                     }
                 }
             });
@@ -162,7 +178,21 @@ var o_mutationObserver = {
             mutationsList.forEach((mutation, idx) => {
                 if (idx === lastMutationIdx) {
                     if (mutation.target.classList.value.match(/ui-sortable/)) {
-                        adjustSelectedMetadataPS();
+                        // Note we call the original version here, not the debounced
+                        // version, because we need the PS to be visible instantly in
+                        // order for scrollTop to work below.
+                        o_browse.adjustSelectedMetadataPS();
+                        // if the new item appears below the viewable area, move the scrollbar
+                        let lastElement = $(mutation.target).children().last();
+                        if (!lastElement.isOnScreen(".op-selected-metadata-column", 1)) {
+                            let containerHeight = o_browse.selectedMetadataContainerHeight();
+                            let containerTop = $(".op-selected-metadata-column").offset().top;
+                            let containerBottom = containerHeight + containerTop;
+                            let elementTop = lastElement.offset().top;
+                            let elementHeight = lastElement.outerHeight();
+                            let newScrollPosition = $(".op-selected-metadata-column").scrollTop() + (elementTop + elementHeight - containerBottom);
+                            $(".op-selected-metadata-column").scrollTop(newScrollPosition);
+                        }
                     }
                 }
             });
@@ -170,43 +200,23 @@ var o_mutationObserver = {
 
         // ps in browse dialog
         let browseDialogObserver = new MutationObserver(function(mutationsList) {
-            let lastMutationIdx = mutationsList.length - 1;
-            mutationsList.forEach((mutation, idx) => {
-                if (idx === lastMutationIdx) {
-                    adjustBrowseDialogPS();
-                }
-            });
+            adjustBrowseDialogPS();
         });
 
         // ps in gallery view
         let galleryViewObserver = new MutationObserver(function(mutationsList) {
-            let lastMutationIdx = mutationsList.length - 1;
-            mutationsList.forEach((mutation, idx) => {
-                if (idx === lastMutationIdx) {
-                    adjustBrowseHeight();
-                }
-            });
+            adjustBrowseHeight();
         });
 
         // ps in table view
         let tableViewObserver = new MutationObserver(function(mutationsList) {
-            let lastMutationIdx = mutationsList.length - 1;
-            mutationsList.forEach((mutation, idx) => {
-                if (idx === lastMutationIdx) {
-                    adjustTableSize();
-                }
-            });
+            adjustTableSize();
         });
 
         // update ps when switching between gallery and table view
         let switchGalleryAndTableObserver = new MutationObserver(function(mutationsList) {
-            let lastMutationIdx = mutationsList.length - 1;
-            mutationsList.forEach((mutation, idx) => {
-                if (idx === lastMutationIdx) {
-                    adjustBrowseHeight();
-                    adjustTableSize();
-                }
-            });
+            adjustBrowseHeight();
+            adjustTableSize();
         });
 
         // target node: target element that MutationObserver is observing, need to be a node

--- a/opus/application/static_media/js/mutationObserver.js
+++ b/opus/application/static_media/js/mutationObserver.js
@@ -38,7 +38,7 @@ var o_mutationObserver = {
         };
 
         let searchSideBarHeightChanged = _.debounce(o_search.searchSideBarHeightChanged, 200);
-        let searchWidgetHeightChanged = _.debounce(o_search.searchHeightChanged, 200);
+        let searchWidgetHeightChanged = _.debounce(o_search.searchWidgetHeightChanged, 200);
         let searchHeightChanged = _.debounce(o_search.searchHeightChanged, 200);
         let adjustBrowseHeight = _.debounce(o_browse.adjustBrowseHeight, 200);
         let adjustTableSize = _.debounce(o_browse.adjustTableSize, 200);

--- a/opus/application/static_media/js/mutationObserver.js
+++ b/opus/application/static_media/js/mutationObserver.js
@@ -184,7 +184,8 @@ var o_mutationObserver = {
                         o_browse.adjustSelectedMetadataPS();
                         // if the new item appears below the viewable area, move the scrollbar
                         let lastElement = $(mutation.target).children().last();
-                        if (!lastElement.isOnScreen(".op-selected-metadata-column", 1)) {
+                        if (mutation.addedNodes.length !== 0 &&
+                            !lastElement.isOnScreen(".op-selected-metadata-column", 1)) {
                             let containerHeight = o_browse.selectedMetadataContainerHeight();
                             let containerTop = $(".op-selected-metadata-column").offset().top;
                             let containerBottom = containerHeight + containerTop;

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -203,6 +203,10 @@ var opus = {
         opus.lastSelections = selections;
         opus.lastExtras = extras;
 
+        // Force the Select Metadata dialog to refresh the next time we go to the browse
+        // tab in case the categories are changed by this search.
+        o_browse.metadataSelectorDrawn = false;
+        
         // Update the UI in the following order:
         // 1) Normalize all the inputs and check for validity (allNormalizedApiCall)
         // 2) Perform the search and get the result count (getResultCount)
@@ -558,7 +562,7 @@ var opus = {
 
         // When the browser is resized, we need to recalculate the scrollbars
         // for all tabs.
-        let adjustSearchHeightDB = _.debounce(o_search.adjustSearchHeight, 200);
+        let searchHeightChangedDB = _.debounce(o_search.searchHeightChanged, 200);
         let adjustBrowseHeightDB = _.debounce(function() {o_browse.adjustBrowseHeight(true);}, 200);
         let adjustTableSizeDB = _.debounce(o_browse.adjustTableSize, 200);
         let adjustProductInfoHeightDB = _.debounce(o_cart.adjustProductInfoHeight, 200);
@@ -570,7 +574,7 @@ var opus = {
         let displayCartLeftPaneDB = _.debounce(o_cart.displayCartLeftPane, 200);
 
         $(window).on("resize", function() {
-            adjustSearchHeightDB();
+            searchHeightChangedDB();
             adjustBrowseHeightDB();
             adjustTableSizeDB();
             adjustProductInfoHeightDB();

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -151,6 +151,10 @@ var opus = {
             $(".op-reset-button button").prop("disabled", true);
         }
 
+        // If we're coming in from a URL, we want to leave startobs and cart_startobs
+        // alone so we are using the values in the URL.
+        let leaveStartObs = true;
+
         // Compare selections and last selections, extras and last extras to see if anything
         // has changed that would require an update to the results. We ignore q-types for
         // search fields that aren't actually being searched on because when the user changes
@@ -163,11 +167,9 @@ var opus = {
             if (!opus.force_load) {
                 return;
             }
+            // Everything is the same but force_load is true; fall through to the reload
+            // This happens on OPUS initialization
         } else {
-            // The selections or extras have changed in a meaningful way requiring an update
-            opus.prefs.startobs = 1;
-            opus.prefs.cart_startobs = 1;
-
             // If selections != opus.selections or extras != opus.extras,
             // it means the user manually updated the URL in the browser,
             // so we have to reload the page. We can't just continue on normally
@@ -179,11 +181,11 @@ var opus = {
                 opus.extras = extras;
                 location.reload();
                 return;
-            } else {
-                // Otherwise, this was just a user change to one of the search criteria inside
-                // the UI, so erase the previous data and reload the results.
-                o_browse.clearObservationData();
             }
+
+            // The selections or extras have changed in a meaningful way requiring an update
+            // In this case we want to reset startobs and cart_startobs to 1
+            leaveStartObs = false;
         }
 
         opus.force_load = false;
@@ -206,7 +208,12 @@ var opus = {
         // Force the Select Metadata dialog to refresh the next time we go to the browse
         // tab in case the categories are changed by this search.
         o_browse.metadataSelectorDrawn = false;
-        
+
+        // Clear the gallery and table views on the browse tab so we start afresh when the data
+        // returns. There's no point in clearing the cart tab since the search doesn't
+        // affect what appears there.
+        o_browse.clearBrowseObservationDataAndEraseDOM(leaveStartObs);
+
         // Update the UI in the following order:
         // 1) Normalize all the inputs and check for validity (allNormalizedApiCall)
         // 2) Perform the search and get the result count (getResultCount)
@@ -235,7 +242,7 @@ var opus = {
 
         // Take the results from the normalization, check for errors, and update the
         // UI to show the user if anything is wrong. This sets the opus.allInputsValid
-        // flag used below.
+        // flag used below and also updates the hash.
         o_search.validateRangeInput(normalizedData, true);
 
         if (!opus.allInputsValid) {
@@ -244,6 +251,18 @@ var opus = {
             $("#op-result-count").text("?");
             $("#op-observation-number").html("?");
             return;
+        }
+
+        if (opus.getCurrentTab() === "browse") {
+            // The user was really quick, and switched tabs before we had a chance
+            // to notice that the search parameters had changed. So they're looking at
+            // old data using an old hash :-( The clearObservationDataAndEraseDOM earlier
+            // will at least make them look at a blank screen, but we still need to
+            // force them to reload the data now that we have updated the hash.
+            // Note that things are OK if they switch tabs AFTER this point, even
+            // if result_count hasn't returned, because at least the hash has been
+            // updated so their call to dataimages.json will have the correct parameters.
+            o_browse.loadData(opus.getCurrentTab());
         }
 
         // Execute the query and return the result count

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -430,12 +430,12 @@ var o_search = {
         return $("#search").height() - offset;
     },
 
-    adjustSearchHeight: function() {
-        o_search.adjustSearchSideBarHeight();
-        o_search.adjustSearchWidgetHeight();
+    searchHeightChanged: function() {
+        o_search.searchSideBarHeightChanged();
+        o_search.searchWidgetHeightChanged();
     },
 
-    adjustSearchSideBarHeight: function() {
+    searchSideBarHeightChanged: function() {
         let containerHeight = o_search.searchBarContainerHeight();
         let searchMenuHeight = $(".searchMenu").height();
         $("#search .sidebar_wrapper").height(containerHeight);
@@ -451,7 +451,7 @@ var o_search = {
         o_search.searchScrollbar.update();
     },
 
-    adjustSearchWidgetHeight: function() {
+    searchWidgetHeightChanged: function() {
         let footerHeight = $(".app-footer").outerHeight();
         let mainNavHeight = $("#op-main-nav").outerHeight();
         let totalNonSearchAreaHeight = footerHeight + mainNavHeight;

--- a/opus/application/static_media/js/utils.js
+++ b/opus/application/static_media/js/utils.js
@@ -43,7 +43,7 @@ var o_utils = {
 /**
  * returns true if an element is visible
  */
-$.fn.isOnScreen = function(scope) {
+$.fn.isOnScreen = function(scope, slop) {
     if (!this || !scope) {
         return;
     }
@@ -55,7 +55,7 @@ $.fn.isOnScreen = function(scope) {
     let top = scope.offset().top;
     let bottom = top + scope.height();
     let elementHeight = target.outerHeight();
-    let offset = elementHeight * .50;   // allow 50% of the observation to be half visible
+    let offset = elementHeight * slop;   // allow part of the object to be off screen
     let elementTop = target.offset().top;
     let elementBottom = elementTop + elementHeight;
     // hack to take care of table header height

--- a/opus/application/test_api/test_results_api.py
+++ b/opus/application/test_api/test_results_api.py
@@ -220,7 +220,7 @@ class ApiResultsTests(TestCase, ApiTestHelper):
     def test__api_metadata2_vg_iss_2_s_c4360845_default_html_private(self):
         "[test_results_api.py] /api/metadata_v2: vg-iss-2-s-c4360845 default html private"
         url = '/opus/__api/metadata_v2/vg-iss-2-s-c4360845.html'
-        expected = b'<ul id="detail__data_general_constraints" class="op-detail-list">\n<li class="op-detail-entry">\n<i class="fa fa-info-circle op-detail-entry-icon" data-toggle="tooltip"\ntitle="'
+        expected = b'<ul id="detail__data_general_constraints" class="op-detail-list">\n<li class="op-detail-entry">\n<i class="fas fa-info-circle op-detail-entry-icon" data-toggle="tooltip"\ntitle="'
         self._run_html_startswith(url, expected)
 
     def test__api_metadata_vg_iss_2_s_c4360845_default_csv(self):
@@ -311,7 +311,7 @@ class ApiResultsTests(TestCase, ApiTestHelper):
     def test__api_metadata2_vg_iss_2_s_c4360845_cols_opusid_html_private(self):
         "[test_results_api.py] /api/metadata_v2: vg-iss-2-s-c4360845 cols opusid html private"
         url = '/opus/__api/metadata_v2/vg-iss-2-s-c4360845.html?cols=opusid'
-        expected = b'<ul class="op-detail-list">\n<li class="op-detail-entry">\n<i class="fa fa-info-circle op-detail-entry-icon" data-toggle="tooltip"\ntitle="A unique ID assigned to an observation by the Ring-Moon Systems Node of the PDS. The OPUS ID is useful for referencing specific observations in a mission-independent manner but should never be used outside of OPUS. To reference an observation outside of OPUS, use the Volume ID, Product ID, and/or Primary File Spec. Note: The format of the OPUS ID is not guaranteed to remain the same over time."></i>&nbsp;\n<div>\nOPUS ID: vg-iss-2-s-c4360845\n</div>\n</li>\n</ul>\n'
+        expected = b'<ul class="op-detail-list">\n<li class="op-detail-entry">\n<i class="fas fa-info-circle op-detail-entry-icon" data-toggle="tooltip"\ntitle="A unique ID assigned to an observation by the Ring-Moon Systems Node of the PDS. The OPUS ID is useful for referencing specific observations in a mission-independent manner but should never be used outside of OPUS. To reference an observation outside of OPUS, use the Volume ID, Product ID, and/or Primary File Spec. Note: The format of the OPUS ID is not guaranteed to remain the same over time."></i>&nbsp;\n<div>\nOPUS ID: vg-iss-2-s-c4360845\n</div>\n</li>\n</ul>\n'
         self._run_html_startswith(url, expected)
 
     def test__api_metadata_vg_iss_2_s_c4360845_cols_opusid_csv(self):


### PR DESCRIPTION
- Fixed duplicate IDs on left search pane and metadata selector that was causing things the user did in one place to affect the other. Now IDs have a prefix.
- Fixed a bug where when new categories were added or removed from the search tab, the metadata selector wasn't updated.
- In the metadata selector, when a category is expanded scroll so that the new category is visible just like we do on the search tab. Fixes #767.
- In the metadata selector, when a new item it added to the right pane, make sure it is visible.
- When a metadata column is added, make the (i) appear in the correct place relative to ones that were loaded through menu.html.
- When removing a metadata column by clicking on the left pane, the right <li> would fade out, but if you clicked on the trashcan it would just disappear. Now it fades out in both cases.
- Fixed improper font naming of fa-info-circle.
- Recent changes to consolidate code broke what happens when the metadata selector exits with "Save". Now it keeps the slider and the scroll position as it was, rather than resetting back to obs 1. For the table this is basically seamless. For the gallery it will realign the top row with the top of the browser (see issue #761). Fixes #783.
- Make sure the bottom of a recently exposed category is *entirely* on the screen, not just half of it.
- When you click on a table header or sort pill to change the sort order, the table headers compress and then expand (there's no space between the table header label and the sort arrow, then there is). This was caused by a missing class. I've added it and now sorting the table is much smoother.
- General code cleanup.
