### PR TITLE
Slider jumping issue (#807) and infinite scroll realigns rows issue #(761)

### DIFF
--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -107,13 +107,14 @@ body {
     background-color: white;
 }
 
+/* Note: this is the scrolling area for thumbnail, when min-height is set
+We will have extra space at the bottom for scrolling even if thumbnail is
+not taking up the whole page. */
 #browse .gallery {
     margin: 0;
     padding: 0;
-    margin-top: .25em;
     background-color: #303030; /* #383838; */
     padding-left: 1.5em;
-    min-height: 700px;
 }
 
 .op-gallery-view {

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -787,7 +787,7 @@ var o_browse = {
         let nextObsNum = obsNum + galleryBoundingRect.x;
         let contentsView = o_browse.getScrollContainerClass();
         let previousScrollObsNum = $(`${tab} ${contentsView}`).data("infiniteScroll").options.scrollbarObsNum;
-        let maxSliderVal = o_browse.getSliderMaxValue(viewNamespace, galleryBoundingRect)
+        let maxSliderVal = o_browse.getSliderMaxValue(viewNamespace, galleryBoundingRect);
         obsNum = Math.min(obsNum, maxSliderVal);
         if ((previousScrollObsNum > obsNum && previousScrollObsNum < nextObsNum) ||
             (obsNum === maxSliderVal && previousScrollObsNum > maxSliderVal)) {

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -702,8 +702,12 @@ var o_browse = {
             let galleryBoundingRect = viewNamespace.galleryBoundingRect;
 
             // When we update the slider, the following steps are run:
-            // 1. Get the current startObs and top obsNum (top item in table view and one of
-            //    top row items in gallery view) that scrollbar is at.
+            // 1. Get the current startObs (top left item in gallery view in current page)
+            //    and top obsNum (top item in table view and one of top row items in gallery
+            //    view) that scrollbar is at.
+            //    - If browser is resized, realign doms by deleting some cached obSnum to make
+            //      sure first cached obs are at the correct row boundary. If we don't do so,
+            //      all rendered obs will be with the wrong row boundary after browser resizing.
             // 2. Get the max value for slider.
             // 3. Get the scrollbar offset for both gallery and table view.
             // 4. Update the slider value and data in infiniteScroll instances and URL using
@@ -733,16 +737,24 @@ var o_browse = {
 
     realignDOMAndGetStartObsAndScrollbarObsNum: function(selector, browserResized) {
         /**
-         * get the current startObs (obsNum, for slider number) and the
+         * Get the current startObs (obsNum, for slider number) and the
          * top item's obsNum in table view, this item will also be at the
          * top row in gallery view (currentScrollObsNum, for setting
-         * scrollbar location).
+         * scrollbar location). If browser is resized, realign doms by
+         * deleting some observations from the beginning. This will make
+         * sure the first cached obs is at the correct row boundary
+         * after browser resizing. (which means (first obs - 1) % row size
+         * is equal to 0). If we don't realign doms, first rendered obs
+         * will be at the wrong row boundary, and all rendered obs will
+         * be with the wrong row boundary ((first obs - 1) % row size
+         * will not be 0).
          */
         let tab = opus.getViewTab();
         let viewNamespace = opus.getViewNamespace();
         let galleryBoundingRect = viewNamespace.galleryBoundingRect;
         // this will get the top left obsNum for gallery view or the top obsNum for table view
         let firstCachedObs = $(selector).first().data("obs");
+
         if (browserResized) {
             o_browse.deleteObsToCorrectRowBoundary(tab, firstCachedObs);
         }
@@ -808,7 +820,15 @@ var o_browse = {
     deleteObsToCorrectRowBoundary: function(tab, firstCachedObs) {
         /**
          * If browser window is resized, delete some cached observations
-         * to make sure row boundary is correct.
+         * to make sure row boundary is correct. When browser is resized,
+         * the first cached obs will always be rendered as the first item
+         * of the top row of all rendered obs. If we don't delete some
+         * observations from the beginning, the first cached obs will be
+         * at the wrong row boundary. And all rendered obs will be at the
+         * wrong row boundary ((first obs - 1) % row size will not
+         * be 0). So we delete some observations and that way the first
+         * cached obs is at the correct row boundary after resizing (
+         * (first obs - 1) % row size is equal to 0).
          */
         let viewNamespace = opus.getViewNamespace();
         let galleryBoundingRect = viewNamespace.galleryBoundingRect;

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -711,10 +711,14 @@ var o_browse = {
 
             // table: obsNum = calculatedFirstObs + number of row
             // gallery: obsNum = calculatedFirstObs + number of row * number of obs in a row
+            // Note: in table view, we divide by 2nd table tr's height because in some corner
+            // cases, the first table tr's height will be 1px larger than rest of tr, and this
+            // will mess up the calculation.
             let obsNumDiff = (o_browse.isGalleryView() ?
                               Math.round((topBoxBoundary - firstCachedObsTop)/o_browse.imageSize) *
                               galleryBoundingRect.x :
-                              Math.round((topBoxBoundary - firstCachedObsTop)/$(`${tab} tbody tr`).outerHeight()));
+                              Math.round((topBoxBoundary - firstCachedObsTop)/
+                              $(`${tab} tbody tr`).eq(1).outerHeight()));
 
             let obsNum = obsNumDiff + calculatedFirstObs;
             if (browserResized) {

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -757,6 +757,9 @@ var o_browse = {
 
         if (browserResized) {
             o_browse.deleteObsToCorrectRowBoundary(tab, firstCachedObs);
+            // update firstCachedObs after first couple observations are deleted so that slider
+            // will be upddated to the correct value when browser is resized
+            firstCachedObs = $(selector).first().data("obs");
         }
 
         let firstCachedObsTop = $(selector).first().offset().top;

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -708,11 +708,14 @@ var o_browse = {
             // 3. Get the scrollbar offset for both gallery and table view.
             // 4. Update the slider value and data in infiniteScroll instances and URL using
             //    the data obtained from above 2 steps.
-            let [obsNum, currentScrollObsNum] = o_browse.realignDOMAndGetStartObsAndScrollbarObsNum(selector,
+            let obsNumObj = o_browse.realignDOMAndGetStartObsAndScrollbarObsNum(selector,
                                                 tab, viewNamespace, galleryBoundingRect, browserResized);
+            let obsNum = obsNumObj.startObs;
+            let currentScrollObsNum = obsNumObj.scrollbarObsNum;
             let maxSliderVal = o_browse.getSliderMaxValue(viewNamespace, galleryBoundingRect);
-            let [galleryOffset, tableOffset] = o_browse.getScrollbarOffset(tab, obsNum, currentScrollObsNum);
-
+            let scrollbarOffset = o_browse.getScrollbarOffset(tab, obsNum, currentScrollObsNum);
+            let galleryOffset = scrollbarOffset.galleryOffset;
+            let tableOffset = scrollbarOffset.tableOffset;
             o_browse.updateSliderValue(obsNum, currentScrollObsNum, galleryOffset, tableOffset);
         }
 
@@ -801,7 +804,7 @@ var o_browse = {
             currentScrollObsNum = o_browse.isGalleryView() ? previousScrollObsNum : currentScrollObsNum;
         }
 
-        return [obsNum, currentScrollObsNum];
+        return {"startObs": obsNum, "scrollbarObsNum": currentScrollObsNum};
     },
 
     deleteObsToCorrectRowBoundary: function(tab, viewNamespace ,galleryBoundingRect, firstCachedObs) {
@@ -902,7 +905,7 @@ var o_browse = {
             tableOffset = tableTargetTopPosition - tableContainerTopPosition - tableHeaderHeight;
         }
 
-        return [galleryOffset, tableOffset];
+        return {"galleryOffset": galleryOffset, "tableOffset": tableOffset};
     },
 
     checkScroll: function() {

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -708,12 +708,11 @@ var o_browse = {
             // 3. Get the scrollbar offset for both gallery and table view.
             // 4. Update the slider value and data in infiniteScroll instances and URL using
             //    the data obtained from above 2 steps.
-            let obsNumObj = o_browse.realignDOMAndGetStartObsAndScrollbarObsNum(selector,
-                                                tab, viewNamespace, galleryBoundingRect, browserResized);
+            let obsNumObj = o_browse.realignDOMAndGetStartObsAndScrollbarObsNum(selector, browserResized);
             let obsNum = obsNumObj.startObs;
             let currentScrollObsNum = obsNumObj.scrollbarObsNum;
-            let maxSliderVal = o_browse.getSliderMaxValue(viewNamespace, galleryBoundingRect);
-            let scrollbarOffset = o_browse.getScrollbarOffset(tab, obsNum, currentScrollObsNum);
+            let maxSliderVal = o_browse.getSliderMaxValue();
+            let scrollbarOffset = o_browse.getScrollbarOffset(obsNum, currentScrollObsNum);
             let galleryOffset = scrollbarOffset.galleryOffset;
             let tableOffset = scrollbarOffset.tableOffset;
             o_browse.updateSliderValue(obsNum, currentScrollObsNum, galleryOffset, tableOffset);
@@ -733,19 +732,20 @@ var o_browse = {
         }
     },
 
-    realignDOMAndGetStartObsAndScrollbarObsNum: function(selector, tab, viewNamespace, galleryBoundingRect,
-                                                         browserResized) {
+    realignDOMAndGetStartObsAndScrollbarObsNum: function(selector, browserResized) {
         /**
          * get the current startObs (obsNum, for slider number) and the
          * top item's obsNum in table view, this item will also be at the
          * top row in gallery view (currentScrollObsNum, for setting
          * scrollbar location).
          */
-
+        let tab = opus.getViewTab();
+        let viewNamespace = opus.getViewNamespace();
+        let galleryBoundingRect = viewNamespace.galleryBoundingRect;
         // this will get the top left obsNum for gallery view or the top obsNum for table view
         let firstCachedObs = $(selector).first().data("obs");
         if (browserResized) {
-            o_browse.deleteObsToCorrectRowBoundary(tab, viewNamespace, galleryBoundingRect, firstCachedObs);
+            o_browse.deleteObsToCorrectRowBoundary(tab, firstCachedObs);
         }
 
         let firstCachedObsTop = $(selector).first().offset().top;
@@ -797,7 +797,7 @@ var o_browse = {
         let nextObsNum = obsNum + galleryBoundingRect.x;
         let contentsView = o_browse.getScrollContainerClass();
         let previousScrollObsNum = $(`${tab} ${contentsView}`).data("infiniteScroll").options.scrollbarObsNum;
-        let maxSliderVal = o_browse.getSliderMaxValue(viewNamespace, galleryBoundingRect);
+        let maxSliderVal = o_browse.getSliderMaxValue();
         obsNum = Math.min(obsNum, maxSliderVal);
         if ((previousScrollObsNum > obsNum && previousScrollObsNum < nextObsNum) ||
             (obsNum === maxSliderVal && previousScrollObsNum > maxSliderVal)) {
@@ -807,11 +807,13 @@ var o_browse = {
         return {"startObs": obsNum, "scrollbarObsNum": currentScrollObsNum};
     },
 
-    deleteObsToCorrectRowBoundary: function(tab, viewNamespace ,galleryBoundingRect, firstCachedObs) {
+    deleteObsToCorrectRowBoundary: function(tab, firstCachedObs) {
         /**
          * If browser window is resized, delete some cached observations
          * to make sure row boundary is correct.
          */
+        let viewNamespace = opus.getViewNamespace();
+        let galleryBoundingRect = viewNamespace.galleryBoundingRect;
         let numToDelete = ((galleryBoundingRect.x - (firstCachedObs - 1) % galleryBoundingRect.x) %
                            galleryBoundingRect.x);
 
@@ -825,11 +827,13 @@ var o_browse = {
         }
     },
 
-    getSliderMaxValue: function(viewNamespace, galleryBoundingRect) {
+    getSliderMaxValue: function() {
         /**
          * Get the maximum value for slider based on gallery view row
          * boundary.
          */
+        let viewNamespace = opus.getViewNamespace();
+        let galleryBoundingRect = viewNamespace.galleryBoundingRect;
         let dataResultCount = viewNamespace.totalObsCount;
         let firstObsInLastRow = (o_utils.floor((dataResultCount - 1)/galleryBoundingRect.x) *
                                  galleryBoundingRect.x + 1);
@@ -848,7 +852,7 @@ var o_browse = {
         let viewNamespace = opus.getViewNamespace();
         let galleryBoundingRect = viewNamespace.galleryBoundingRect;
         let startObsLabel = o_browse.getStartObsLabel();
-        let maxSliderVal = o_browse.getSliderMaxValue(viewNamespace, galleryBoundingRect);
+        let maxSliderVal = o_browse.getSliderMaxValue();
 
         if (maxSliderVal >= obsNum) {
             // "sliderObsNum" will be the startObs.
@@ -885,12 +889,13 @@ var o_browse = {
         o_hash.updateHash(true);
     },
 
-    getScrollbarOffset: function(tab, obsNum, currentScrollObsNum) {
+    getScrollbarOffset: function(obsNum, currentScrollObsNum) {
         /**
          * Get galleryOffset and tableOffset, these values will be used
          * in the calculation in setScrollbarPosition and provide smooth
          * scrolling when infiniteScroll load event is triggered.
          */
+        let tab = opus.getViewTab();
         let galleryTarget = $(`${tab} .op-thumbnail-container[data-obs="${obsNum}"]`);
         let tableTarget = $(`${tab} .op-data-table tbody tr[data-obs='${currentScrollObsNum}']`);
         let galleryOffset = 0;

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -903,6 +903,8 @@ var o_browse = {
                                  galleryBoundingRect.x + 1);
         let maxSliderVal = (firstObsInLastRow - galleryBoundingRect.x *
                             (galleryBoundingRect.y - 1));
+        // Max slider value can't go negative
+        maxSliderVal = Math.max(maxSliderVal, 1);
 
         return maxSliderVal;
     },

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -755,8 +755,9 @@ var o_browse = {
         // this will get the top left obsNum for gallery view or the top obsNum for table view
         let firstCachedObs = $(selector).first().data("obs");
 
+        let numToDelete = 0;
         if (browserResized) {
-            o_browse.deleteObsToCorrectRowBoundary(tab, firstCachedObs);
+            numToDelete = o_browse.deleteObsToCorrectRowBoundary(tab, firstCachedObs);
             // update firstCachedObs after first couple observations are deleted so that slider
             // will be upddated to the correct value when browser is resized
             firstCachedObs = $(selector).first().data("obs");
@@ -812,10 +813,18 @@ var o_browse = {
         let previousScrollObsNum = $(`${tab} ${contentsView}`).data("infiniteScroll").options.scrollbarObsNum;
         let maxSliderVal = o_browse.getSliderMaxValue();
         obsNum = Math.min(obsNum, maxSliderVal);
-        if ((previousScrollObsNum > obsNum && previousScrollObsNum < nextObsNum) ||
+        console.log(`obsNum: ${obsNum}`);
+        console.log(`galleryBoundingRect.x : ${galleryBoundingRect.x}`);
+        console.log(`nextObsNum: ${nextObsNum}`);
+        console.log(`currentScrollObsNum before conversion: ${currentScrollObsNum}`);
+        if (browserResized && numToDelete) {
+            currentScrollObsNum = obsNum;
+            // set scrollbar position here????
+        } else if ((previousScrollObsNum > obsNum && previousScrollObsNum < nextObsNum) ||
             (obsNum === maxSliderVal && previousScrollObsNum > maxSliderVal)) {
             currentScrollObsNum = o_browse.isGalleryView() ? previousScrollObsNum : currentScrollObsNum;
         }
+        console.log(`currentScrollObsNum after conversion: ${currentScrollObsNum}`);
 
         return {"startObs": obsNum, "scrollbarObsNum": currentScrollObsNum};
     },
@@ -846,6 +855,9 @@ var o_browse = {
                 o_browse.deleteCachedObservation(galleryObsElem, tableObsElem, count, viewNamespace);
             }
         }
+
+        console.log(`numToDelete: ${numToDelete}`);
+        return numToDelete;
     },
 
     getSliderMaxValue: function() {

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -722,7 +722,7 @@ var o_browse = {
         }
 
         let galleryImages = o_browse.countGalleryImages();
-        if (opus.prefs[startObsLabel] + numObservations < galleryImages.x * galleryImages.y) {
+        if ((opus.prefs[startObsLabel] + numObservations - 1) < galleryImages.x * galleryImages.y) {
             // disable the slider because the observations don't fill the browser window
             // $("#op-observation-slider").slider({
             //     "value": 1,

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -713,9 +713,8 @@ var o_browse = {
             let currentScrollObsNum = obsNumObj.scrollbarObsNum;
             let maxSliderVal = o_browse.getSliderMaxValue();
             let scrollbarOffset = o_browse.getScrollbarOffset(obsNum, currentScrollObsNum);
-            let galleryOffset = scrollbarOffset.galleryOffset;
-            let tableOffset = scrollbarOffset.tableOffset;
-            o_browse.updateSliderValue(obsNum, currentScrollObsNum, galleryOffset, tableOffset);
+            o_browse.updateSliderValue(obsNum, currentScrollObsNum, scrollbarOffset.galleryOffset,
+                                       scrollbarOffset.tableOffset);
         }
 
         let galleryImages = o_browse.countGalleryImages();
@@ -755,10 +754,9 @@ var o_browse = {
         // For gallery view, the topBoxBoundary is the top of .gallery-contents
         // For table view, we will set the topBoxBoundary to be the bottom of thead
         // (account for height of thead)
-        let browseContentsContainer = $(`${tab} .gallery-contents`);
+        let browseContentsContainerTop = $(`${tab} .gallery-contents`).offset().top;
         let topBoxBoundary = (o_browse.isGalleryView() ?
-                              browseContentsContainer.offset().top :
-                              browseContentsContainer.offset().top +
+                              browseContentsContainerTop : browseContentsContainerTop +
                               $(`${tab} .op-data-table thead th`).outerHeight());
 
         // table: obsNum = alignedCachedFirstObs + number of row
@@ -1663,7 +1661,6 @@ var o_browse = {
                         // right before infiniteScroll load event is triggered. This will be used to properly
                         // set the scrollbar and slider location after new data is loaded.
                         let scrollbarObsNum = opus.prefs[startObsLabel];
-                        scrollbarObsNum = Math.max(scrollbarObsNum, 1);
 
                         // Update the obsNum in infiniteScroll instances with the first obsNum of the row above current last page
                         // This will be used to set the scrollbar position later

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -788,7 +788,7 @@ var o_browse = {
                           Math.round((topBoxBoundary - firstCachedObsTop)/
                           tableRowHeight));
 
-        let obsNum = obsNumDiff + alignedCachedFirstObs;
+        let obsNum = Math.max((obsNumDiff + alignedCachedFirstObs), 1);
 
         // currentScrollObsNum: the current top item in table view. This item is
         // also one of the top row items in gallery view
@@ -799,8 +799,8 @@ var o_browse = {
         // (it will be used to updated slider obsNum).
         // The calculation below is to make sure we are getting the first item in the
         // top row in gallery view.
-        obsNum = (o_utils.floor((obsNum - 1)/galleryBoundingRect.x) *
-                  galleryBoundingRect.x + 1);
+        obsNum = Math.max((o_utils.floor((obsNum - 1)/galleryBoundingRect.x) *
+                          galleryBoundingRect.x + 1), 1);
 
         // In gallery view, if scrollbarObsNum in infiniteScroll instance is:
         // (1) still within the current startObs' boundary

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -778,14 +778,19 @@ var o_browse = {
         obsNum = (o_utils.floor((obsNum - 1)/galleryBoundingRect.x) *
                   galleryBoundingRect.x + 1);
 
-        // In gallery view, if scrollbarObsNum in infiniteScroll instance is still within the
-        // current startObs' boundary, we want to make sure it didn't get updated to startObs.
-        // This will make sure table view scrollbar location stays at where it's been left off
-        // when we switch back to table view again.
+        // In gallery view, if scrollbarObsNum in infiniteScroll instance is:
+        // (1) still within the current startObs' boundary
+        // (2) larger than max slider value when current startObs is equal to max slider value
+        // We want to make sure it didn't get updated to startObs. This will make sure table
+        // view scrollbar location stays at where it's been left off when we switch back to
+        // table view again.
         let nextObsNum = obsNum + galleryBoundingRect.x;
         let contentsView = o_browse.getScrollContainerClass();
         let previousScrollObsNum = $(`${tab} ${contentsView}`).data("infiniteScroll").options.scrollbarObsNum;
-        if ((previousScrollObsNum > obsNum) && (previousScrollObsNum < nextObsNum)) {
+        let maxSliderVal = o_browse.getSliderMaxValue(viewNamespace, galleryBoundingRect)
+        obsNum = Math.min(obsNum, maxSliderVal);
+        if ((previousScrollObsNum > obsNum && previousScrollObsNum < nextObsNum) ||
+            (obsNum === maxSliderVal && previousScrollObsNum > maxSliderVal)) {
             currentScrollObsNum = o_browse.isGalleryView() ? previousScrollObsNum : currentScrollObsNum;
         }
 

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -813,18 +813,27 @@ var o_browse = {
         let previousScrollObsNum = $(`${tab} ${contentsView}`).data("infiniteScroll").options.scrollbarObsNum;
         let maxSliderVal = o_browse.getSliderMaxValue();
         obsNum = Math.min(obsNum, maxSliderVal);
-        console.log(`obsNum: ${obsNum}`);
-        console.log(`galleryBoundingRect.x : ${galleryBoundingRect.x}`);
-        console.log(`nextObsNum: ${nextObsNum}`);
-        console.log(`currentScrollObsNum before conversion: ${currentScrollObsNum}`);
-        if (browserResized && numToDelete) {
-            currentScrollObsNum = obsNum;
-            // set scrollbar position here????
-        } else if ((previousScrollObsNum > obsNum && previousScrollObsNum < nextObsNum) ||
+
+        if ((previousScrollObsNum > obsNum && previousScrollObsNum < nextObsNum) ||
             (obsNum === maxSliderVal && previousScrollObsNum > maxSliderVal)) {
             currentScrollObsNum = o_browse.isGalleryView() ? previousScrollObsNum : currentScrollObsNum;
+
+            // When resizing happened and some observations are deleted to correct the row boundary:
+            // In table view, if scrollbarObsNum is still within the current startObs' boundary, scrollbar
+            // will stay at where it is.
+            if (browserResized && numToDelete) {
+                currentScrollObsNum = previousScrollObsNum;
+                o_browse.setScrollbarPosition(obsNum, currentScrollObsNum);
+            }
+        } else {
+            // When resizing happened and some observations are deleted to correct the row boundary:
+            // In table view, if scrollbarObsNum is not within the current startObs' boundary, scrollbar
+            // will be moved to the location where slider value (current startObs) is the top item.
+            if (browserResized && numToDelete) {
+                currentScrollObsNum = obsNum;
+                o_browse.setScrollbarPosition(obsNum, currentScrollObsNum);
+            }
         }
-        console.log(`currentScrollObsNum after conversion: ${currentScrollObsNum}`);
 
         return {"startObs": obsNum, "scrollbarObsNum": currentScrollObsNum};
     },
@@ -856,7 +865,6 @@ var o_browse = {
             }
         }
 
-        console.log(`numToDelete: ${numToDelete}`);
         return numToDelete;
     },
 

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -763,19 +763,9 @@ var o_browse = {
             firstCachedObs = $(selector).first().data("obs");
         }
 
-        let obsNum = o_browse.calculateCurrentStartObs(selector, firstCachedObs);
-
-        // currentScrollObsNum: the current top item in table view. This item is
-        // also one of the top row items in gallery view
-        // (it will be used to updated the table view scrollbar location).
-        let currentScrollObsNum = obsNum;
-
-        // obsNum: startObs, the most top left obsNum in gallery.
-        // (it will be used to updated slider obsNum).
-        // The calculation below is to make sure we are getting the first item in the
-        // top row in gallery view.
-        obsNum = Math.max((o_utils.floor((obsNum - 1)/galleryBoundingRect.x) *
-                          galleryBoundingRect.x + 1), 1);
+        let calculatedObsNumObj = o_browse.calculateCurrentStartObs(selector, firstCachedObs);
+        let obsNum = calculatedObsNumObj.startObs;
+        let currentScrollObsNum = calculatedObsNumObj.scrollbarObsNum;
 
         // In gallery view, if scrollbarObsNum in infiniteScroll instance is:
         // (1) still within the current startObs' boundary
@@ -849,7 +839,19 @@ var o_browse = {
 
         let obsNum = Math.max((obsNumDiff + alignedCachedFirstObs), 1);
 
-        return obsNum;
+        // currentScrollObsNum: the current top item in table view. This item is
+        // also one of the top row items in gallery view
+        // (it will be used to updated the table view scrollbar location).
+        let currentScrollObsNum = obsNum;
+
+        // obsNum: startObs, the most top left obsNum in gallery.
+        // (it will be used to updated slider obsNum).
+        // The calculation below is to make sure we are getting the first item in the
+        // top row in gallery view.
+        obsNum = Math.max((o_utils.floor((obsNum - 1)/galleryBoundingRect.x) *
+                          galleryBoundingRect.x + 1), 1);
+
+        return {"startObs": obsNum, "scrollbarObsNum": currentScrollObsNum};
     },
 
     deleteObsToCorrectRowBoundary: function(tab, firstCachedObs) {

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -638,12 +638,13 @@ var o_browse = {
 
     // called when the slider is moved...
     onSliderHandleMoving: function(value) {
-        value = (value == undefined? 1 : value);
+        value = (value === undefined) ? 1 : Math.max(value, 1);
         $("#browse .op-observation-number").html(o_utils.addCommas(value));
     },
 
     // This function will be called when we scroll the slide to a target value
     onSliderHandleStop: function(value) {
+        value = Math.max(value, 1);
         let view = opus.prefs.view;
         let tab = opus.getViewTab();
         let elem = $(`${tab} .op-thumbnail-container[data-obs="${value}"]`);
@@ -721,15 +722,21 @@ var o_browse = {
                                        scrollbarOffset.tableOffset);
         }
 
+        let currentSliderValue = $(`${tab} #op-observation-slider`).slider("option", "value");
+        let currentSliderMax = $(`${tab} #op-observation-slider`).slider("option", "max");
+
         let galleryImages = o_browse.countGalleryImages();
-        if ((opus.prefs[startObsLabel] + numObservations - 1) < galleryImages.x * galleryImages.y) {
+        if ((opus.prefs[startObsLabel] + numObservations - 1) < galleryImages.x * galleryImages.y ||
+            (currentSliderValue <= 1 && currentSliderValue >= currentSliderMax)) {
             // disable the slider because the observations don't fill the browser window
-            // $("#op-observation-slider").slider({
+            // $(`${tab} #op-observation-slider`).slider({
             //     "value": 1,
             //     "step": o_browse.gallerySliderStep,
             //     "max": 1,
             // });
             $(`${tab} .op-slider-pointer`).css("width", "3ch");
+            // Make sure slider always move the the most left before being disabled.
+            $(`${tab} .op-observation-number`).html("1");
             $(`${tab} .op-observation-number`).html("-");
             $(`${tab} .op-slider-nav`).addClass("op-button-disabled");
         }
@@ -1683,7 +1690,7 @@ var o_browse = {
         if (!$(selector).data("infiniteScroll")) {
             $(selector).infiniteScroll({
                 path: function() {
-                    let obsNum = opus.prefs[startObsLabel];
+                    let obsNum = Math.max(opus.prefs[startObsLabel], 1);
                     let customizedLimitNum;
                     let lastObs = $(`${tab} .op-thumbnail-container`).last().data("obs");
                     let firstCachedObs = $(`${tab} .op-thumbnail-container`).first().data("obs");
@@ -1701,6 +1708,7 @@ var o_browse = {
 
                             // Update the obsNum in infiniteScroll instances with firstCachedObs
                             // This will be used to set the scrollbar position later
+                            firstCachedObs = Math.max(firstCachedObs, 1);
                             if (infiniteScrollData) {
                                 $(`${tab} .op-gallery-view`).infiniteScroll({"sliderObsNum": firstCachedObs});
                                 $(`${tab} .op-data-table-view`).infiniteScroll({"sliderObsNum": firstCachedObs});
@@ -1723,6 +1731,7 @@ var o_browse = {
 
                         // Update the obsNum in infiniteScroll instances with the first obsNum of the row above current last page
                         // This will be used to set the scrollbar position later
+                        scrollbarObsNum = Math.max(scrollbarObsNum, 1);
                         if (infiniteScrollData && obsNum <= viewNamespace.totalObsCount) {
                             $(`${tab} .op-gallery-view`).infiniteScroll({"sliderObsNum": scrollbarObsNum});
                             $(`${tab} .op-data-table-view`).infiniteScroll({"sliderObsNum": scrollbarObsNum});

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -707,6 +707,7 @@ var o_browse = {
                                                                             galleryBoundingRect,
                                                                             browserResized);
             let maxSliderVal = o_browse.getSliderMaxValue(viewNamespace, galleryBoundingRect);
+
             o_browse.updateSliderValue(tab, galleryBoundingRect, startObsLabel, maxSliderVal,
                                        obsNum, currentScrollObsNum);
         }
@@ -769,8 +770,20 @@ var o_browse = {
         // (this wll be used to updated the table view scrollbar location after initInfiniteScroll
         //  load is triggered).
         let currentScrollObsNum = obsNum;
+        let contentsView = o_browse.getScrollContainerClass();
+        let previousScrollObsNum = $(`${tab} ${contentsView}`).data("infiniteScroll").options.scrollbarObsNum;
+
         obsNum = (o_utils.floor((obsNum - 1)/galleryBoundingRect.x) *
                   galleryBoundingRect.x + 1);
+        let nextObsNum = obsNum + galleryBoundingRect.x;
+
+        // In gallery view, if scrollbarObsNum in infiniteScroll instance is still within the
+        // current startObs' boundary, we want to make sure it didn't get updated to startObs.
+        // This will make sure table view scrollbar location stays at where it's been left off
+        // when we switch back to table view again.
+        if ((previousScrollObsNum > obsNum) && (previousScrollObsNum < nextObsNum)) {
+            currentScrollObsNum = o_browse.isGalleryView() ? previousScrollObsNum : currentScrollObsNum;
+        }
 
         return [obsNum, currentScrollObsNum];
     },
@@ -809,7 +822,7 @@ var o_browse = {
                                  galleryBoundingRect.x + 1);
         let maxSliderVal = (firstObsInLastRow - galleryBoundingRect.x *
                             (galleryBoundingRect.y - 1));
-                            
+
         return maxSliderVal;
     },
 
@@ -1174,7 +1187,8 @@ var o_browse = {
         // sync up scrollbar position
         if (galleryInfiniteScroll && tableInfiniteScroll) {
             let startObs = $(`${tab} ${contentsView}`).data("infiniteScroll").options.sliderObsNum;
-            o_browse.setScrollbarPosition(startObs, startObs);
+            let scrollbarObs = $(`${tab} ${contentsView}`).data("infiniteScroll").options.scrollbarObsNum;
+            o_browse.setScrollbarPosition(startObs, scrollbarObs);
         }
     },
 

--- a/opus/application/static_media/js/cart.js
+++ b/opus/application/static_media/js/cart.js
@@ -246,7 +246,7 @@ var o_cart = {
                     }
 
                     let startObsLabel = o_browse.getStartObsLabel();
-                    let startObs = opus.prefs[startObsLabel];
+                    let startObs = Math.max(opus.prefs[startObsLabel], 1);
                     startObs = (startObs > o_cart.totalObsCount  ? 1 : startObs);
                     o_browse.loadData(view, startObs);
 
@@ -264,7 +264,7 @@ var o_cart = {
 
     emptyCart: function(returnToSearch=false) {
         // change indicator to zero and let the server know:
-        $.getJSON("/opus/__cart/reset.json", function(data) {  
+        $.getJSON("/opus/__cart/reset.json", function(data) {
             if (!returnToSearch) {
                 opus.changeTab("cart");
             } else {


### PR DESCRIPTION
- I accindently kill https://github.com/SETI/pds-opus/pull/809 when renaming my remote branch, so I recreate this pull request that combines previous two pull requests (since they are modifying the similar function and area).
- This pull request is related to the following issues: #807 and #761 
- This pull request also combines the following two old pull requests: 
  - https://github.com/SETI/pds-opus/pull/809
  - https://github.com/SETI/pds-opus/pull/806
- local branch: slider_issue_807_and_infiniteScroll_issue_761
- Now the scrollbar position will not be re-aligned after infiniteScroll load is triggered.
- Now when scrolling in table view, switch to gallery view, and go back to table view again, the scrollbar position at table view will still be at the same observation number as previous one if the startObs is not changed in gallery view. For example: (row boundary: 15)
  - The current slider number is 8206 in table view. We scroll down to 8218 as the top item in table view. Switch to gallery view, and switch back to table view again. 8218 will still be the top item in table view because the startObs is not changed in gallery view.
  - The current slider number is 11026 in table view. We scroll down to 11032 as the top item in table view. Switch to gallery view and scroll down so that 11041 is the new startObs. Switch back to table view, the top item will be 11041 because the startObs is changed in gallery view and slider is updated to 11041.
  