### PR TITLE
Issue related to window reload caused by selecting search checkboxes (#798)

### DIFF
--- a/opus/application/static_media/js/hash.js
+++ b/opus/application/static_media/js/hash.js
@@ -22,7 +22,7 @@ var o_hash = {
         let hash = [];
         for (let param in opus.selections) {
             if (opus.selections[param].length) {
-                hash.push(param + "=" + opus.selections[param].join(",").replace(" ", "%20"));
+                hash.push(param + "=" + opus.selections[param].join(",").replace(/ /g, "%20"));
             }
         }
 

--- a/opus/application/static_media/js/hash.js
+++ b/opus/application/static_media/js/hash.js
@@ -22,7 +22,7 @@ var o_hash = {
         let hash = [];
         for (let param in opus.selections) {
             if (opus.selections[param].length) {
-                hash.push(param + "=" + opus.selections[param].join(",").replace(/ /g, "%20"));
+                hash.push(param + "=" + opus.selections[param].join(","));
             }
         }
 

--- a/opus/application/static_media/js/hash.js
+++ b/opus/application/static_media/js/hash.js
@@ -159,7 +159,9 @@ var o_hash = {
                     // each qtype will only have one value at a time
                     extras[slug] = [value];
                 } else {
-                    // If value contains ", ", it's one value from string input.
+                    // If value contains ", ", it's one value from string input. This will make sure "," in
+                    // slug value gets encoded in "%2C" in URL, and store as decoded "," in opus internal variables
+                    // selections.
                     if (value.includes(", ")) {
                         selections[slug] = [value];
                     } else {
@@ -237,7 +239,14 @@ var o_hash = {
                     }
                 } else {
                     // these are search params/value!
-                    opus.selections[slug] = value.split(',');
+                    // If value contains ", ", it's one value from string input. This will make sure "," in
+                    // slug value gets encoded in "%2C" in URL, and store as decoded "," in opus internal variables
+                    // opus.selections.
+                    if (value.includes(", ")) {
+                        opus.selections[slug] = [value];
+                    } else {
+                        opus.selections[slug] = value.split(',');
+                    }
                 }
             }
         });

--- a/opus/application/static_media/js/hash.js
+++ b/opus/application/static_media/js/hash.js
@@ -237,8 +237,6 @@ var o_hash = {
                     }
                 } else {
                     // these are search params/value!
-                    // revisit here !!!
-                    // opus.selections[slug] = value.replace(/\+/g, " ").split(',');
                     opus.selections[slug] = value.split(',');
                 }
             }

--- a/opus/application/static_media/js/hash.js
+++ b/opus/application/static_media/js/hash.js
@@ -22,7 +22,7 @@ var o_hash = {
         let hash = [];
         for (let param in opus.selections) {
             if (opus.selections[param].length) {
-                hash.push(param + "=" + opus.selections[param].join(",").replace(/ /g,"+"));
+                hash.push(param + "=" + opus.selections[param].join(",").replace(" ", "%20"));
             }
         }
 
@@ -96,7 +96,7 @@ var o_hash = {
                     // each qtype will only have one value at a time
                     extras[slug] = [value];
                 } else {
-                    selections[slug] = value.replace("+", " ").split(",");
+                    selections[slug] = value.split(",");
                 }
             }
         });

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -156,10 +156,7 @@ var opus = {
         // If we're coming in from a URL, we want to leave startobs and cart_startobs
         // alone so we are using the values in the URL.
         let leaveStartObs = true;
-        console.log(`=== selections ===`);
-        console.log(selections);
-        console.log(`=== opus.selections ===`);
-        console.log(opus.selections);
+        
         // Compare selections and last selections, extras and last extras to see if anything
         // has changed that would require an update to the results. We ignore q-types for
         // search fields that aren't actually being searched on because when the user changes

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -559,8 +559,7 @@ var opus = {
             }
 
             // Update URL in browser
-            window.location.hash = "/" + normalizeURLData.new_url.replace(" ", "%20");
-            // window.location.hash = "/" + normalizeURLData.new_url.replace(" ", "%20");
+            window.location.hash = "/" + normalizeURLData.new_url.replace(/ /g, "%20");
             // Perform rest of initialization process
             opus.opusInitialization();
             // Watch the hash and URL for changes; this runs continuously

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -156,7 +156,7 @@ var opus = {
         // If we're coming in from a URL, we want to leave startobs and cart_startobs
         // alone so we are using the values in the URL.
         let leaveStartObs = true;
-        
+
         // Compare selections and last selections, extras and last extras to see if anything
         // has changed that would require an update to the results. We ignore q-types for
         // search fields that aren't actually being searched on because when the user changes
@@ -558,12 +558,22 @@ var opus = {
                 $(".op-user-msg").addClass("op-show-msg");
             }
 
+            // Get the newURLHash array from new_slugs (data returned from api call).
+            // The reason we don't use new_url directly is because some slug values might
+            // contain "&", and we can't just do .split("&"). This is a more proper way
+            // to get newURLHash array.
+            let newSlugArr = normalizeURLData.new_slugs;
+            let newURLHash = [];
+            for (let idx in newSlugArr) {
+                let slugObj = newSlugArr[idx];
+                for (let slug in slugObj) {
+                    newURLHash.push(`${slug}=${slugObj[slug]}`);
+                }
+            }
             // Encode and update new URL in browser:
-            // After getting new_url from normalizedURLAPICall, we convert space to "%20" and "+" to "2B".
-            // This will make sure URL (either coming from legacy or new one) has "%20" as space and "2B" as "+".
-            let newURL = normalizeURLData.new_url.replace(/ /g, "%20");
-            newURL = newURL.replace(/\+/g, "%2B");
-            window.location.hash = "/" + newURL;
+            newURLHash = o_hash.encodeHashArray(newURLHash);
+            newURLHash = newURLHash.join("&");
+            window.location.hash = "/" + newURLHash;
 
             // Perform rest of initialization process
             opus.opusInitialization();

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -564,8 +564,7 @@ var opus = {
             // to get newURLHash array.
             let newSlugArr = normalizeURLData.new_slugs;
             let newURLHash = [];
-            for (let idx in newSlugArr) {
-                let slugObj = newSlugArr[idx];
+            for (let slugObj of newSlugArr) {
                 for (let slug in slugObj) {
                     newURLHash.push(`${slug}=${slugObj[slug]}`);
                 }

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -559,7 +559,8 @@ var opus = {
             }
 
             // Update URL in browser
-            window.location.hash = "/" + normalizeURLData.new_url.replace(" ", "+");
+            window.location.hash = "/" + normalizeURLData.new_url.replace(" ", "%20");
+            // window.location.hash = "/" + normalizeURLData.new_url.replace(" ", "%20");
             // Perform rest of initialization process
             opus.opusInitialization();
             // Watch the hash and URL for changes; this runs continuously

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -156,7 +156,10 @@ var opus = {
         // If we're coming in from a URL, we want to leave startobs and cart_startobs
         // alone so we are using the values in the URL.
         let leaveStartObs = true;
-
+        console.log(`=== selections ===`);
+        console.log(selections);
+        console.log(`=== opus.selections ===`);
+        console.log(opus.selections);
         // Compare selections and last selections, extras and last extras to see if anything
         // has changed that would require an update to the results. We ignore q-types for
         // search fields that aren't actually being searched on because when the user changes
@@ -558,8 +561,13 @@ var opus = {
                 $(".op-user-msg").addClass("op-show-msg");
             }
 
-            // Update URL in browser
-            window.location.hash = "/" + normalizeURLData.new_url.replace(/ /g, "%20");
+            // Encode and update new URL in browser:
+            // After getting new_url from normalizedURLAPICall, we convert space to "%20" and "+" to "2B".
+            // This will make sure URL (either coming from legacy or new one) has "%20" as space and "2B" as "+".
+            let newURL = normalizeURLData.new_url.replace(/ /g, "%20");
+            newURL = newURL.replace(/\+/g, "%2B");
+            window.location.hash = "/" + newURL;
+
             // Perform rest of initialization process
             opus.opusInitialization();
             // Watch the hash and URL for changes; this runs continuously

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -238,41 +238,46 @@ var o_search = {
         });
 
         $("#search").on("change", "input.multichoice, input.singlechoice", function() {
-           // mult widget gets changed
-           let id = $(this).attr("id").split("_")[0];
-           let value = $(this).attr("value").replace(/\+/g, "%2B");
-           value = value.replace(/ /g, "%20");
-           if ($(this).is(":checked")) {
-               let values = [];
-               if (opus.selections[id]) {
-                   values = opus.selections[id]; // this param already has been constrained
-               }
+            // mult widget gets changed
+            let id = $(this).attr("id").split("_")[0];
+            // When user selects a value with "+", we replace it with "%2B".
+            // When user selects a value with white spaces, we replace them with "%20".
+            // These will be stored in opus.selections and used to compare with selections (from
+            // o_hash.getSelectionsExtrasFromHash()) in load function in opus.js.
+            let value = $(this).attr("value").replace(/\+/g, "%2B");
+            value = value.replace(/ /g, "%20");
 
-               // for surfacegeometry we only want a target selected
-               if (id === "surfacegeometrytargetname") {
-                  opus.selections[id] = [value];
-               } else {
-                  // add the new value to the array of values
-                  values.push(value);
-                  // add the array of values to selections
-                  opus.selections[id] = values;
-               }
+            if ($(this).is(":checked")) {
+                let values = [];
+                if (opus.selections[id]) {
+                    values = opus.selections[id]; // this param already has been constrained
+                }
 
-               // special menu behavior for surface geo, slide in a loading indicator..
-               if (id == "surfacetarget") {
+                // for surfacegeometry we only want a target selected
+                if (id === "surfacegeometrytargetname") {
+                    opus.selections[id] = [value];
+                } else {
+                    // add the new value to the array of values
+                    values.push(value);
+                    // add the array of values to selections
+                    opus.selections[id] = values;
+                }
+
+                // special menu behavior for surface geo, slide in a loading indicator..
+                if (id == "surfacetarget") {
                     let surface_loading = '<li style="margin-left:50%; display:none" class="spinner">&nbsp;</li>';
                     $(surface_loading).appendTo($("a.surfacetarget").parent()).slideDown("slow").delay(500);
-               }
+                }
 
-           } else {
-               let remove = opus.selections[id].indexOf(value); // find index of value to remove
-               opus.selections[id].splice(remove,1);        // remove value from array
+            } else {
+                let remove = opus.selections[id].indexOf(value); // find index of value to remove
+                opus.selections[id].splice(remove,1);        // remove value from array
 
-               if (opus.selections[id].length === 0) {
-                   delete opus.selections[id];
-               }
-           }
-           o_hash.updateHash();
+                if (opus.selections[id].length === 0) {
+                    delete opus.selections[id];
+                }
+            }
+            o_hash.updateHash();
         });
 
         // range behaviors and string behaviors for search widgets - qtype select dropdown

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -240,12 +240,7 @@ var o_search = {
         $("#search").on("change", "input.multichoice, input.singlechoice", function() {
             // mult widget gets changed
             let id = $(this).attr("id").split("_")[0];
-            // When user selects a value with "+", we replace it with "%2B".
-            // When user selects a value with white spaces, we replace them with "%20".
-            // These will be stored in opus.selections and used to compare with selections (from
-            // o_hash.getSelectionsExtrasFromHash()) in load function in opus.js.
-            let value = $(this).attr("value").replace(/\+/g, "%2B");
-            value = value.replace(/ /g, "%20");
+            let value = $(this).attr("value");
 
             if ($(this).is(":checked")) {
                 let values = [];

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -237,31 +237,32 @@ var o_search = {
             o_search.parseFinalNormalizedInputDataAndUpdateHash(slug, url);
         });
 
-        $('#search').on("change", 'input.multichoice, input.singlechoice', function() {
+        $("#search").on("change", "input.multichoice, input.singlechoice", function() {
            // mult widget gets changed
-           let id = $(this).attr("id").split('_')[0];
-           let value = $(this).attr("value").replace(/\+/g, '%2B');
+           let id = $(this).attr("id").split("_")[0];
+           let value = $(this).attr("value").replace(/\+/g, "%2B");
+           value = value.replace(" ", "%20");
 
-           if ($(this).is(':checked')) {
+           if ($(this).is(":checked")) {
                let values = [];
                if (opus.selections[id]) {
                    values = opus.selections[id]; // this param already has been constrained
                }
 
                // for surfacegeometry we only want a target selected
-               if (id === 'surfacegeometrytargetname') {
+               if (id === "surfacegeometrytargetname") {
                   opus.selections[id] = [value];
                } else {
                   // add the new value to the array of values
-                  values[values.length] = value;
+                  values.push(value);
                   // add the array of values to selections
                   opus.selections[id] = values;
                }
 
                // special menu behavior for surface geo, slide in a loading indicator..
-               if (id == 'surfacetarget') {
+               if (id == "surfacetarget") {
                     let surface_loading = '<li style="margin-left:50%; display:none" class="spinner">&nbsp;</li>';
-                    $(surface_loading).appendTo($('a.surfacetarget').parent()).slideDown("slow").delay(500);
+                    $(surface_loading).appendTo($("a.surfacetarget").parent()).slideDown("slow").delay(500);
                }
 
            } else {

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -241,8 +241,7 @@ var o_search = {
            // mult widget gets changed
            let id = $(this).attr("id").split("_")[0];
            let value = $(this).attr("value").replace(/\+/g, "%2B");
-           value = value.replace(" ", "%20");
-
+           value = value.replace(/ /g, "%20");
            if ($(this).is(":checked")) {
                let values = [];
                if (opus.selections[id]) {


### PR DESCRIPTION
- This pull request is related to issue #798 
- Local branch: search_reload_issue_798
- Previous window reload issue is caused by the difference between opus.selections and selections obtained from getSelectionsExtrasFromHash. Previously, in opus.selections, if selected value has white space, the white space will be stored as white space. But in selections, the white space is stored as %20 (URL encoding for white space). This difference will cause reload in opus.load function. Now all white space will be stored as %20 so opus.selections and selections are the same and window won't reload.