### PR TITLE
Update OPUS Firefox supported version from 59+ to 64+.

### DIFF
--- a/opus/application/apps/help/templates/help/about.html
+++ b/opus/application/apps/help/templates/help/about.html
@@ -177,7 +177,7 @@
 </p>
 
 <p>Please note that OPUS requires a browser size of at least 600 by 350. We
-	support Firefox (59+), Chrome (56+), Safari (10.1+), and Opera (42+).
+	support Firefox (64+), Chrome (56+), Safari (10.1+), and Opera (42+).
 </p>
 
 <p>Updates are announced on

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -89,7 +89,7 @@ var opus = {
 
     // store the browser version and width supported by OPUS
     browserSupport: {
-        "firefox": 59,
+        "firefox": 64,
         "chrome": 56,
         "chrome (ios)": 56,
         "opera": 42,


### PR DESCRIPTION
When running with Firefox version 63 or less, the default scrollbar in detail page left pane will exist and show up in parallel with perfect scrollbar. This is caused by the workaround for enabling ctrl + F scroll search in opus.css (line 1478-1482). We will change the OPUS Firefox supported version to from 59+ to 64+.