### PR TITLE
Fix the issue of ps missing in browse gallery view in Safari. 

### DIFF
--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -133,11 +133,11 @@
                             <p>Remove or edit one or more of the search criteria selected on the Search tab
                             or click on the Reset Search button to reset the search criteria to default.</p>
                        </div>
-                       <div class="row justify-content-start op-gallery-view mx-0">
+                       <div class="justify-content-start op-gallery-view mx-0">
                             <div class="mr-0 thumb gallery gallery-scroll">
                             </div>
                         </div>
-                        <div class="row op-data-table-view mx-0">
+                        <div class="op-data-table-view mx-0">
                             <div class="col-lg p-0">
                                 <table class="table table-hover table-bordered table-striped table-dark table-sm op-data-table mb-0">
                                     <thead></thead>

--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -229,11 +229,11 @@
                                 at the top of the page, mouse over the thumbnail gallery images to reveal the tools,
                                 then click on the cart icon.  </p>
                             </div>
-                            <div class="row justify-content-start op-gallery-view mr-0 ml-1">
+                            <div class="justify-content-start op-gallery-view mr-0 ml-1">
                                 <div class="mr-0 thumb gallery gallery-scroll">
                                 </div>
                             </div>
-                            <div class="row op-data-table-view mx-0">
+                            <div class="op-data-table-view mx-0">
                                 <div class="col-lg p-0">
                                     <table class="table table-hover table-bordered table-striped table-dark table-sm op-no-select op-data-table mb-0">
                                         <thead></thead>

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -1061,6 +1061,11 @@ nav.panel-heading {
     text-decoration: none;
 }
 
+/* Make sure ps container is NOT a flexbox (display: flex) */
+#cart #op-download-options-container {
+    display: block;
+}
+
 /* Cart view navbar responsiveness */
 @media (max-width: 1100px) {
     /* Remove the top/bottom extra spaces in options of 2nd navbar when


### PR DESCRIPTION
This is caused by ps not working well in flexbox container (https://github.com/mdbootstrap/perfect-scrollbar/wiki/Caveats) , so we remove "row" class for .op-gallery-view and .op-data-table-view. And we also set display to block for #op-download-options-container. These three ps containers were set to display flex previously. 
Verified on latest Chrome, Firefox, Opera, Safari (12.1, 11.1, 10.1)


