### PR TITLE
Make sure when bootstrap modal is open, extra padding-right is not added to body and navbar

### DIFF
--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2,6 +2,16 @@ body {
     overflow: hidden;
 }
 
+/* Make sure when bootstrap modal is open, extra padding-right is not
+added to body and navbar */
+body.modal-open {
+    padding-right: 0 !important;
+}
+
+body.modal-open .navbar {
+    padding-right: 16px !important;
+}
+
 .app-body {
     margin-top: 3.8em !important;
     overflow: hidden;


### PR DESCRIPTION
When bootstrap modal is open, depending on the % of the browser size, some extra padding-right will be added to body and navbar. (please refer to this: https://github.com/twbs/bootstrap/issues/17622, it's carried over from bootstrap 3 and labeled as won't fix) This will cause the thumbnail images or the "help" icon shift to the left.  By keeping padding-right the same (in opus.css) before & after modal open, images and help icon will not shift left/right when we open/close modal.