### PR TITLE
Slider Jumping issue #807

### DIFF
--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -711,10 +711,14 @@ var o_browse = {
 
             // table: obsNum = calculatedFirstObs + number of row
             // gallery: obsNum = calculatedFirstObs + number of row * number of obs in a row
+            // Note: in table view, we divide by 2nd table tr's height because in some corner
+            // cases, the first table tr's height will be 1px larger than rest of tr, and this
+            // will mess up the calculation.
             let obsNumDiff = (o_browse.isGalleryView() ?
                               Math.round((topBoxBoundary - firstCachedObsTop)/o_browse.imageSize) *
                               galleryBoundingRect.x :
-                              Math.round((topBoxBoundary - firstCachedObsTop)/$(`${tab} tbody tr`).outerHeight()));
+                              Math.round((topBoxBoundary - firstCachedObsTop)/
+                              $(`${tab} tbody tr`).eq(1).outerHeight()));
 
             let obsNum = obsNumDiff + calculatedFirstObs;
             if (browserResized) {


### PR DESCRIPTION
- This is related to #807 
- Local branch: slider_issue_807
- The reason for slider jumping:
  - In updateSliderHandle, we are calculating the startObs and table row height is used in the calculation ($(`${tab} tbody tr`).outerHeight()). However when issue happened, the first row height will be 1px (coming from a 1px top border, and it's not in css file. This only happened in my firefox and I didn't see it in my chrome) larger than rest of row height, and this will messed up the calculation. That's why slider always jump to one row ahead when switching from gallery to table view.  Now we usd the 2nd row height (same as rest of table tr's height), please let me know if we prefer to do something like: ``` Math.min($(`${tab} tbody tr`).outerHeight(), $(`${tab} tbody tr`).eq(1).outerHeight())```
- Now we break down steps in updateSliderHandle into multiple functions and there are comments. 