### PR TITLE
Fix the issue of the missing (i) icon next to qtype in search widgets (issue #827)

### DIFF
--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -453,7 +453,7 @@
     <div class="op-overlay"></div>
 
     {% include "ui/footer.html" %}
-    <div id="op-range-qtype-helper-html">
+    <div id="op-qtype-tooltip">
         <p><strong>Any</strong> = The image contains at least a portion of the region bounded by the given min and max.</p>
 
         <p><strong>All</strong> = The image contains the entire requested range from min to max.</p>

--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -453,7 +453,7 @@
     <div class="op-overlay"></div>
 
     {% include "ui/footer.html" %}
-    <div id="range_query_widget_helper_html">
+    <div id="op-range-qtype-helper-html">
         <p><strong>Any</strong> = The image contains at least a portion of the region bounded by the given min and max.</p>
 
         <p><strong>All</strong> = The image contains the entire requested range from min to max.</p>

--- a/opus/application/apps/ui/templates/ui/widget.html
+++ b/opus/application/apps/ui/templates/ui/widget.html
@@ -44,11 +44,6 @@
                     {% endif %}
 
                         {{ form|safe }}
-                    {% if initial_qtype %}
-                        <li class ="op-range-qtype-helper">
-                            <a class="text-dark" tabindex="0" data-toggle="popover" data-placement="left"><i class="fas fa-info-circle"></i></a>
-                        </li>
-                    {% endif %}
                 </ul>
             </div>
         </article>

--- a/opus/application/apps/ui/templates/ui/widget.html
+++ b/opus/application/apps/ui/templates/ui/widget.html
@@ -1,7 +1,7 @@
 {% comment %}
     this is all inside of: <li id="widget__{{ slug }}" class="widget">
 
-    #op-range-qtype-helper-html div is appended in base.html, and popover is initialized
+    #op-qtype-tooltip div is appended in base.html, and popover is initialized
     in getWidget function in widgets.js
 {% endcomment %}
 

--- a/opus/application/apps/ui/templates/ui/widget.html
+++ b/opus/application/apps/ui/templates/ui/widget.html
@@ -1,7 +1,8 @@
 {% comment %}
     this is all inside of: <li id="widget__{{ slug }}" class="widget">
 
-    range-qtype-helper div is appended in widgets.js becuase omg was impossible to layout #todo
+    #op-range-qtype-helper-html div is appended in base.html, and popover is initialized
+    in getWidget function in widgets.js
 {% endcomment %}
 
 <div class="card">
@@ -43,6 +44,11 @@
                     {% endif %}
 
                         {{ form|safe }}
+                    {% if initial_qtype %}
+                        <li class ="op-range-qtype-helper">
+                            <a class="text-dark" tabindex="0" data-toggle="popover" data-placement="left"><i class="fas fa-info-circle"></i></a>
+                        </li>
+                    {% endif %}
                 </ul>
             </div>
         </article>

--- a/opus/application/apps/ui/views.py
+++ b/opus/application/apps/ui/views.py
@@ -305,6 +305,7 @@ def api_get_widget(request, **kwargs):
         "range_form_types": settings.RANGE_FORM_TYPES,
         "mult_form_types": settings.MULT_FORM_TYPES,
         "units": units,
+        'initial_qtype': initial_qtype,
     }
     ret = render(request, template, context)
 

--- a/opus/application/apps/ui/views.py
+++ b/opus/application/apps/ui/views.py
@@ -293,7 +293,6 @@ def api_get_widget(request, **kwargs):
     label = param_info.body_qualified_label()
     intro = param_info.intro
     units = param_info.get_units()
-
     template = "ui/widget.html"
     context = {
         "slug": slug,
@@ -305,7 +304,6 @@ def api_get_widget(request, **kwargs):
         "range_form_types": settings.RANGE_FORM_TYPES,
         "mult_form_types": settings.MULT_FORM_TYPES,
         "units": units,
-        'initial_qtype': initial_qtype,
     }
     ret = render(request, template, context)
 

--- a/opus/application/apps/ui/views.py
+++ b/opus/application/apps/ui/views.py
@@ -293,6 +293,7 @@ def api_get_widget(request, **kwargs):
     label = param_info.body_qualified_label()
     intro = param_info.intro
     units = param_info.get_units()
+
     template = "ui/widget.html"
     context = {
         "slug": slug,

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -1314,7 +1314,7 @@ is wide enough */
     color: gray;
 }
 
-#op-range-qtype-helper-html {
+#op-qtype-tooltip {
     display: none;
     width: 500px;
 }

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -1309,12 +1309,12 @@ is wide enough */
     padding-left: 3%;
 }
 
-.widget-main .range-qtype-helper {
+.widget-main .op-range-qtype-helper {
     font-size: 130%;
     color: gray;
 }
 
-#range_query_widget_helper_html {
+#op-range-qtype-helper-html {
     display: none;
     width: 500px;
 }

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -76,6 +76,19 @@ var o_widgets = {
                 }
             });
         });
+
+        // $("#search").on("click", ".widget-main .op-range-qtype-helper", function() {
+            // $(".widget-main .op-range-qtype-helper i").popover({
+            //   // html:true,
+            //     container: "body",
+            //     // trigger:"hover",
+            //     content: function() {
+            //         console.log($("#op-range-qtype-helper-html").html());
+            //         return $("#op-range-qtype-helper-html").html();
+            //     }
+            // });
+        // });
+
     },
 
 
@@ -408,6 +421,16 @@ var o_widgets = {
                 opus.extras[qtype] = [defaultOption];
                 o_hash.updateHash();
             }
+
+            // Initialize popover, this for the (i) icon next to qtype 
+            $(".widget-main .op-range-qtype-helper a").popover({
+                html: true,
+                container: "body",
+                trigger:"hover",
+                content: function() {
+                    return $("#op-range-qtype-helper-html").html();
+                }
+            });
 
             // If we have a string input widget open, initialize autocomplete for string input
             let displayDropDownList = true;

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -76,19 +76,6 @@ var o_widgets = {
                 }
             });
         });
-
-        // $("#search").on("click", ".widget-main .op-range-qtype-helper", function() {
-            // $(".widget-main .op-range-qtype-helper i").popover({
-            //   // html:true,
-            //     container: "body",
-            //     // trigger:"hover",
-            //     content: function() {
-            //         console.log($("#op-range-qtype-helper-html").html());
-            //         return $("#op-range-qtype-helper-html").html();
-            //     }
-            // });
-        // });
-
     },
 
 
@@ -422,7 +409,7 @@ var o_widgets = {
                 o_hash.updateHash();
             }
 
-            // Initialize popover, this for the (i) icon next to qtype 
+            // Initialize popover, this for the (i) icon next to qtype
             $(".widget-main .op-range-qtype-helper a").popover({
                 html: true,
                 container: "body",

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -402,14 +402,7 @@ var o_widgets = {
             // Need to wait until api return to determine if the widget has qtype selections
             let hash = o_hash.getHashArray();
             let qtype = "qtype-" + slug;
-            if ($(`#widget__${slug} select[name="${qtype}"]`).length !== 0 && !hash[qtype]) {
-                // When a widget with qtype is open, the value of the first option tag is the default value for qtype
-                let defaultOption = $(`#widget__${slug} select[name="${qtype}"]`).first("option").val();
-                opus.extras[qtype] = [defaultOption];
-                o_hash.updateHash();
-            }
 
-            // If we have a widget with qtype options any/all/only, we will append the (i) icon.
             if ($(`#widget__${slug} select[name="${qtype}"]`).length !== 0) {
                 let qtypeValue = $(`#widget__${slug} select[name="${qtype}"] option:selected`).val();
                 if (qtypeValue === "any" || qtypeValue === "all" || qtypeValue === "only") {
@@ -417,6 +410,14 @@ var o_widgets = {
                                     <a class="text-dark" tabindex="0" data-toggle="popover" data-placement="left">\
                                     <i class="fas fa-info-circle"></i></a></li>';
                     $(`#widget__${slug} .widget-main ul`).append(helpIcon);
+                }
+
+                if (!hash[qtype]) {
+                    // When a widget with qtype is open, the value of the first option tag is the
+                    // default value for qtype
+                    let defaultOption = $(`#widget__${slug} select[name="${qtype}"]`).first("option").val();
+                    opus.extras[qtype] = [defaultOption];
+                    o_hash.updateHash();
                 }
             }
 
@@ -426,7 +427,7 @@ var o_widgets = {
                 container: "body",
                 trigger:"hover",
                 content: function() {
-                    return $("#op-range-qtype-helper-html").html();
+                    return $("#op-qtype-tooltip").html();
                 }
             });
 

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -409,6 +409,17 @@ var o_widgets = {
                 o_hash.updateHash();
             }
 
+            // If we have a widget with qtype options any/all/only, we will append the (i) icon.
+            if ($(`#widget__${slug} select[name="${qtype}"]`).length !== 0) {
+                let qtypeValue = $(`#widget__${slug} select[name="${qtype}"] option:selected`).val();
+                if (qtypeValue === "any" || qtypeValue === "all" || qtypeValue === "only") {
+                    let helpIcon = '<li class ="op-range-qtype-helper">\
+                                    <a class="text-dark" tabindex="0" data-toggle="popover" data-placement="left">\
+                                    <i class="fas fa-info-circle"></i></a></li>';
+                    $(`#widget__${slug} .widget-main ul`).append(helpIcon);
+                }
+            }
+
             // Initialize popover, this for the (i) icon next to qtype
             $(".widget-main .op-range-qtype-helper a").popover({
                 html: true,


### PR DESCRIPTION
- Fixes #827 
- Local branch: tooltip_issue_for_any_all_only_827
- Use the same popover method for the hover over event on (i) icon next to qtype.