### PR TITLE
Add git commit and database info to About pane

### DIFF
--- a/opus/application/apps/help/templates/help/about.html
+++ b/opus/application/apps/help/templates/help/about.html
@@ -188,3 +188,7 @@
 <p>We actively solicit <a href="https://pds-rings.seti.org/cgi-bin/comments/form.pl" target="_blank">questions, comments, and feedback</a>
 	and look forward to hearing from you.
 </p>
+
+<hr>
+
+<p><small>git commit {{ git_id }} &mdash; {{ database_schema }} on {{ database_host}}</small></p>

--- a/opus/application/apps/help/templates/help/about.html
+++ b/opus/application/apps/help/templates/help/about.html
@@ -191,4 +191,5 @@
 
 <hr>
 
-<p><small>git commit {{ git_id }} &mdash; {{ database_schema }} on {{ database_host}}</small></p>
+<p><small>OPUS Version {{ git_id }}<br/>
+    Database {{ database_schema }} on {{ database_host}}</small></p>

--- a/opus/application/apps/help/views.py
+++ b/opus/application/apps/help/views.py
@@ -43,7 +43,7 @@ def api_about(request):
         exit_api_call(api_code, ret)
         raise ret
 
-    git_id = get_latest_git_commit_id(True)
+    git_id = get_git_version(True, True)
     database_schema = settings.DB_SCHEMA_NAME
     database_host = settings.DB_HOST_NAME
     context = {

--- a/opus/application/apps/help/views.py
+++ b/opus/application/apps/help/views.py
@@ -17,6 +17,8 @@ from metadata.views import get_fields_info
 from search.views import ObsGeneral, MultObsGeneralInstrumentId
 from tools.app_utils import *
 
+import settings
+
 log = logging.getLogger(__name__)
 
 
@@ -41,7 +43,16 @@ def api_about(request):
         exit_api_call(api_code, ret)
         raise ret
 
-    ret = render(request, 'help/about.html')
+    git_id = get_latest_git_commit_id(True)
+    database_schema = settings.DB_SCHEMA_NAME
+    database_host = settings.DB_HOST_NAME
+    context = {
+        'git_id': git_id,
+        'database_schema': database_schema,
+        'database_host': database_host
+    }
+
+    ret = render(request, 'help/about.html', context)
     exit_api_call(api_code, ret)
     return ret
 

--- a/opus/application/apps/tools/app_utils.py
+++ b/opus/application/apps/tools/app_utils.py
@@ -344,19 +344,39 @@ def format_metadata_number_or_func(val, form_type_func, form_type_format):
     except TypeError:
         return str(val)
 
-def get_latest_git_commit_id(force_valid=False):
+def get_git_version(force_valid=False, use_tag=False):
     curcwd = os.getcwd()
+    commit_id = 'Unknown'
+    tag = None
+
     try:
         os.chdir(settings.PDS_OPUS_PATH)
         # decode here to convert byte object to string
-        ret = (subprocess.check_output(['git', 'log', '--format=%H', '-n', '1'])
-               .strip().decode('utf8'))
+        commit_id = (subprocess.check_output(['git', 'log', '--format=%H',
+                                              '-n', '1'])
+                     .strip().decode('utf8'))
     except:
         log.warning('Unable to get the latest git commit id')
-        if force_valid:
-            ret = 'Unknown'
-        else:
-            ret = str(random.getrandbits(128))
+        if not force_valid:
+            commit_id = str(random.getrandbits(128))
+
+    if use_tag:
+        try:
+            # decode here to convert byte object to string
+            tag = (subprocess.check_output(['git', 'tag', '--points-at'])
+                   .strip().decode('utf8'))
+            if '\n' in tag:
+                tag = tag[:tag.index('\n')]
+        except:
+            log.warning('Unable to get the current git tag')
+
+    if tag:
+        if tag.startswith('v'):
+            tag = tag[1:]
+        ret = tag
+    else:
+        ret = commit_id
+
     os.chdir(curcwd)
     return ret
 

--- a/opus/application/apps/tools/app_utils.py
+++ b/opus/application/apps/tools/app_utils.py
@@ -344,7 +344,7 @@ def format_metadata_number_or_func(val, form_type_func, form_type_format):
     except TypeError:
         return str(val)
 
-def get_latest_git_commit_id():
+def get_latest_git_commit_id(force_valid=False):
     curcwd = os.getcwd()
     try:
         os.chdir(settings.PDS_OPUS_PATH)
@@ -353,7 +353,10 @@ def get_latest_git_commit_id():
                .strip().decode('utf8'))
     except:
         log.warning('Unable to get the latest git commit id')
-        ret = str(random.getrandbits(128))
+        if force_valid:
+            ret = 'Unknown'
+        else:
+            ret = str(random.getrandbits(128))
     os.chdir(curcwd)
     return ret
 

--- a/opus/application/apps/ui/views.py
+++ b/opus/application/apps/ui/views.py
@@ -48,7 +48,7 @@ class main_site(TemplateView):
         context['default_sort_order'] = settings.DEFAULT_SORT_ORDER
         context['menu'] = menu['menu']
         if settings.OPUS_FILE_VERSION == '':
-            settings.OPUS_FILE_VERSION = get_latest_git_commit_id()
+            settings.OPUS_FILE_VERSION = get_git_version()
         context['OPUS_FILE_VERSION'] = settings.OPUS_FILE_VERSION
         return context
 


### PR DESCRIPTION
While playing around with the servers I decided it would be helpful to make it easy to know which version of OPUS is running and what database is serving it. What do you think?
