### PR TITLE
Unsupported version message - print version and allow user to click thru

### DIFF
--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -396,9 +396,10 @@
         {% include "ui/confirm_modal.html" with
             id_name="op-browser-version-msg"
             confirm_title="Message About Your Browser Version"
-            confirm_msg=""
+            confirm_msg="Please consider upgrading your Browser Version"
             target="op-browser-version-msg"
-            allow_close=False
+            yes_text="OK"
+            allow_close=True
             draggable=False
         %}
         {% include "ui/confirm_modal.html" with

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -836,6 +836,7 @@ var opus = {
          */
         let browserName, browserVersion, matchObj;
         let userAgent = navigator.userAgent;
+        let updateString = "Please use a supported browser for a better experience.";
 
         if (userAgent.indexOf("Firefox") > -1) {
             // Example output:
@@ -867,19 +868,19 @@ var opus = {
             browserName = "Safari";
             browserVersion = matchObj[1];
         } else {
-            browserName = "unsupported";
-            browserVersion = "0.0";
+            browserName = `unsupported - ${userAgent}`;
+            browserVersion = "";
+            updateString = "";
         }
 
-        let browser = `${browserName} ${browserVersion}. Please update your browser`;
-        if (browserName === "unsupported") {
-            browser = browserName;
-        }
-        let modalMsg = (`Your current browser is ${browser}. OPUS supports
+        let browser = `${browserName} ${browserVersion}</br></br>OPUS may not work properly on your browser.`;
+        let modalMsg = (`Your current browser is ${browser}</br>
+                        We support
                         Firefox (${opus.browserSupport.firefox}+),
                         Chrome (${opus.browserSupport.chrome}+),
                         Safari (${opus.browserSupport.safari}+),
-                        and Opera (${opus.browserSupport.opera}+).`);
+                        and Opera (${opus.browserSupport.opera}+).
+                        ${updateString}`);
         $("#op-browser-version-msg .modal-body").html(modalMsg);
         browserName = browserName.toLowerCase();
 


### PR DESCRIPTION
-changed the modal to add a confirm
-added the version that is unsupported to the modal for better ability to debug
-allow the user to click thru and use an unsupported version