### PR TITLE
Test Branch: fix the issue of startobs not resetting to 1 with new search

### DIFF
--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -840,17 +840,23 @@ var o_browse = {
             currentScrollObsNum = o_browse.isGalleryView() ? previousScrollObsNum : currentScrollObsNum;
         }
 
-        // Properly set obsNum to make sure the last row is fully displayed when scrollbar reaches to the end
-        // of the data.
+        // Properly set obsNum to make sure the last row is fully displayed when scrollbar
+        // reaches to the end of the data.
         let lastObs = $(`${tab} .op-thumbnail-container`).last().data("obs");
         if (lastObs === viewNamespace.totalObsCount) {
             if (o_browse.isGalleryView()) {
-                if (viewNamespace.galleryScrollbar.reach.y === "end") {
+                if (viewNamespace.galleryScrollbar.reach.y === "end" && obsNum >=
+                    maxSliderVal - galleryBoundingRect.x) {
                     obsNum = maxSliderVal;
-                    currentScrollObsNum = currentScrollObsNum >= maxSliderVal ? currentScrollObsNum : maxSliderVal;
+                    if (previousScrollObsNum > maxSliderVal) {
+                        currentScrollObsNum = previousScrollObsNum;
+                    } else {
+                        currentScrollObsNum = currentScrollObsNum >= maxSliderVal ? currentScrollObsNum : maxSliderVal;
+                    }
                 }
             } else {
-                if (viewNamespace.tableScrollbar.reach.y === "end") {
+                if (viewNamespace.tableScrollbar.reach.y === "end" && obsNum >=
+                    maxSliderVal - galleryBoundingRect.tr) {
                     obsNum = maxSliderVal;
                 }
             }
@@ -861,7 +867,6 @@ var o_browse = {
         // 2. In table view, the top obs will stay the same.
         if (browserResized || isDOMChanged) {
             currentScrollObsNum = previousScrollObsNum;
-            let scrollbarOffset = o_browse.getScrollbarOffset(obsNum, currentScrollObsNum);
             let infiniteScrollDataObj = $(`${tab} ${contentsView}`).data("infiniteScroll").options;
             let offset = infiniteScrollDataObj.scrollbarOffset;
 
@@ -2018,9 +2023,11 @@ var o_browse = {
         $("#galleryViewContents").removeClass("op-disabled");
         viewNamespace.infiniteScrollLoadInProgress = false;
 
-        // Realign DOMS after all new obs are rendered. This will make sure all DOMs are aligned
-        // when browser is resized in the middle of infiniteScroll load.
-        o_browse.updateSliderHandle(false, true);
+        if (data.count !== 0) {
+            // Realign DOMS after all new obs are rendered. This will make sure all DOMs are aligned
+            // when browser is resized in the middle of infiniteScroll load.
+            o_browse.updateSliderHandle(false, true);
+        }
     },
 
     activateBrowseTab: function() {

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -856,6 +856,15 @@ var o_browse = {
             let infiniteScrollDataObj = $(`${tab} ${contentsView}`).data("infiniteScroll").options;
             let offset = infiniteScrollDataObj.scrollbarOffset;
 
+            // When resizing with Ctrl + "+"/"-" (it triggers "scroll" event first, and then "resize" event),
+            // sometimes the previous startObs will be moved to one row ahead of current top row. The
+            // scrollbarOffset stored from updateSliderHandle in "scroll" event will have an absolute value
+            // close to image size which will then set the scrollbar position with one row offset from
+            // updateSliderHandle in "resize" event later. So we reset offset to 0 if the value stored in
+            // infiniteScroll instance will cause one row difference in setScrollbarPosition.
+            let compareFactor = o_browse.imageSize * opus.sliderViewableFraction;
+            offset = (o_browse.isGalleryView() ? (Math.abs(offset) > compareFactor ? 0 : offset) : offset);
+
             // Set offset for scrollbar position so that it will have smooth scrolling in both
             // gallery and table view when infiniteScroll load is triggered.
             o_browse.setScrollbarPosition(obsNum, currentScrollObsNum, undefined, offset);

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1665,9 +1665,7 @@ var o_browse = {
 
         // need to add limit - getting twice as much so that the prefetch is done in one get instead of two.
         let limitNum = customizedLimitNum === undefined ? o_browse.getLimit(view) * 2 : customizedLimitNum;
-        if (limitNum === 0 || isNaN(limitNum)) {
-            opus.logError(`limitNum:  ${limitNum}, customizedLimitNum = ${customizedLimitNum}`);
-        }
+
         url += `&limit=${limitNum}`;
 
         return url;
@@ -1815,7 +1813,7 @@ var o_browse = {
                     // If there is no Cached data at all, loadData function will be called to
                     // render initial data, during this time, we want to make sure infintieScroll
                     // doesn't render any data to avoid duplicated cached obs.
-                    if (o_browse.loadDataInProgress || ($(`${tab} .op-data-table tbody tr`).length === 0 &&
+                    if (viewNamespace.loadDataInProgress || ($(`${tab} .op-data-table tbody tr`).length === 0 &&
                         $(`${tab} .gallery .op-thumbnail-container`).length === 0)) {
                         customizedLimitNum = 0;
                     }
@@ -1869,7 +1867,6 @@ var o_browse = {
     },
 
     loadData: function(view, startObs, customizedLimitNum=undefined) {
-        o_browse.loadDataInProgress = true;
         let tab = opus.getViewTab(view);
         let startObsLabel = o_browse.getStartObsLabel(view);
         let contentsView = o_browse.getScrollContainerClass(view);
@@ -1921,6 +1918,7 @@ var o_browse = {
         $(".op-page-loading-status > .loader").show();
         // Note: when browse page is refreshed, startObs passed in (from activateBrowseTab) will start from 1
         let url = o_browse.getDataURL(view, startObs, customizedLimitNum);
+        viewNamespace.loadDataInProgress = true;
         // metadata; used for both table and gallery
         $.getJSON(url, function(data) {
             if (data.reqno < opus.lastLoadDataRequestNo[view]) {
@@ -1953,7 +1951,7 @@ var o_browse = {
             o_browse.updateSortOrder(data);
 
             viewNamespace.reloadObservationData = false;
-            o_browse.loadDataInProgress = false;
+            viewNamespace.loadDataInProgress = false;
         });
     },
 

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -50,6 +50,8 @@ var o_browse = {
     tempHash: "",
     onRenderData: false,
     fading: false,  // used to prevent additional clicks until the fade animation complete
+
+    loadDataInProgress: false,
     /**
     *
     *  all the things that happen on the browse tab
@@ -1810,11 +1812,11 @@ var o_browse = {
                         }
                     }
 
-                    // If there is no Cached data at all, loadData function will be called
-                    // to render data, during this time, we want to make sure infintieScroll
+                    // If there is no Cached data at all, loadData function will be called to
+                    // render initial data, during this time, we want to make sure infintieScroll
                     // doesn't render any data to avoid duplicated cached obs.
-                    if ($(`${tab} .op-data-table tbody tr`).length === 0 ||
-                        $(`${tab} .gallery .op-thumbnail-container`).length === 0) {
+                    if (o_browse.loadDataInProgress || ($(`${tab} .op-data-table tbody tr`).length === 0 &&
+                        $(`${tab} .gallery .op-thumbnail-container`).length === 0)) {
                         customizedLimitNum = 0;
                     }
 
@@ -1867,6 +1869,7 @@ var o_browse = {
     },
 
     loadData: function(view, startObs, customizedLimitNum=undefined) {
+        o_browse.loadDataInProgress = true;
         let tab = opus.getViewTab(view);
         let startObsLabel = o_browse.getStartObsLabel(view);
         let contentsView = o_browse.getScrollContainerClass(view);
@@ -1950,6 +1953,7 @@ var o_browse = {
             o_browse.updateSortOrder(data);
 
             viewNamespace.reloadObservationData = false;
+            o_browse.loadDataInProgress = false;
         });
     },
 

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1867,6 +1867,10 @@ var o_browse = {
     },
 
     loadData: function(view, startObs, customizedLimitNum=undefined) {
+        /**
+         * Fetch initial data when reloading page, changing sort order,
+         * or switching to browse tab after search is changed. 
+         */
         let tab = opus.getViewTab(view);
         let startObsLabel = o_browse.getStartObsLabel(view);
         let contentsView = o_browse.getScrollContainerClass(view);

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1809,6 +1809,15 @@ var o_browse = {
                             opus.prefs[startObsLabel] = scrollbarObsNum;
                         }
                     }
+
+                    // If there is no Cached data at all, loadData function will be called
+                    // to render data, during this time, we want to make sure infintieScroll
+                    // doesn't render any data to avoid duplicated cached obs.
+                    if ($(`${tab} .op-data-table tbody tr`).length === 0 ||
+                        $(`${tab} .gallery .op-thumbnail-container`).length === 0) {
+                        customizedLimitNum = 0;
+                    }
+
                     // if totalObsCount is not yet defined, we still need to init the infinite scroll...
                     //if (viewNamespace.totalObsCount === undefined || obsNum <= viewNamespace.totalObsCount) {
                         let path = o_browse.getDataURL(view, obsNum, customizedLimitNum);
@@ -1909,7 +1918,6 @@ var o_browse = {
         $(".op-page-loading-status > .loader").show();
         // Note: when browse page is refreshed, startObs passed in (from activateBrowseTab) will start from 1
         let url = o_browse.getDataURL(view, startObs, customizedLimitNum);
-
         // metadata; used for both table and gallery
         $.getJSON(url, function(data) {
             if (data.reqno < opus.lastLoadDataRequestNo[view]) {
@@ -1927,13 +1935,12 @@ var o_browse = {
             viewNamespace.observationData = {};
             $(`${tab} .gallery`).empty();
             o_browse.hideGalleryViewModal();
-
             o_browse.renderGalleryAndTable(data, this.url, view);
 
             // When pasting a URL, prefetch some data from previous page so that
             // scrollbar will stay in the middle.
             let firstObs = $(`${tab} [data-obs]`).first().data("obs");
-            if (startObs === firstObs) {
+            if (startObs === firstObs && firstObs !== 1) {
                 $(`${tab} ${contentsView}`).trigger("ps-scroll-up");
             }
 
@@ -2268,7 +2275,7 @@ var o_browse = {
         // XXX For some reason having these lines here makes data sometimes double-load
         // when the scrollbar isn't at the top, so for now this is disabled and the
         // user might occasionally see old data briefly while the new stuff loads.
-        // $("#browse .gallery").empty();
-        // $("#browse .op-data-table tbody").empty();
+        $("#browse .gallery").empty();
+        $("#browse .op-data-table tbody").empty();
     },
 };

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -789,6 +789,14 @@ var o_browse = {
         let firstCachedObs = $(selector).first().data("obs");
 
         let numToDelete = 0;
+
+        // When we keep resizing browser and more DOMs are deleted, infiniteScroll load will
+        // trigger to load new data (previous page). During the time when infiniteScroll is
+        // still loading (before all new obs are rendered), if we keep resizing and cause some
+        // DOMs to get deleted, at the end after load is done, there will be some DOMs missing
+        // between the end of newly loaded obs and beginning of old cached obs. So we add the
+        // protection here. Another updateSliderHandle will be called to realign DOMS after all
+        // new obs are rendered in infiniteScrollLoadEventListener.
         if (browserResized && !viewNamespace.infiniteScrollLoadInProgress) {
             // We delete cached obs when we are in gallery view or switch from table to gallery view.
             if (o_browse.isGalleryView()) {
@@ -2008,6 +2016,10 @@ var o_browse = {
         // if left/right arrow are disabled, make them clickable again
         $("#galleryViewContents").removeClass("op-disabled");
         viewNamespace.infiniteScrollLoadInProgress = false;
+
+        // Realign DOMS after all new obs are rendered. This will make sure all DOMs are aligned
+        // when browser is resized in the middle of infiniteScroll load.
+        o_browse.updateSliderHandle(true);
     },
 
     activateBrowseTab: function() {

--- a/opus/application/static_media/js/cart.js
+++ b/opus/application/static_media/js/cart.js
@@ -45,6 +45,7 @@ var o_cart = {
     statusDataErrorCollector: [],
 
     loadDataInProgress: false,
+    infiniteScrollLoadInProgress: false,
     /**
      *
      *  managing cart communication between server and client and

--- a/opus/application/static_media/js/cart.js
+++ b/opus/application/static_media/js/cart.js
@@ -43,6 +43,8 @@ var o_cart = {
 
     // collector for all cart status error messages
     statusDataErrorCollector: [],
+
+    loadDataInProgress: false,
     /**
      *
      *  managing cart communication between server and client and

--- a/opus/application/static_media/js/mutationObserver.js
+++ b/opus/application/static_media/js/mutationObserver.js
@@ -45,9 +45,9 @@ var o_mutationObserver = {
         // make sure the height of .op-gallery-view and .op-data-table-view are set right away
         // when switching to browse tab or switching between gallery & table view. That way the
         // calculation of setScrollbarPosition will be correct and slider value will match startObs.
-        let adjustBrowseHeight = function() {o_browse.adjustBrowseHeight(true);};
+        let adjustBrowseHeight = function() {o_browse.adjustBrowseHeight(false, true);};
         let adjustTableSize = o_browse.adjustTableSize;
-        
+
         let adjustProductInfoHeight = _.debounce(o_cart.adjustProductInfoHeight, 200);
         let adjustHelpPanelHeight = _.debounce(opus.adjustHelpPanelHeight, 200);
         let adjustMetadataSelectorMenuPS = _.debounce(o_browse.adjustMetadataSelectorMenuPS, 200);

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -268,7 +268,11 @@ var opus = {
             // Note that things are OK if they switch tabs AFTER this point, even
             // if result_count hasn't returned, because at least the hash has been
             // updated so their call to dataimages.json will have the correct parameters.
-            o_browse.loadData(opus.getCurrentTab());
+
+            // Prevent loadData to call the same dataimages API twice
+            if (!o_browse.loadDataInProgress) {
+                o_browse.loadData(opus.getCurrentTab());
+            }
         }
 
         // Execute the query and return the result count

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -103,7 +103,7 @@ var opus = {
     splashVersion: 1,
 
     // The viewable percentage of an item such that it can be treated as startobs
-    // 0.8 => 80% 
+    // 0.8 => 80%
     sliderViewableFraction: 0.8,
 
     //------------------------------------------------------------------------------------
@@ -606,7 +606,7 @@ var opus = {
         // When the browser is resized, we need to recalculate the scrollbars
         // for all tabs.
         let searchHeightChangedDB = _.debounce(o_search.searchHeightChanged, 200);
-        let adjustBrowseHeightDB = _.debounce(function() {o_browse.adjustBrowseHeight(true);}, 200);
+        let adjustBrowseHeightDB = function() {o_browse.adjustBrowseHeight(true);};
         let adjustTableSizeDB = _.debounce(o_browse.adjustTableSize, 200);
         let adjustProductInfoHeightDB = _.debounce(o_cart.adjustProductInfoHeight, 200);
         let adjustDetailHeightDB = _.debounce(o_detail.adjustDetailHeight, 200);


### PR DESCRIPTION
- Local branch: startObs_not_reset_in_new_search_issue
- This is a test branch that have the fix to the issue of startobs not resetting to 1 with new search.
- Still in middle of testing all slider/infiniteScroll/ps behaviors:
    - Current Test cases:
        - Scrolling will be smooth when infiniteScroll load is triggered:
            - When scrolling up/down to trigger infiniteScroll load, scrolling will be smooth.
            - In gallery view, when keep resizing (to cause DOMs deleted) and infiniteScroll load is triggered, scrollbar will be moved from top to the middle smoothly (no jumping).
        - Pasting an URL with startObs:
            - In gallery view, when pasting an URL with a startObs not aligned with current browser size, the startObs will be rounded down (aligned with current browser size).
            - In table view, when pasting an URL with a startObs not aligned with current browser size, the startObs will stay the same and not be rounded down.
        - Browser resizing:
            - In table view, when keep resizing the browser, the slider value will not change.
            - In gallery view, when keep resizing the browser, the slider value will get smaller, and the previous value will stay in the top row.
        - In gallery/table view, when we keep refreshing the page, the slider value will not change and scrollbar will stay in the middle.
        - In browse tab, move the slider to the middle. Go to search tab and change the search. Switch back to browse tab, and slider value will start from 1.
- Current issue:
  - When doing browser resizing, we can do:
    1. Drag the browser to resize: this will trigger “resize” event first and then “scroll” event, slider will update correctly (like in gallery view, the slider value will keep decreasing, etc).
    2. Ctrl + “+” and Ctrl + “-” to resize: this will trigger “scroll” event first, and then “resize” event, and slider will sometimes behave differently from what we expect (like in gallery view, the value will increase sometimes when we keep doing ctrl + “+” and ctrl + “-” repetitively. Or in table view, the slider value will change).