### PR TITLE
Select metadata headers cleanup

### DIFF
--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -105,7 +105,7 @@
                                     <a href="#" class="op-browse-view nav-link" data-view="data"><i class="far fa-list-alt"></i></a>
                                 </li>
                                 <li class="nav-item">
-                                    <a href="#" class="op-metadata-modal nav-link" data-toggle="modal" data-target="#op-metadata-selector" title="Select metadata to display or include in CSV files for each observation"><i class="fas fa-columns"></i>&nbsp;Select Metadata</a>
+                                    <a href="#" class="op-metadata-modal nav-link" data-toggle="modal" data-target="#op-select-metadata" title="Select metadata to display or include in CSV files for each observation"><i class="fas fa-columns"></i>&nbsp;Select Metadata</a>
                                 </li>
                                 <li class="nav-item">
                                     <a href="#" class="op-download-csv nav-link" download title="Download CSV of selected metadata for ALL observations in current results"><i class="fas fa-download"></i>&nbsp;Download CSV (all results)</a>
@@ -170,7 +170,7 @@
                                         <a href="#" class="op-browse-view nav-link" data-toggle="modal" data-target="#op-cart-view" data-view="data" title="View sortable metadata table"><i class="far fa-list-alt"></i>&nbsp;View Table</a>
                                     </li>
                                     <li class="nav-item">
-                                        <a href="#" class="op-metadata-modal nav-link" data-toggle="modal" data-target="#op-metadata-selector" title="Select metadata to display or include in CSV files for each observation"><i class="fas fa-columns"></i>&nbsp;Select Metadata</a>
+                                        <a href="#" class="op-metadata-modal nav-link" data-toggle="modal" data-target="#op-select-metadata" title="Select metadata to display or include in CSV files for each observation"><i class="fas fa-columns"></i>&nbsp;Select Metadata</a>
                                     </li>
                                     <li class="nav-item">
                                         <a href="#" class="op-download-csv nav-link" download title="Download CSV of selected metadata for all observations in cart"><i class="fas fa-file-csv"></i>&nbsp;Metadata CSV</a>
@@ -316,7 +316,7 @@
         </div>
 
         <!--modal dialog for the metadata selector -->
-        <div id="op-metadata-selector" class="modal fade" role="dialog" tabbindex="-1" data-backdrop="false" aria-labelledby="op-metadata-selectorLabel" aria-hidden="true">
+        <div id="op-select-metadata" class="modal fade" role="dialog" tabbindex="-1" data-backdrop="false" aria-labelledby="op-select-metadataLabel" aria-hidden="true">
             <div class="modal-dialog modal-lg" role="document">
                 <div class="modal-content">
                     <div class="modal-header bg-dark text-light font-weight-bold font-lg py-3">
@@ -325,7 +325,7 @@
                             <i class="far fa-times-circle fa-lg text-light"></i>
                         </button>
                     </div>
-                    <div class="modal-body metadata" id="op-metadata-selector-contents"></div>
+                    <div class="modal-body metadata" id="op-select-metadata-contents"></div>
                     <div class="modal-footer">
                         <div class="left-container">
                             <button type="reset" class="btn btn-info">Reset to Default</button>

--- a/opus/application/apps/ui/templates/ui/menu.html
+++ b/opus/application/apps/ui/templates/ui/menu.html
@@ -1,7 +1,7 @@
 {% block menu %}
-    <ul class="searchMenu list-group list-group-flush">
+    <ul class="op-search-menu list-group list-group-flush">
         {% for div in menu.divs %}
-            <li class="list-group-item py-2">
+            <li class="list-group-item py-2 op-search-menu-category">
                 {#  Each div has a top-level catgory  #}
                 {% if div.table_name == 'obs_general' %}
                     <a href="#{{ which }}-submenu-{{ div.table_name }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle" data-cat="{{ div.table_name }}">

--- a/opus/application/apps/ui/templates/ui/select_metadata.html
+++ b/opus/application/apps/ui/templates/ui/select_metadata.html
@@ -1,7 +1,7 @@
 {% extends "ui/menu.html" %}
 
 {% block menu %}
-<div class="row op-select-metadata-headers">
+<div class="row op-select-metadata-headers op-no-select">
     <div class="col">
         <div class="op-all-metadata-column-header">
             <div class="text-center font-weight-bold h5">Available Metadata Fields</div>
@@ -20,7 +20,7 @@
     </div>
 </div>
 <hr class="op-select-metadata-headers-hr">
-<div class="row">
+<div class="row op-no-select">
     <div class="col">
         <div class="op-all-metadata-column">
             {{ block.super }} {# renders ui/menu.html #}

--- a/opus/application/apps/ui/templates/ui/select_metadata.html
+++ b/opus/application/apps/ui/templates/ui/select_metadata.html
@@ -1,27 +1,50 @@
 {% extends "ui/menu.html" %}
 
 {% block menu %}
+<div class="row op-select-metadata-headers">
+    <div class="col">
+        <div class="op-all-metadata-column-header">
+            <div class="text-center font-weight-bold h5">Available Metadata Fields</div>
+            Click on a field name to include (or exclude) it from the Selected Metadata list.
+            To show Surface Geometry Constraints, select a Surface Geometry Target Name on
+            the Search tab.
+        </div>
+    </div>
+    <div class="col">
+        <div class="op-selected-metadata-column-header">
+            <div class="text-center font-weight-bold h5">Selected Metadata Fields</div>
+            These fields will be shown in the Table View, Slideshow, and Detail tab and
+            will be included in downloaded CSV files and archives. Fields can be reordered
+            with drag-and-drop.
+        </div>
+    </div>
+</div>
+<hr class="op-select-metadata-headers-hr">
 <div class="row">
-    <div class="op-all-metadata-column col">
-        {{ block.super }} {# renders ui/menu.html #}
+    <div class="col">
+        <div class="op-all-metadata-column">
+            {{ block.super }} {# renders ui/menu.html #}
+        </div>
     </div>
 
-    <div class="op-selected-metadata-column col">
-  	    <ul>
-            {% for slug, param_info in all_slugs_info.items %}
-  		        <li id="cchoose__{{ slug }}">
-                    <span class="info">&nbsp;<i class="fas fa-info-circle" title = "
-                        {% if param_info.get_tooltip %}
-                            {{ param_info.get_tooltip|striptags }}
-                        {% else  %}
-                            {{ param_info.body_qualified_label_results }}
-                        {% endif %}
-                    "></i></span>
-                    {{ param_info.body_qualified_label_results }}
-                    <span class="unselect"><i class="far fa-trash-alt"></i></span>
-	            </li>
-            {% endfor %}
-        </ul>
+    <div class="col">
+        <div class="op-selected-metadata-column">
+      	    <ul>
+                {% for slug, param_info in all_slugs_info.items %}
+      		        <li id="cchoose__{{ slug }}">
+                        <span class="info">&nbsp;<i class="fas fa-info-circle" title = "
+                            {% if param_info.get_tooltip %}
+                                {{ param_info.get_tooltip|striptags }}
+                            {% else  %}
+                                {{ param_info.body_qualified_label_results }}
+                            {% endif %}
+                        "></i></span>
+                        {{ param_info.body_qualified_label_results }}
+                        <span class="unselect"><i class="far fa-trash-alt"></i></span>
+    	            </li>
+                {% endfor %}
+            </ul>
+        </div>
     </div>
 </div>
 {% endblock %}

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -207,9 +207,10 @@ to 100%, this will make the shrinking look smoother */
         margin-left: 1em !important;
     }
 
-    /* keep equal padding on both left/right sides of search menu when
-    screen is narrow */
-    #search ul.searchMenu {
+    /* Keep equal padding on both left/right sides of the search menu when
+       the screen is narrow. Don't do this for the metadata selector so the
+       menu is close to the edge of the dialog. */
+    #search ul.op-search-menu {
         padding-right: 1em;
         padding-left: 1em;
     }
@@ -226,12 +227,12 @@ to 100%, this will make the shrinking look smoother */
 
 /* If the menu category (in the search pane or metadata selector) is collapsed,
    then rotate the little triangle 90 degrees to indicate its status. */
-.searchMenu .dropdown-toggle::after {
+.op-search-menu .dropdown-toggle::after {
     transition: all .3s;
     -webkit-transition: all .3s;
 }
 
-.searchMenu .dropdown-toggle.collapsed::after {
+.op-search-menu .dropdown-toggle.collapsed::after {
     transform: rotate(-90deg);
     -webkit-transform: rotate(-90deg);
 }
@@ -260,7 +261,7 @@ hr.shadow-divider {
     box-shadow: 0 9px 9px -10px #8c8b8b inset;
 }
 
-ul.searchMenu {
+ul.op-search-menu {
     padding-right: 2em;
 }
 
@@ -585,61 +586,69 @@ th.sticky-header {
     display: inline-grid;
 }
 
-#op-metadata-selector i.fa-check {
+#op-select-metadata i.fa-check {
     display: inline-block;
 }
 
-#op-metadata-selector ul li {
+#op-select-metadata ul li {
     text-decoration: none;
 }
 
 /* prevent weird browser y-scrollbar */
-#op-metadata-selector {
+#op-select-metadata {
     overflow-y: hidden;
 }
 
 /* make modal width shrink smoothly with screen */
-#op-metadata-selector .modal-dialog {
+#op-select-metadata .modal-dialog {
     /* max-width: 1100px; */
     max-width: 92%;
 }
 
-#op-metadata-selector .modal-content {
+#op-select-metadata .modal-content {
     border: solid 2px #FFF;
 }
 
 /* Make both "Save Changes" and "Discard Changes" stay in one line */
-#op-metadata-selector .right-container {
+#op-select-metadata .right-container {
     display: flex;
 }
 
 /* Make a little white space between "Save Changes" and "Discard Changes" */
-#op-metadata-selector .right-container button[type="submit"] {
+#op-select-metadata .right-container button[type="submit"] {
     margin-right: 2px;
 }
 
-#op-metadata-selector .right-container button[type="cancel"] {
+#op-select-metadata .right-container button[type="cancel"] {
     margin-left: 2px;
 }
 
 /* Make white space (padding) in metadata selector menu responsive */
-#op-metadata-selector .searchMenu {
-    padding-right: 7%;
+#op-select-metadata .op-search-menu {
+    padding-right: 3%;
 }
 
 /* Make white space (padding) in metadata selector modal responsive */
+.op-all-metadata-column-header, .op-selected-metadata-column-header {
+    padding-left: calc(1.5% + 4px);
+    padding-right: 2.0%;
+}
+
 .op-all-metadata-column, .op-selected-metadata-column {
+    position: relative;
     padding-left: 1.5%;
     padding-right: 1.5%;
-    /* make metadata selector modal height responsive */
-    max-height: calc(75vh - 150px);
     overflow: scroll;
     overflow-x: auto;
 }
 
+.op-all-metadata-column .op-search-menu-category {
+    padding-left: 4px;
+    padding-top: 0px !important; /* Required to override style default */
+}
+
 .op-all-metadata-column ul li {
     padding-bottom: 3px;
-
 }
 
 .op-all-metadata-column .cat_label {
@@ -658,7 +667,7 @@ narrow */
 }
 
 .op-selected-metadata-column ul {
-    padding-inline-start: 0.5em;
+    padding-inline-start: 4px;
     padding-inline-end: 1em;
 }
 
@@ -684,7 +693,7 @@ narrow */
 }
 
 .op-selected-metadata-column ul li {
-    padding: 5px 15px;
+    padding: 5px 10px 5px 5px;
     border: 1px dotted gray;
     list-style-type: none;
 }
@@ -787,7 +796,7 @@ when window sized is narrow */
     z-index: 999;
 }
 
-#galleryView button.close, #op-metadata-selector button.close {
+#galleryView button.close, #op-select-metadata button.close {
     position: absolute;
     float: right;
     top: .8em;
@@ -1199,29 +1208,29 @@ is wide enough */
     font-size: 80%;
 }
 
-.searchMenu a.dropdown-toggle {
+.op-search-menu a.dropdown-toggle {
     margin-top: 5px;
     margin-bottom: 12px;
     font-weight: 600;
     color: initial;
 }
 
-.searchMenua.dropdown-toggle:hover {
+.op-search-menu a.dropdown-toggle:hover {
     text-decoration: none;
 }
 
-.searchMenu a.op-search-param {
+.op-search-menu a.op-search-param {
     margin-top: 5px;
     margin-bottom: 12px;
     font-weight: 70;
     color: initial;
 }
 
-.searchMenu a.op-search-param:hover {
+.op-search-menu a.op-search-param:hover {
     text-decoration: none;
 }
 
-#searchMenu .list-group li:nth-child(1) {
+.op-search-menu .list-group li:nth-child(1) {
     border-top: 0 none;
 }
 

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -45,7 +45,7 @@ var o_browse = {
     imageSize: 100,     // default
 
     metadataDetailOpusId: "",
-    metadataSelectorDrawn: false,
+    selectMetadataDrawn: false,
 
     tempHash: "",
     onRenderData: false,
@@ -91,7 +91,7 @@ var o_browse = {
             }
         });
 
-        $("#op-metadata-selector").modal({
+        $("#op-select-metadata").modal({
             keyboard: false,
             backdrop: 'static',
             show: false,
@@ -475,7 +475,7 @@ var o_browse = {
 
             if ((e.which || e.keyCode) == 27) { // esc - close modals
                 o_browse.hideGalleryViewModal();
-                $("#op-metadata-selector").modal('hide');
+                $("#op-select-metadata").modal('hide');
                 // reset range select
                 o_browse.undoRangeSelect();
             }
@@ -849,7 +849,6 @@ var o_browse = {
         // 2. In table view, the top obs will stay the same.
         if (browserResized) {
             currentScrollObsNum = previousScrollObsNum;
-            let scrollbarOffset = o_browse.getScrollbarOffset(obsNum, currentScrollObsNum);
             let infiniteScrollDataObj = $(`${tab} ${contentsView}`).data("infiniteScroll").options;
             let offset = infiniteScrollDataObj.scrollbarOffset;
 
@@ -1166,51 +1165,19 @@ var o_browse = {
         opus.changeTab("detail");
     },
 
-    // columns can be reordered wrt each other in 'metadata selector' by dragging them
-    metadataDragged: function(element) {
-        let cols = $.map($(element).sortable("toArray"), function(item) {
-            return item.split("__")[1];
-        });
-        opus.prefs.cols = cols;
-    },
 
-    addColumn: function(slug) {
-        let menuSelector = `#op-metadata-selector .op-all-metadata-column a[data-slug=${slug}]`;
-        o_menu.markMenuItem(menuSelector);
-
-        let label = $(menuSelector).data("qualifiedlabel");
-        let info = `<i class="fas fa-info-circle" title="${$(menuSelector).find('*[title]').attr("title")}"></i>`;
-        let html = `<li id="cchoose__${slug}" class="ui-sortable-handle"><span class="info">&nbsp;${info}</span>${label}<span class="unselect"><i class="far fa-trash-alt"></span></li>`;
-        $(".op-selected-metadata-column > ul").append(html);
-    },
-
-    resetMetadata: function(cols, closeModal) {
-        opus.prefs.cols = cols.slice();
-
-        if (closeModal == true) {
-            $("#op-metadata-selector").modal('hide');
-        }
-
-        // uncheck all on left; we will check them as we go
-        o_menu.markMenuItem("#op-metadata-selector .op-all-metadata-column a", "unselect");
-
-        // remove all from selected column
-        $("#op-metadata-selector .op-selected-metadata-column li").remove();
-
-        // add them back and set the check
-        $.each(cols, function(index, slug) {
-            o_browse.addColumn(slug);
-        });
-    },
+    /******************************************/
+    /********* SELECT METADATA DIALOG *********/
+    /******************************************/
 
     // metadata selector behaviors
-    addMetadataSelectorBehaviors: function() {
+    addSelectMetadataBehaviors: function() {
         // Global within this function so behaviors can communicate
         /* jshint varstmt: false */
         var currentSelectedMetadata = opus.prefs.cols.slice();
         /* jshint varstmt: true */
 
-        $("#op-metadata-selector").on("hide.bs.modal", function(e) {
+        $("#op-select-metadata").on("hide.bs.modal", function(e) {
             // update the data table w/the new columns
             if (!o_utils.areObjectsEqual(opus.prefs.cols, currentSelectedMetadata)) {
                 let tab = opus.getViewTab();
@@ -1224,14 +1191,15 @@ var o_browse = {
             }
         });
 
-        $("#op-metadata-selector").on("show.bs.modal", function(e) {
+        $("#op-select-metadata").on("show.bs.modal", function(e) {
             // this is to make sure modal is back to it original position when open again
-            $("#op-metadata-selector .modal-dialog").css({top: 0, left: 0});
+            $("#op-select-metadata .modal-dialog").css({top: 0, left: 0});
+            o_browse.adjustSelectMetadataHeight();
             // save current column state so we can look for changes
             currentSelectedMetadata = opus.prefs.cols.slice();
 
             o_browse.hideMenu();
-            o_browse.renderMetadataSelector();
+            o_browse.renderSelectMetadata();
 
             // Do the fake API call to write in the Apache log files that
             // we invoked the metadata selector so log_analyzer has something to
@@ -1241,12 +1209,12 @@ var o_browse = {
             });
         });
 
-        $("#op-metadata-selector .op-all-metadata-column").on("click", '.submenu li a', function() {
+        $("#op-select-metadata .op-all-metadata-column").on("click", '.submenu li a', function() {
             let slug = $(this).data('slug');
             if (!slug) { return; }
 
             let chosenSlugSelector = `#cchoose__${slug}`;
-            let menuSelector = `#op-metadata-selector .op-all-metadata-column a[data-slug=${slug}]`;
+            let menuSelector = `#op-select-metadata .op-all-metadata-column a[data-slug=${slug}]`;
 
             if ($(chosenSlugSelector).length === 0) {
                 // this slug was previously unselected, add to cols
@@ -1265,7 +1233,7 @@ var o_browse = {
         });
 
         // removes chosen column
-        $("#op-metadata-selector .op-selected-metadata-column").on("click", "li .unselect", function() {
+        $("#op-select-metadata .op-selected-metadata-column").on("click", "li .unselect", function() {
             if (opus.prefs.cols.length <= 1) {
                 return;     // prevent user from removing all the columns
             }
@@ -1277,14 +1245,14 @@ var o_browse = {
                 $(`#cchoose__${slug}`).fadeOut(200, function() {
                     $(this).remove();
                 });
-                let menuSelector = `#op-metadata-selector .op-all-metadata-column a[data-slug=${slug}]`;
+                let menuSelector = `#op-select-metadata .op-all-metadata-column a[data-slug=${slug}]`;
                 o_menu.markMenuItem(menuSelector, "unselected");
             }
             return false;
         });
 
         // buttons
-        $("#op-metadata-selector").on("click", ".btn", function() {
+        $("#op-select-metadata").on("click", ".btn", function() {
             switch($(this).attr("type")) {
                 case "reset":
                     opus.prefs.cols = [];
@@ -1299,20 +1267,170 @@ var o_browse = {
                     break;
             }
         });
-    },  // /addMetadataSelectorBehaviors
+    },  // /addSelectMetadataBehaviors
 
-    // there are interactions that are applied to different code snippets,
-    // this returns the namespace, view_var
-    // that distinguishes cart vs result tab views
-    // NOTE: get rid of all this with a framework!
-    // usage:
-    // utility function to figure out what view we are in
-    /*
-        // usage
-        view_info = o_browse.getViewInfo();
-        namespace = view_info['namespace'];
-        prefix = view_info['prefix'];
-    */
+    renderSelectMetadata: function() {
+        if (!o_browse.selectMetadataDrawn) {
+            let url = "/opus/__forms/metadata_selector.html?" + o_hash.getHash();
+            $(".modal-body.metadata").load( url, function(response, status, xhr)  {
+
+                o_browse.selectMetadataDrawn = true;  // bc this gets saved not redrawn
+                $("#op-select-metadata .op-reset-button").hide(); // we are not using this
+
+                // since we are rendering the left side of metadata selector w/the same code that builds the select menu,
+                // we need to unhighlight the selected widgets
+                o_menu.markMenuItem("#op-select-metadata .op-all-metadata-column a", "unselect");
+
+                // display check next to any currently used columns
+                $.each(opus.prefs.cols, function(index, col) {
+                    o_menu.markMenuItem(`#op-select-metadata .op-all-metadata-column a[data-slug="${col}"]`);
+                });
+
+                o_browse.addSelectMetadataBehaviors();
+
+                o_browse.allMetadataScrollbar = new PerfectScrollbar("#op-select-metadata-contents .op-all-metadata-column", {
+                    minScrollbarLength: opus.minimumPSLength
+                });
+                o_browse.selectedMetadataScrollbar = new PerfectScrollbar("#op-select-metadata-contents .op-selected-metadata-column", {
+                    minScrollbarLength: opus.minimumPSLength
+                });
+
+                $(".op-selected-metadata-column > ul").sortable({
+                    items: "li",
+                    cursor: "grab",
+                    stop: function(event, ui) { o_browse.metadataDragged(this); }
+                });
+            });
+        }
+    },
+
+    addColumn: function(slug) {
+        let menuSelector = `#op-select-metadata .op-all-metadata-column a[data-slug=${slug}]`;
+        o_menu.markMenuItem(menuSelector);
+
+        let label = $(menuSelector).data("qualifiedlabel");
+        let info = `<i class="fas fa-info-circle" title="${$(menuSelector).find('*[title]').attr("title")}"></i>`;
+        let html = `<li id="cchoose__${slug}" class="ui-sortable-handle"><span class="info">&nbsp;${info}</span>${label}<span class="unselect"><i class="far fa-trash-alt"></span></li>`;
+        $(".op-selected-metadata-column > ul").append(html);
+    },
+
+    // columns can be reordered wrt each other in 'metadata selector' by dragging them
+    metadataDragged: function(element) {
+        let cols = $.map($(element).sortable("toArray"), function(item) {
+            return item.split("__")[1];
+        });
+        opus.prefs.cols = cols;
+    },
+
+    resetMetadata: function(cols, closeModal) {
+        opus.prefs.cols = cols.slice();
+
+        if (closeModal == true) {
+            $("#op-select-metadata").modal('hide');
+        }
+
+        // uncheck all on left; we will check them as we go
+        o_menu.markMenuItem("#op-select-metadata .op-all-metadata-column a", "unselect");
+
+        // remove all from selected column
+        $("#op-select-metadata .op-selected-metadata-column li").remove();
+
+        // add them back and set the check
+        $.each(cols, function(index, slug) {
+            o_browse.addColumn(slug);
+        });
+    },
+
+    adjustSelectMetadataHeight: function() {
+        /**
+         * Set the height of the "Select Metadata" dialog based on the browser size.
+         */
+        $(".op-select-metadata-headers").show(); // Show now so computations are accurate
+        $(".op-select-metadata-headers-hr").show();
+        let footerHeight = $(".app-footer").outerHeight();
+        let mainNavHeight = $("#op-main-nav").outerHeight();
+        let modalHeaderHeight = $("#op-select-metadata .modal-header").outerHeight();
+        let modalFooterHeight = $("#op-select-metadata .modal-footer").outerHeight();
+        let selectMetadataHeadersHeight = $(".op-select-metadata-headers").outerHeight()+30;
+        let selectMetadataHeadersHRHeight = $(".op-select-metadata-headers-hr").outerHeight();
+        /* If modalHeaderHeight is zero, the dialog is in the process of being rendered
+           and we don't have valid data yet. If we set the height based on the zeros,
+           we get an annoying "jump" in the dialog size after it's done rendering.
+           So we use a default value that will cover the common case of a dialog wide
+           enough to cause excessive header word wrap.
+        */
+        if (modalHeaderHeight === 0) {
+            modalHeaderHeight = 57;
+            modalFooterHeight = 68;
+            selectMetadataHeadersHeight = 122;
+            selectMetadataHeadersHRHeight = 1;
+
+        }
+        let totalNonGalleryHeight = (footerHeight + mainNavHeight + modalHeaderHeight +
+                                     modalFooterHeight + selectMetadataHeadersHeight +
+                                     selectMetadataHeadersHRHeight);
+        /* 55 is a rough guess for how much space we want below the dialog, when possible.
+           130 is the minimum size required to display four metadata fields.
+           Anything less than that makes the dialog useless. In that case we hide the
+           header text to give us more room. */
+        let height = Math.max($(window).height()-totalNonGalleryHeight-55);
+        if (height < 130) {
+            $(".op-select-metadata-headers").hide();
+            $(".op-select-metadata-headers-hr").hide();
+            height += selectMetadataHeadersHeight + selectMetadataHeadersHRHeight;
+        }
+        $(".op-all-metadata-column").css("height", height);
+        $(".op-selected-metadata-column").css("height", height);
+    },
+
+    selectMetadataMenuContainerHeight: function() {
+        return $(".op-all-metadata-column").outerHeight();
+    },
+
+    selectedMetadataContainerHeight: function() {
+        return $(".op-selected-metadata-column").outerHeight();
+    },
+
+    hideOrShowSelectMetadataMenuPS: function() {
+        let containerHeight = $(".op-all-metadata-column").height();
+        let menuHeight = $(".op-all-metadata-column .op-search-menu").height();
+        if (o_browse.allMetadataScrollbar) {
+            if (containerHeight >= menuHeight) {
+                if (!$(".op-all-metadata-column .ps__rail-y").hasClass("hide_ps__rail-y")) {
+                    $(".op-all-metadata-column .ps__rail-y").addClass("hide_ps__rail-y");
+                    o_browse.allMetadataScrollbar.settings.suppressScrollY = true;
+                }
+            } else {
+                $(".op-all-metadata-column .ps__rail-y").removeClass("hide_ps__rail-y");
+                o_browse.allMetadataScrollbar.settings.suppressScrollY = false;
+            }
+            o_browse.allMetadataScrollbar.update();
+        }
+    },
+
+    hideOrShowSelectedMetadataPS: function() {
+        let containerHeight = $(".op-selected-metadata-column").height();
+        let selectedMetadataHeight = $(".op-selected-metadata-column .ui-sortable").height();
+
+        if (o_browse.selectedMetadataScrollbar) {
+            if (containerHeight >= selectedMetadataHeight) {
+                if (!$(".op-selected-metadata-column .ps__rail-y").hasClass("hide_ps__rail-y")) {
+                    $(".op-selected-metadata-column .ps__rail-y").addClass("hide_ps__rail-y");
+                    o_browse.selectedMetadataScrollbar.settings.suppressScrollY = true;
+                }
+            } else {
+                $(".op-selected-metadata-column .ps__rail-y").removeClass("hide_ps__rail-y");
+                o_browse.selectedMetadataScrollbar.settings.suppressScrollY = false;
+            }
+            o_browse.selectedMetadataScrollbar.update();
+        }
+    },
+
+    /*************************************************/
+    /********* END OF SELECT METADATA DIALOG *********/
+    /*************************************************/
+
+
     getViewInfo: function() {
         // this function returns some data you need depending on whether
         // you are in #cart or #browse views
@@ -1386,49 +1504,6 @@ var o_browse = {
         return url;
     },
 
-    metadataSelectorMenuContainerHeight: function() {
-        return $(".op-all-metadata-column").outerHeight();
-    },
-
-    selectedMetadataContainerHeight: function() {
-        return $(".op-selected-metadata-column").outerHeight();
-    },
-
-    renderMetadataSelector: function() {
-        if (!o_browse.metadataSelectorDrawn) {
-            let url = "/opus/__forms/metadata_selector.html?" + o_hash.getHash();
-            $(".modal-body.metadata").load( url, function(response, status, xhr)  {
-
-                o_browse.metadataSelectorDrawn = true;  // bc this gets saved not redrawn
-                $("#op-metadata-selector .op-reset-button").hide(); // we are not using this
-
-                // since we are rendering the left side of metadata selector w/the same code that builds the select menu,
-                // we need to unhighlight the selected widgets
-                o_menu.markMenuItem("#op-metadata-selector .op-all-metadata-column a", "unselect");
-
-                // display check next to any currently used columns
-                $.each(opus.prefs.cols, function(index, col) {
-                    o_menu.markMenuItem(`#op-metadata-selector .op-all-metadata-column a[data-slug="${col}"]`);
-                });
-
-                o_browse.addMetadataSelectorBehaviors();
-
-                o_browse.allMetadataScrollbar = new PerfectScrollbar("#op-metadata-selector-contents .op-all-metadata-column", {
-                    minScrollbarLength: opus.minimumPSLength
-                });
-                o_browse.selectedMetadataScrollbar = new PerfectScrollbar("#op-metadata-selector-contents .op-selected-metadata-column", {
-                    minScrollbarLength: opus.minimumPSLength
-                });
-
-                $(".op-selected-metadata-column > ul").sortable({
-                    items: "li",
-                    cursor: "grab",
-                    stop: function(event, ui) { o_browse.metadataDragged(this); }
-                });
-            });
-        }
-    },
-
     renderGalleryAndTable: function(data, url, view) {
         // render the gallery and table at the same time.
         let tab = opus.getViewTab(view);
@@ -1484,7 +1559,7 @@ var o_browse = {
                 // we have to store the relative observation number because we may not have pages in succession, this is for the slider position
                 viewNamespace.observationData[opusId] = item.metadata;	// for galleryView, store in global array
 
-                let mainTitle = `#${item.obs_num}: ${opusId}\r\nClick to enlarge\r\Ctrl+click to toggle cart\r\nShift+click to start/end range`;
+                let mainTitle = `#${item.obs_num}: ${opusId}\r\nClick to enlarge (slideshow mode)\r\Ctrl+click to toggle cart\r\nShift+click to start/end range`;
 
                 // gallery
                 let images = item.images;
@@ -1850,9 +1925,9 @@ var o_browse = {
                 }
             });
 
-            function eventListenerWithView(event, response, path) {
+            let eventListenerWithView = function(event, response, path) {
                 o_browse.infiniteScrollLoadEventListener(event, response, path, view);
-            }
+            };
             $(selector).on("load.infiniteScroll", eventListenerWithView);
         }
     },
@@ -1991,7 +2066,7 @@ var o_browse = {
 
         $(".op-page-loading-status > .loader").show();
         o_browse.updateBrowseNav();
-        o_browse.renderMetadataSelector();   // just do this in background so there's no delay when we want it...
+        o_browse.renderSelectMetadata();   // just do this in background so there's no delay when we want it...
         // Call the following two functions to make sure the height of .op-gallery-view and .op-data-table-view
         // are set. This will prevent the height of data obs containers from jumping when the page is loaded,
         // and avoid the wrong calculation of container position in setScrollbarPosition.
@@ -2087,42 +2162,6 @@ var o_browse = {
         $(`${tab} .op-data-table-view`).width(containerWidth);
         $(`${tab} .op-data-table-view`).height(containerHeight);
         opus.getViewNamespace().tableScrollbar.update();
-    },
-
-    adjustMetadataSelectorMenuPS: function() {
-        let containerHeight = $(".op-all-metadata-column").height();
-        let menuHeight = $(".op-all-metadata-column .searchMenu").height();
-
-        if (o_browse.allMetadataScrollbar) {
-            if (containerHeight > menuHeight) {
-                if (!$(".op-all-metadata-column .ps__rail-y").hasClass("hide_ps__rail-y")) {
-                    $(".op-all-metadata-column .ps__rail-y").addClass("hide_ps__rail-y");
-                    o_browse.allMetadataScrollbar.settings.suppressScrollY = true;
-                }
-            } else {
-                $(".op-all-metadata-column .ps__rail-y").removeClass("hide_ps__rail-y");
-                o_browse.allMetadataScrollbar.settings.suppressScrollY = false;
-            }
-            o_browse.allMetadataScrollbar.update();
-        }
-    },
-
-    adjustSelectedMetadataPS: function() {
-        let containerHeight = $(".op-selected-metadata-column").height();
-        let selectedMetadataHeight = $(".op-selected-metadata-column .ui-sortable").height();
-
-        if (o_browse.selectedMetadataScrollbar) {
-            if (containerHeight > selectedMetadataHeight) {
-                if (!$(".op-selected-metadata-column .ps__rail-y").hasClass("hide_ps__rail-y")) {
-                    $(".op-selected-metadata-column .ps__rail-y").addClass("hide_ps__rail-y");
-                    o_browse.selectedMetadataScrollbar.settings.suppressScrollY = true;
-                }
-            } else {
-                $(".op-selected-metadata-column .ps__rail-y").removeClass("hide_ps__rail-y");
-                o_browse.selectedMetadataScrollbar.settings.suppressScrollY = false;
-            }
-            o_browse.selectedMetadataScrollbar.update();
-        }
     },
 
     adjustBrowseDialogPS: function() {

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1391,16 +1391,15 @@ var o_browse = {
             modalFooterHeight = 68;
             selectMetadataHeadersHeight = 122;
             selectMetadataHeadersHRHeight = 1;
-
         }
-        let totalNonGalleryHeight = (footerHeight + mainNavHeight + modalHeaderHeight +
-                                     modalFooterHeight + selectMetadataHeadersHeight +
-                                     selectMetadataHeadersHRHeight);
+        let totalNonScrollableHeight = (footerHeight + mainNavHeight + modalHeaderHeight +
+                                        modalFooterHeight + selectMetadataHeadersHeight +
+                                        selectMetadataHeadersHRHeight);
         /* 55 is a rough guess for how much space we want below the dialog, when possible.
            130 is the minimum size required to display four metadata fields.
            Anything less than that makes the dialog useless. In that case we hide the
            header text to give us more room. */
-        let height = Math.max($(window).height()-totalNonGalleryHeight-55);
+        let height = Math.max($(window).height()-totalNonScrollableHeight-55);
         if (height < 130) {
             $(".op-select-metadata-headers").hide();
             $(".op-select-metadata-headers-hr").hide();

--- a/opus/application/static_media/js/cart.js
+++ b/opus/application/static_media/js/cart.js
@@ -226,7 +226,7 @@ var o_cart = {
     activateCartTab: function() {
         let view = opus.prefs.view;
         o_browse.updateBrowseNav();
-        o_browse.renderMetadataSelector();   // just do this in background so there's no delay when we want it...
+        o_browse.renderSelectMetadata();   // just do this in background so there's no delay when we want it...
         if (o_cart.reloadObservationData) {
             let zippedFiles_html = $(".zippedFiles", "#cart").html();
             $("#cart .op-results-message").hide();

--- a/opus/application/static_media/js/mutationObserver.js
+++ b/opus/application/static_media/js/mutationObserver.js
@@ -47,11 +47,12 @@ var o_mutationObserver = {
         // calculation of setScrollbarPosition will be correct and slider value will match startObs.
         let adjustBrowseHeight = function() {o_browse.adjustBrowseHeight(true);};
         let adjustTableSize = o_browse.adjustTableSize;
-        
+
         let adjustProductInfoHeight = _.debounce(o_cart.adjustProductInfoHeight, 200);
         let adjustHelpPanelHeight = _.debounce(opus.adjustHelpPanelHeight, 200);
-        let adjustMetadataSelectorMenuPS = _.debounce(o_browse.adjustMetadataSelectorMenuPS, 200);
-        let adjustSelectedMetadataPS = _.debounce(o_browse.adjustSelectedMetadataPS, 200);
+        let adjustSelectMetadataHeight = _.debounce(o_browse.adjustSelectMetadataHeight, 200);
+        let hideOrShowSelectMetadataMenuPS = _.debounce(o_browse.hideOrShowSelectMetadataMenuPS, 200);
+        let hideOrShowSelectedMetadataPS = _.debounce(o_browse.hideOrShowSelectedMetadataPS, 200);
         let adjustBrowseDialogPS = _.debounce(o_browse.adjustBrowseDialogPS, 200);
 
         // Init MutationObserver with a callback function. Callback will be called when changes are detected.
@@ -144,12 +145,18 @@ var o_mutationObserver = {
         });
 
         // ps in select metadata modal
-        let metadataSelectorObserver = new MutationObserver(function(mutationsList) {
-            adjustMetadataSelectorMenuPS();
-            adjustSelectedMetadataPS();
+        let selectMetadataObserver = new MutationObserver(function(mutationsList) {
+            mutationsList.forEach((mutation, idx) => {
+                //ignore attribute change in ps to avoid infinite loop of callback function caused by ps update
+                if (!mutation.target.classList.value.match(/ps/)) {
+                    adjustSelectMetadataHeight();
+                }
+            });
+            hideOrShowSelectMetadataMenuPS();
+            hideOrShowSelectedMetadataPS();
         });
 
-        let metadataSelectorMenuObserver = new MutationObserver(function(mutationsList) {
+        let selectMetadataMenuObserver = new MutationObserver(function(mutationsList) {
             let lastMutationIdx = mutationsList.length - 1;
             mutationsList.forEach((mutation, idx) => {
                 if (idx === lastMutationIdx) {
@@ -160,13 +167,13 @@ var o_mutationObserver = {
                         // Note we call the original version here, not the debounced
                         // version, because we need the PS to be visible instantly in
                         // order for scrollTop to work below.
-                        o_browse.adjustMetadataSelectorMenuPS();
+                        o_browse.hideOrShowSelectMetadataMenuPS();
                         // if the collapse opens below the viewable area, move the scrollbar
                         // only move the scrollbar if we open the menu item
                         let lastElement = $(mutation.target).children().last();
                         if (mutation.target.classList.value.match(/show/) &&
                             !lastElement.isOnScreen(".op-all-metadata-column", 1)) {
-                            let containerHeight = o_browse.metadataSelectorMenuContainerHeight();
+                            let containerHeight = o_browse.selectMetadataMenuContainerHeight();
                             let containerTop = $(".op-all-metadata-column").offset().top;
                             let containerBottom = containerHeight + containerTop;
                             let elementTop = lastElement.offset().top;
@@ -187,7 +194,7 @@ var o_mutationObserver = {
                         // Note we call the original version here, not the debounced
                         // version, because we need the PS to be visible instantly in
                         // order for scrollTop to work below.
-                        o_browse.adjustSelectedMetadataPS();
+                        o_browse.hideOrShowSelectedMetadataPS();
                         // if the new item appears below the viewable area, move the scrollbar
                         let lastElement = $(mutation.target).children().last();
                         if (mutation.addedNodes.length !== 0 &&
@@ -233,8 +240,8 @@ var o_mutationObserver = {
         let searchSidebar = $("#sidebar")[0];
         let searchWidget = $("#op-search-widgets")[0];
         let helpPanel = $("#op-help-panel")[0];
-        let metadataSelector = $("#op-metadata-selector")[0];
-        let metadataSelectorContents = $("#op-metadata-selector-contents")[0];
+        let selectMetadata = $("#op-select-metadata")[0];
+        let selectMetadataContents = $("#op-select-metadata-contents")[0];
         let browseDialogModal = $("#galleryView.modal")[0];
         let galleryView = $(".gallery")[0];
         let tableView = $(".op-data-table")[0];
@@ -259,11 +266,11 @@ var o_mutationObserver = {
         // update ps in help panel
         helpPanelObserver.observe(helpPanel, attrObserverConfig);
         // update ps when select metadata modal open/close,
-        metadataSelectorObserver.observe(metadataSelector, {attributes: true});
+        selectMetadataObserver.observe(selectMetadata, {attributes: true});
         // udpate ps when select metadata menu expand/collapse
-        metadataSelectorMenuObserver.observe(metadataSelectorContents, attrObserverConfig);
+        selectMetadataMenuObserver.observe(selectMetadataContents, attrObserverConfig);
         // update ps when selected metadata are added/removed
-        selectedMetadataObserver.observe(metadataSelectorContents, childListObserverConfig);
+        selectedMetadataObserver.observe(selectMetadataContents, childListObserverConfig);
         // update ps when browse dialog open/close
         browseDialogObserver.observe(browseDialogModal, {attributes: true});
         // udpate ps in browse gallery view

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -617,7 +617,6 @@ var opus = {
         let adjustProductInfoHeightDB = _.debounce(o_cart.adjustProductInfoHeight, 200);
         let adjustDetailHeightDB = _.debounce(o_detail.adjustDetailHeight, 200);
         let adjustHelpPanelHeightDB = _.debounce(opus.adjustHelpPanelHeight, 200);
-        let adjustSelectMetadataHeightDB = _.debounce(o_browse.adjustSelectMetadataHeight, 200);
         let hideOrShowSelectMetadataMenuPSDB = _.debounce(o_browse.hideOrShowSelectMetadataMenuPS, 200);
         let hideOrShowSelectedMetadataPSDB = _.debounce(o_browse.hideOrShowSelectedMetadataPS, 200);
         let adjustBrowseDialogPSDB = _.debounce(o_browse.adjustBrowseDialogPS, 200);
@@ -630,7 +629,7 @@ var opus = {
             adjustProductInfoHeightDB();
             adjustDetailHeightDB();
             adjustHelpPanelHeightDB();
-            adjustSelectMetadataHeightDB();
+            o_browse.adjustSelectMetadataHeight();
             hideOrShowSelectMetadataMenuPSDB();
             hideOrShowSelectedMetadataPSDB();
             adjustBrowseDialogPSDB();

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -215,7 +215,7 @@ var opus = {
 
         // Force the Select Metadata dialog to refresh the next time we go to the browse
         // tab in case the categories are changed by this search.
-        o_browse.metadataSelectorDrawn = false;
+        o_browse.selectMetadataDrawn = false;
 
         // Clear the gallery and table views on the browse tab so we start afresh when the data
         // returns. There's no point in clearing the cart tab since the search doesn't
@@ -613,8 +613,9 @@ var opus = {
         let adjustProductInfoHeightDB = _.debounce(o_cart.adjustProductInfoHeight, 200);
         let adjustDetailHeightDB = _.debounce(o_detail.adjustDetailHeight, 200);
         let adjustHelpPanelHeightDB = _.debounce(opus.adjustHelpPanelHeight, 200);
-        let adjustMetadataSelectorMenuPSDB = _.debounce(o_browse.adjustMetadataSelectorMenuPS, 200);
-        let adjustSelectedMetadataPSDB = _.debounce(o_browse.adjustSelectedMetadataPS, 200);
+        let adjustSelectMetadataHeightDB = _.debounce(o_browse.adjustSelectMetadataHeight, 200);
+        let hideOrShowSelectMetadataMenuPSDB = _.debounce(o_browse.hideOrShowSelectMetadataMenuPS, 200);
+        let hideOrShowSelectedMetadataPSDB = _.debounce(o_browse.hideOrShowSelectedMetadataPS, 200);
         let adjustBrowseDialogPSDB = _.debounce(o_browse.adjustBrowseDialogPS, 200);
         let displayCartLeftPaneDB = _.debounce(o_cart.displayCartLeftPane, 200);
 
@@ -625,8 +626,9 @@ var opus = {
             adjustProductInfoHeightDB();
             adjustDetailHeightDB();
             adjustHelpPanelHeightDB();
-            adjustMetadataSelectorMenuPSDB();
-            adjustSelectedMetadataPSDB();
+            adjustSelectMetadataHeightDB();
+            hideOrShowSelectMetadataMenuPSDB();
+            hideOrShowSelectedMetadataPSDB();
             adjustBrowseDialogPSDB();
             displayCartLeftPaneDB();
             opus.checkBrowserSize();

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -438,7 +438,7 @@ var o_search = {
 
     searchSideBarHeightChanged: function() {
         let containerHeight = o_search.searchBarContainerHeight();
-        let searchMenuHeight = $(".searchMenu").height();
+        let searchMenuHeight = $(".op-search-menu").height();
         $("#search .sidebar_wrapper").height(containerHeight);
 
         if (containerHeight > searchMenuHeight) {
@@ -499,12 +499,11 @@ var o_search = {
 
         o_widgets.updateWidgetCookies();
 
-        for (let key in opus.prefs.widgets) {  // fetch each widget
-            let slug = opus.prefs.widgets[key];
+        $.each(opus.prefs.widgets, function(key, slug) {
             if ($.inArray(slug, opus.widgetsDrawn) < 0) {  // only draw if not already drawn
                 o_widgets.getWidget(slug,"#op-search-widgets");
             }
-        }
+        });
 
         o_search.searchTabDrawn = true;
     },


### PR DESCRIPTION
- Fixes #781 
- Clean up select metadata code
- Rename metadata selector to select metadata everywhere
- Add headers to select metadata dialog with instructions
- Implement dialog responsiveness in JS instead of CSS for more flexibility
- Rename #searchMenu to op-search-menu and various other cleanup