### PR TITLE
Fix slider jump. Tighten up margins around numbers in slider.

### DIFF
--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1044,7 +1044,12 @@ var o_browse = {
             opus.prefs[startObsLabel] = obsNum;
 
             $(`${tab} .op-observation-number`).html(o_utils.addCommas(obsNum));
-            $(`${tab} .op-slider-pointer`).css("width", `${o_utils.addCommas(maxSliderVal).length*0.7}em`);
+            let numberWidth = o_utils.addCommas(maxSliderVal).length*0.5+0.7;
+            $(`${tab} .op-slider-pointer`).css("width", `${numberWidth}em`);
+            // See https://stackoverflow.com/questions/5540170/jquery-ui-sliders-hops-when-clicked
+            $(`${tab} .op-slider-pointer`).css("margin-left", `-${numberWidth/2}em`);
+            // This offsets the slider bar from the "Observation #" text
+            $(`${tab} .op-observation-slider`).css("margin-left", `${numberWidth/2-0.5}em`);
 
             // just make the step size the number of the obserations across the page...
             // if the observations have not yet been rendered, leave the default, it will get changed later


### PR DESCRIPTION
- Fix slider jumping when you click on it and move the mouse slightly.
- Tighten up the margins around the numbers in the slider.
- Fixes #838.