### PR TITLE
Fix issues of messing up URL when clicking download buttons in cart page (#832) and ctrl + f search scroll in help pane (#828)

### DIFF
--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -1483,13 +1483,14 @@ the workaround for ctrl + F search scroll to work with perfect scrollbar */
 
 /* Hide the Chrome default scrollbar, this is part of steps to make ctrl
 + F search scroll to work with perfect scrollbar in Chrome. */
-.op-detail-metadata::-webkit-scrollbar {
+.op-detail-metadata::-webkit-scrollbar,
+#op-help-panel .card-body::-webkit-scrollbar {
     display: none;
 }
 
 /* Hide the FF default scrollbar in detail page, this is part of steps to
 make ctrl + F search scroll to work with perfect scrollbar in FF. */
-.op-detail-metadata {
+.op-detail-metadata, #op-help-panel .card-body {
     scrollbar-width: none;
 }
 

--- a/opus/application/static_media/js/cart.js
+++ b/opus/application/static_media/js/cart.js
@@ -66,10 +66,14 @@ var o_cart = {
         });
 
         $("#cart").on("click", ".downloadData", function(e) {
+            // prevent url hash from being changed to # (in a tag href)
+            e.preventDefault();
             o_cart.downloadZip("create_zip_data_file", "Internal error creating data zip file");
         });
 
         $("#cart").on("click", ".downloadURL", function(e) {
+            // prevent url hash from being changed to # (in a tag href)
+            e.preventDefault();
             o_cart.downloadZip("create_zip_url_file", "Internal error creating URL zip file");
         });
 

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -652,7 +652,9 @@ var opus = {
             opus.changeTab(tab);
         });
 
-        $(".op-help-item").on("click", function() {
+        $(".op-help-item").on("click", function(e) {
+            // prevent url hash from being changed to # (in a tag href)
+            e.preventDefault();
             opus.displayHelpPane($(this).data("action"));
         });
 

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -765,6 +765,12 @@ var opus = {
         $("#op-help-panel .op-header-text").html(`<h2>${header}</h2>`);
         $("#op-help-panel .op-card-contents").html("Loading... please wait.");
         $("#op-help-panel .loader").show();
+
+        // Enable default scrollbar for Ctrl + F search scroll to work in Chrome and Firefox.
+        if (opus.currentBrowser === "chrome" || opus.currentBrowser === "firefox") {
+            $("#op-help-panel .card-body").addClass("op-enable-default-scrolling");
+        }
+
         // We only need one perfectScrollbar because the pane is reused
         if (!opus.helpScrollbar) {
             opus.helpScrollbar = new PerfectScrollbar("#op-help-panel .card-body", {


### PR DESCRIPTION
- Fixes #832, #828
- Fixes the similar issue to #832 when clicking any item in help menu.
- Local branch: issues_832_828
