### PR TITLE
Minor bugfix to remove trashcan from selectMetadata

### DIFF
--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -538,6 +538,7 @@
     <script src="{{ STATIC_URL }}js/detail.js?version={{ OPUS_FILE_VERSION }}" type="text/javascript"></script>
     <script src="{{ STATIC_URL }}js/search.js?version={{ OPUS_FILE_VERSION }}" type="text/javascript"></script>
     <script src="{{ STATIC_URL }}js/widgets.js?version={{ OPUS_FILE_VERSION }}" type="text/javascript"></script>
+    <script src="{{ STATIC_URL }}js/selectMetadata.js?version={{ OPUS_FILE_VERSION }}" type="text/javascript"></script>
     <script src="{{ STATIC_URL }}js/hash.js?version={{ OPUS_FILE_VERSION }}" type="text/javascript"></script>
     <script src="{{ STATIC_URL }}js/dictionary.js?version={{ OPUS_FILE_VERSION }}" type="text/javascript"></script>
     <script src="{{ STATIC_URL }}js/mutationObserver.js?version={{ OPUS_FILE_VERSION }}" type="text/javascript"></script>

--- a/opus/application/apps/ui/templates/ui/select_metadata.html
+++ b/opus/application/apps/ui/templates/ui/select_metadata.html
@@ -32,7 +32,7 @@
       	    <ul>
                 {% for slug, param_info in all_slugs_info.items %}
       		        <li id="cchoose__{{ slug }}">
-                        <span class="info">&nbsp;<i class="fas fa-info-circle" title = "
+                        <span class="op-selected-metadata-info">&nbsp;<i class="fas fa-info-circle" title = "
                             {% if param_info.get_tooltip_results %}
                                 {{ param_info.get_tooltip_results|striptags }}
                             {% else  %}
@@ -40,7 +40,7 @@
                             {% endif %}
                         "></i></span>
                         {{ param_info.body_qualified_label_results }}
-                        <span class="unselect"><i class="far fa-trash-alt"></i></span>
+                        <span class="op-selected-metadata-unselect"><i class="far fa-trash-alt"></i></span>
     	            </li>
                 {% endfor %}
             </ul>

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -714,15 +714,15 @@ narrow */
     cursor: grab;
 }
 
-.op-selected-metadata-column ul li .unselect:hover {
+.op-selected-metadata-unselect:hover {
     cursor: default;
 }
 
-.op-selected-metadata-column ul li .info:hover {
+.op-selected-metadata-info:hover {
     cursor: default;
 }
 
-.op-selected-metadata-column .unselect {
+.op-selected-metadata-unselect {
     float: right;
 }
 

--- a/opus/application/static_media/js/cart.js
+++ b/opus/application/static_media/js/cart.js
@@ -4,7 +4,7 @@
 /* jshint nonbsp: true, nonew: true */
 /* jshint varstmt: true */
 /* globals $, PerfectScrollbar */
-/* globals o_browse, o_hash, o_utils, opus */
+/* globals o_browse, o_hash, o_utils, o_selectMetadata, opus */
 
 // The download data left pane will become a slide panel when screen width
 // is equal to or less than the threshold point.
@@ -311,6 +311,14 @@ var o_cart = {
         o_cart.adjustProductInfoHeight();
     },
 
+    isScreenNarrow: function(tab) {
+        return (tab === "#cart" && $(window).height() <= cartLeftPaneMinHeight);
+    },
+
+    isScreenShort: function(tab) {
+        return (tab === "#cart" && $(window).width() <= cartLeftPaneThreshold);
+    },
+
     // download filters
     getDownloadFiltersChecked: function() {
         // returned as url string
@@ -488,7 +496,7 @@ var o_cart = {
         opus.getViewNamespace().galleryBoundingRect = o_browse.countGalleryImages();
 
         o_browse.updateBrowseNav();
-        o_browse.renderSelectMetadata();   // just do this in background so there's no delay when we want it...
+        o_selectMetadata.render();   // just do this in background so there's no delay when we want it...
 
         if (o_cart.reloadObservationData) {
             let zippedFiles_html = $(".op-zipped-files", "#cart").html();

--- a/opus/application/static_media/js/menu.js
+++ b/opus/application/static_media/js/menu.js
@@ -103,7 +103,7 @@ var o_menu = {
 
     markCurrentMenuItems: function() {
         $.each(opus.prefs.widgets, function(index, slug) {
-            o_menu.markMenuItem(`li > [data-slug="${slug}"]`);
+            o_menu.markMenuItem(`.op-search-menu li > [data-slug="${slug}"]`);
         });
     },
 

--- a/opus/application/static_media/js/mutationObserver.js
+++ b/opus/application/static_media/js/mutationObserver.js
@@ -5,7 +5,7 @@
 /* jshint varstmt: true */
 /* jshint multistr: true */
 /* globals $, _ */
-/* globals o_browse, o_cart, o_search, opus */
+/* globals o_browse, o_cart, o_search, o_selectMetadata, opus */
 
 /* jshint varstmt: false */
 var o_mutationObserver = {
@@ -50,9 +50,9 @@ var o_mutationObserver = {
 
         let adjustProductInfoHeight = _.debounce(o_cart.adjustProductInfoHeight, 200);
         let adjustHelpPanelHeight = _.debounce(opus.adjustHelpPanelHeight, 200);
-        let adjustSelectMetadataHeight = _.debounce(o_browse.adjustSelectMetadataHeight, 200);
-        let hideOrShowSelectMetadataMenuPS = _.debounce(o_browse.hideOrShowSelectMetadataMenuPS, 200);
-        let hideOrShowSelectedMetadataPS = _.debounce(o_browse.hideOrShowSelectedMetadataPS, 200);
+        let adjustSelectMetadataHeight = _.debounce(o_selectMetadata.adjustHeight, 200);
+        let hideOrShowSelectMetadataMenuPS = _.debounce(o_selectMetadata.hideOrShowMenuPS, 200);
+        let hideOrShowSelectedMetadataPS = _.debounce(o_selectMetadata.hideOrShowPS, 200);
         let adjustBrowseDialogPS = _.debounce(o_browse.adjustBrowseDialogPS, 200);
 
         // Init MutationObserver with a callback function. Callback will be called when changes are detected.
@@ -167,13 +167,13 @@ var o_mutationObserver = {
                         // Note we call the original version here, not the debounced
                         // version, because we need the PS to be visible instantly in
                         // order for scrollTop to work below.
-                        o_browse.hideOrShowSelectMetadataMenuPS();
+                        o_selectMetadata.hideOrShowMenuPS();
                         // if the collapse opens below the viewable area, move the scrollbar
                         // only move the scrollbar if we open the menu item
                         let lastElement = $(mutation.target).children().last();
                         if (mutation.target.classList.value.match(/show/) &&
                             !lastElement.isOnScreen(".op-all-metadata-column", 1)) {
-                            let containerHeight = o_browse.selectMetadataMenuContainerHeight();
+                            let containerHeight = o_selectMetadata.menuContainerHeight();
                             let containerTop = $(".op-all-metadata-column").offset().top;
                             let containerBottom = containerHeight + containerTop;
                             let elementTop = lastElement.offset().top;
@@ -194,12 +194,12 @@ var o_mutationObserver = {
                         // Note we call the original version here, not the debounced
                         // version, because we need the PS to be visible instantly in
                         // order for scrollTop to work below.
-                        o_browse.hideOrShowSelectedMetadataPS();
+                        o_selectMetadata.hideOrShowPS();
                         // if the new item appears below the viewable area, move the scrollbar
                         let lastElement = $(mutation.target).children().last();
                         if (mutation.addedNodes.length !== 0 &&
                             !lastElement.isOnScreen(".op-selected-metadata-column", 1)) {
-                            let containerHeight = o_browse.selectedMetadataContainerHeight();
+                            let containerHeight = o_selectMetadata.containerHeight();
                             let containerTop = $(".op-selected-metadata-column").offset().top;
                             let containerBottom = containerHeight + containerTop;
                             let elementTop = lastElement.offset().top;

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -5,7 +5,7 @@
 /* jshint varstmt: true */
 /* jshint multistr: true */
 /* globals $, _, PerfectScrollbar */
-/* globals o_browse, o_cart, o_detail, o_hash, o_menu, o_mutationObserver, o_search, o_utils, o_widgets, FeedbackMethods */
+/* globals o_browse, o_cart, o_detail, o_hash, o_menu, o_selectMetadata, o_mutationObserver, o_search, o_utils, o_widgets, FeedbackMethods */
 /* globals DEFAULT_COLUMNS, DEFAULT_WIDGETS, DEFAULT_SORT_ORDER, STATIC_URL */
 
 // defining the opus namespace first; document ready comes after...
@@ -256,7 +256,7 @@ var opus = {
 
         // Force the Select Metadata dialog to refresh the next time we go to the browse
         // tab in case the categories are changed by this search.
-        o_browse.selectMetadataDrawn = false;
+        o_selectMetadata.rendered = false;
 
         // Clear the gallery and table views on the browse tab so we start afresh when the data
         // returns. There's no point in clearing the cart tab since the search doesn't
@@ -681,8 +681,8 @@ var opus = {
         let adjustProductInfoHeightDB = _.debounce(o_cart.adjustProductInfoHeight, 200);
         let adjustDetailHeightDB = _.debounce(o_detail.adjustDetailHeight, 200);
         let adjustHelpPanelHeightDB = _.debounce(opus.adjustHelpPanelHeight, 200);
-        let hideOrShowSelectMetadataMenuPSDB = _.debounce(o_browse.hideOrShowSelectMetadataMenuPS, 200);
-        let hideOrShowSelectedMetadataPSDB = _.debounce(o_browse.hideOrShowSelectedMetadataPS, 200);
+        let hideOrShowSelectMetadataMenuPSDB = _.debounce(o_selectMetadata.hideOrShowMenuPS, 200);
+        let hideOrShowSelectedMetadataPSDB = _.debounce(o_selectMetadata.hideOrShowPS, 200);
         let adjustBrowseDialogPSDB = _.debounce(o_browse.adjustBrowseDialogPS, 200);
         let displayCartLeftPaneDB = _.debounce(o_cart.displayCartLeftPane, 200);
 
@@ -693,7 +693,7 @@ var opus = {
             adjustProductInfoHeightDB();
             adjustDetailHeightDB();
             adjustHelpPanelHeightDB();
-            o_browse.adjustSelectMetadataHeight();
+            o_selectMetadata.adjustHeight();
             hideOrShowSelectMetadataMenuPSDB();
             hideOrShowSelectedMetadataPSDB();
             adjustBrowseDialogPSDB();

--- a/opus/application/static_media/js/selectMetadata.js
+++ b/opus/application/static_media/js/selectMetadata.js
@@ -70,7 +70,7 @@ var o_selectMetadata = {
         });
 
         // removes chosen column
-        $("#op-select-metadata .op-selected-metadata-column").on("click", "li .unselect", function() {
+        $("#op-select-metadata .op-selected-metadata-column").on("click", "li .op-selected-metadata-unselect", function() {
             let slug = $(this).parent().attr("id").split('__')[1];
             o_selectMetadata.removeColumn(slug);
             return false;
@@ -103,7 +103,7 @@ var o_selectMetadata = {
 
                 // since we are rendering the left side of metadata selector w/the same code that builds the select menu,
                 // we need to unhighlight the selected widgets
-                o_menu.markMenuItem("#op-select-metadata .op-all-metadata-column a", "unselect");
+                o_menu.markMenuItem("#op-select-metadata .op-all-metadata-column a", "op-selected-metadata-unselect");
 
                 // display check next to any currently used columns
                 $.each(opus.prefs.cols, function(index, col) {
@@ -124,6 +124,9 @@ var o_selectMetadata = {
                     cursor: "grab",
                     stop: function(event, ui) { o_selectMetadata.metadataDragged(this); }
                 });
+                if (opus.prefs.cols.length <= 1) {
+                    $(".op-selected-metadata-column .op-selected-metadata-unselect").hide();
+                }
                 o_selectMetadata.adjustHeight();
                 o_selectMetadata.rendered = true;
             });
@@ -136,10 +139,10 @@ var o_selectMetadata = {
 
         let label = $(menuSelector).data("qualifiedlabel");
         let info = `<i class="fas fa-info-circle" title="${$(menuSelector).find('*[title]').attr("title")}"></i>`;
-        let html = `<li id="cchoose__${slug}" class="ui-sortable-handle"><span class="info">&nbsp;${info}</span>${label}<span class="unselect"><i class="far fa-trash-alt"></span></li>`;
+        let html = `<li id="cchoose__${slug}" class="ui-sortable-handle"><span class="op-selected-metadata-info">&nbsp;${info}</span>${label}<span class="op-selected-metadata-unselect"><i class="far fa-trash-alt"></span></li>`;
         $(".op-selected-metadata-column > ul").append(html);
         if ($(".op-selected-metadata-column li").length > 1) {
-            $(".op-selected-metadata-column .unselect").show();
+            $(".op-selected-metadata-column .op-selected-metadata-unselect").show();
         }
     },
 
@@ -150,10 +153,10 @@ var o_selectMetadata = {
         opus.prefs.cols.splice($.inArray(slug,opus.prefs.cols), 1);
         $(`#cchoose__${slug}`).fadeOut(200, function() {
             $(this).remove();
+            if ($(".op-selected-metadata-column li").length <= 1) {
+                $(".op-selected-metadata-column .op-selected-metadata-unselect").hide();
+            }
         });
-        if (opus.prefs.cols.length <= 1) {
-            $(".op-selected-metadata-column .unselect").hide();
-        }
     },
 
     // columns can be reordered wrt each other in 'metadata selector' by dragging them

--- a/opus/application/static_media/js/selectMetadata.js
+++ b/opus/application/static_media/js/selectMetadata.js
@@ -1,0 +1,269 @@
+/* jshint esversion: 6 */
+/* jshint bitwise: true, curly: true, freeze: true, futurehostile: true */
+/* jshint latedef: true, leanswitch: true, noarg: true, nocomma: true */
+/* jshint nonbsp: true, nonew: true */
+/* jshint varstmt: true */
+/* globals $, PerfectScrollbar */
+/* globals o_browse, o_hash, o_menu, o_utils, opus */
+
+/******************************************/
+/********* SELECT METADATA DIALOG *********/
+/******************************************/
+/* jshint varstmt: false */
+var o_selectMetadata = {
+/* jshint varstmt: true */
+    selectMetadataDrawn: false,
+
+    // metadata selector behaviors
+    addBehaviors: function() {
+        // Global within this function so behaviors can communicate
+        /* jshint varstmt: false */
+        var currentSelectedMetadata = opus.prefs.cols.slice();
+        /* jshint varstmt: true */
+
+        $("#op-select-metadata").on("hide.bs.modal", function(e) {
+            // update the data table w/the new columns
+            if (!o_utils.areObjectsEqual(opus.prefs.cols, currentSelectedMetadata)) {
+                let tab = opus.getViewTab();
+                o_browse.clearObservationData(true); // Leave startobs alone
+                o_hash.updateURLFromCurrentHash(); // This makes the changes visible to the user
+                o_browse.initTable(tab, opus.colLabels, opus.colLabelsNoUnits);
+                o_browse.loadData(opus.prefs.view);
+            } else {
+                // remove spinner if nothing is re-draw when we click save changes
+                o_browse.hidePageLoaderSpinner();
+            }
+        });
+
+        $("#op-select-metadata").on("show.bs.modal", function(e) {
+            // this is to make sure modal is back to it original position when open again
+            $("#op-select-metadata .modal-dialog").css({top: 0, left: 0});
+            o_selectMetadata.adjustHeight();
+            // save current column state so we can look for changes
+            currentSelectedMetadata = opus.prefs.cols.slice();
+
+            o_browse.hideMenu();
+            o_selectMetadata.render();
+
+            // Do the fake API call to write in the Apache log files that
+            // we invoked the metadata selector so log_analyzer has something to
+            // go on
+            let fakeUrl = "/opus/__fake/__selectmetadatamodal.json";
+            $.getJSON(fakeUrl, function(data) {
+            });
+        });
+
+        $("#op-select-metadata .op-all-metadata-column").on("click", '.submenu li a', function() {
+            let slug = $(this).data('slug');
+            if (!slug) { return; }
+
+            let chosenSlugSelector = `#cchoose__${slug}`;
+            if ($(chosenSlugSelector).length === 0) {
+                // this slug was previously unselected, add to cols
+                o_selectMetadata.addColumn(slug);
+                opus.prefs.cols.push(slug);
+            } else {
+                // slug had been checked, remove from the chosen
+                o_selectMetadata.removeColumn(slug);
+            }
+            return false;
+        });
+
+        // removes chosen column
+        $("#op-select-metadata .op-selected-metadata-column").on("click", "li .unselect", function() {
+            let slug = $(this).parent().attr("id").split('__')[1];
+            o_selectMetadata.removeColumn(slug);
+            return false;
+        });
+
+        // buttons
+        $("#op-select-metadata").on("click", ".btn", function() {
+            switch($(this).attr("type")) {
+                case "reset":
+                    opus.prefs.cols = [];
+                    o_selectMetadata.resetMetadata(opus.defaultColumns);
+                    break;
+                case "submit":
+                    o_browse.showPageLoaderSpinner();
+                    break;
+                case "cancel":
+                    opus.prefs.cols = [];
+                    o_selectMetadata.resetMetadata(currentSelectedMetadata, true);
+                    break;
+            }
+        });
+    },  // /addSelectMetadataBehaviors
+
+    render: function() {
+        if (!o_selectMetadata.rendered) {
+            let url = "/opus/__forms/metadata_selector.html?" + o_hash.getHash();
+            $(".modal-body.op-select-metadata-details").load( url, function(response, status, xhr)  {
+                o_selectMetadata.rendered = true;  // bc this gets saved not redrawn
+                $("#op-select-metadata .op-reset-button").hide(); // we are not using this
+
+                // since we are rendering the left side of metadata selector w/the same code that builds the select menu,
+                // we need to unhighlight the selected widgets
+                o_menu.markMenuItem("#op-select-metadata .op-all-metadata-column a", "unselect");
+
+                // display check next to any currently used columns
+                $.each(opus.prefs.cols, function(index, col) {
+                    o_menu.markMenuItem(`#op-select-metadata .op-all-metadata-column a[data-slug="${col}"]`);
+                });
+
+                o_selectMetadata.addBehaviors();
+
+                o_selectMetadata.allMetadataScrollbar = new PerfectScrollbar("#op-select-metadata-contents .op-all-metadata-column", {
+                    minScrollbarLength: opus.minimumPSLength
+                });
+                o_selectMetadata.selectedMetadataScrollbar = new PerfectScrollbar("#op-select-metadata-contents .op-selected-metadata-column", {
+                    minScrollbarLength: opus.minimumPSLength
+                });
+
+                $(".op-selected-metadata-column > ul").sortable({
+                    items: "li",
+                    cursor: "grab",
+                    stop: function(event, ui) { o_selectMetadata.metadataDragged(this); }
+                });
+                o_selectMetadata.adjustHeight();
+                o_selectMetadata.rendered = true;
+            });
+        }
+    },
+
+    addColumn: function(slug) {
+        let menuSelector = `#op-select-metadata .op-all-metadata-column a[data-slug=${slug}]`;
+        o_menu.markMenuItem(menuSelector);
+
+        let label = $(menuSelector).data("qualifiedlabel");
+        let info = `<i class="fas fa-info-circle" title="${$(menuSelector).find('*[title]').attr("title")}"></i>`;
+        let html = `<li id="cchoose__${slug}" class="ui-sortable-handle"><span class="info">&nbsp;${info}</span>${label}<span class="unselect"><i class="far fa-trash-alt"></span></li>`;
+        $(".op-selected-metadata-column > ul").append(html);
+        if ($(".op-selected-metadata-column li").length > 1) {
+            $(".op-selected-metadata-column .unselect").show();
+        }
+    },
+
+    removeColumn: function(slug) {
+        let menuSelector = `#op-select-metadata .op-all-metadata-column a[data-slug=${slug}]`;
+        o_menu.markMenuItem(menuSelector, "unselected");
+
+        opus.prefs.cols.splice($.inArray(slug,opus.prefs.cols), 1);
+        $(`#cchoose__${slug}`).fadeOut(200, function() {
+            $(this).remove();
+        });
+        if (opus.prefs.cols.length <= 1) {
+            $(".op-selected-metadata-column .unselect").hide();
+        }
+    },
+
+    // columns can be reordered wrt each other in 'metadata selector' by dragging them
+    metadataDragged: function(element) {
+        let cols = $.map($(element).sortable("toArray"), function(item) {
+            return item.split("__")[1];
+        });
+        opus.prefs.cols = cols;
+    },
+
+    resetMetadata: function(cols, closeModal) {
+        opus.prefs.cols = cols.slice();
+
+        if (closeModal == true) {
+            $("#op-select-metadata").modal('hide');
+        }
+
+        // uncheck all on left; we will check them as we go
+        o_menu.markMenuItem("#op-select-metadata .op-all-metadata-column a", "unselect");
+
+        // remove all from selected column
+        $("#op-select-metadata .op-selected-metadata-column li").remove();
+
+        // add them back and set the check
+        $.each(cols, function(index, slug) {
+            o_selectMetadata.addColumn(slug);
+        });
+    },
+
+    adjustHeight: function() {
+        /**
+         * Set the height of the "Select Metadata" dialog based on the browser size.
+         */
+        $(".op-select-metadata-headers").show(); // Show now so computations are accurate
+        $(".op-select-metadata-headers-hr").show();
+        let footerHeight = $(".app-footer").outerHeight();
+        let mainNavHeight = $("#op-main-nav").outerHeight();
+        let modalHeaderHeight = $("#op-select-metadata .modal-header").outerHeight();
+        let modalFooterHeight = $("#op-select-metadata .modal-footer").outerHeight();
+        let selectMetadataHeadersHeight = $(".op-select-metadata-headers").outerHeight()+30;
+        let selectMetadataHeadersHRHeight = $(".op-select-metadata-headers-hr").outerHeight();
+        /* If modalHeaderHeight is zero, the dialog is in the process of being rendered
+           and we don't have valid data yet. If we set the height based on the zeros,
+           we get an annoying "jump" in the dialog size after it's done rendering.
+           So we use a default value that will cover the common case of a dialog wide
+           enough to cause excessive header word wrap.
+        */
+        if (modalHeaderHeight === 0) {
+            modalHeaderHeight = 57;
+            modalFooterHeight = 68;
+            selectMetadataHeadersHeight = 122;
+            selectMetadataHeadersHRHeight = 1;
+        }
+        let totalNonScrollableHeight = (footerHeight + mainNavHeight + modalHeaderHeight +
+                                        modalFooterHeight + selectMetadataHeadersHeight +
+                                        selectMetadataHeadersHRHeight);
+        /* 55 is a rough guess for how much space we want below the dialog, when possible.
+           130 is the minimum size required to display four metadata fields.
+           Anything less than that makes the dialog useless. In that case we hide the
+           header text to give us more room. */
+        let height = Math.max($(window).height()-totalNonScrollableHeight-55);
+        if (height < 130) {
+            $(".op-select-metadata-headers").hide();
+            $(".op-select-metadata-headers-hr").hide();
+            height += selectMetadataHeadersHeight + selectMetadataHeadersHRHeight;
+        }
+        $(".op-all-metadata-column").css("height", height);
+        $(".op-selected-metadata-column").css("height", height);
+    },
+
+    menuContainerHeight: function() {
+        return $(".op-all-metadata-column").outerHeight();
+    },
+
+    containerHeight: function() {
+        return $(".op-selected-metadata-column").outerHeight();
+    },
+
+    hideOrShowMenuPS: function() {
+        let containerHeight = $(".op-all-metadata-column").height();
+        let menuHeight = $(".op-all-metadata-column .op-search-menu").height();
+        if (o_selectMetadata.allMetadataScrollbar) {
+            if (containerHeight >= menuHeight) {
+                if (!$(".op-all-metadata-column .ps__rail-y").hasClass("hide_ps__rail-y")) {
+                    $(".op-all-metadata-column .ps__rail-y").addClass("hide_ps__rail-y");
+                    o_selectMetadata.allMetadataScrollbar.settings.suppressScrollY = true;
+                }
+            } else {
+                $(".op-all-metadata-column .ps__rail-y").removeClass("hide_ps__rail-y");
+                o_selectMetadata.allMetadataScrollbar.settings.suppressScrollY = false;
+            }
+            o_selectMetadata.allMetadataScrollbar.update();
+        }
+    },
+
+    hideOrShowPS: function() {
+        let containerHeight = $(".op-selected-metadata-column").height();
+        let selectedMetadataHeight = $(".op-selected-metadata-column .ui-sortable").height();
+
+        if (o_selectMetadata.selectedMetadataScrollbar) {
+            if (containerHeight >= selectedMetadataHeight) {
+                if (!$(".op-selected-metadata-column .ps__rail-y").hasClass("hide_ps__rail-y")) {
+                    $(".op-selected-metadata-column .ps__rail-y").addClass("hide_ps__rail-y");
+                    o_selectMetadata.selectedMetadataScrollbar.settings.suppressScrollY = true;
+                }
+            } else {
+                $(".op-selected-metadata-column .ps__rail-y").removeClass("hide_ps__rail-y");
+                o_selectMetadata.selectedMetadataScrollbar.settings.suppressScrollY = false;
+            }
+            o_selectMetadata.selectedMetadataScrollbar.update();
+        }
+    },
+};

--- a/opus/application/static_media/js/selectMetadata.js
+++ b/opus/application/static_media/js/selectMetadata.js
@@ -147,14 +147,14 @@ var o_selectMetadata = {
     },
 
     removeColumn: function(slug) {
-        // always have a least one in the list
-        if (opus.prefs.cols.length <=1 ) {
+        let colIndex = $.inArray(slug, opus.prefs.cols);
+        if (colIndex < 0 || opus.prefs.cols.length <= 1) {
             return;
         }
         let menuSelector = `#op-select-metadata .op-all-metadata-column a[data-slug=${slug}]`;
         o_menu.markMenuItem(menuSelector, "unselected");
 
-        opus.prefs.cols.splice($.inArray(slug,opus.prefs.cols), 1);
+        opus.prefs.cols.splice(colIndex, 1);
         $(`#cchoose__${slug}`).fadeOut(200, function() {
             $(this).remove();
             if ($(".op-selected-metadata-column li").length <= 1) {

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -589,7 +589,7 @@ var o_widgets = {
         delete opus.extras[`qtype-${slugNoNum}`];
         delete opus.extras[`z-${slugNoNum}`];
 
-        let selector = `li [data-slug='${slug}']`;
+        let selector = `.op-search-menu li [data-slug='${slug}']`;
         o_menu.markMenuItem(selector, "unselect");
 
         let inputs = $(`#widget__${slugNoNum} input`);


### PR DESCRIPTION
Fixes #724 (Remove trashcan when there is only one metadata column remaining)

Includes minor re-organization of file structure to isolate the files and data associated with the selectMetadata dialog out of browse.js and into selectMetadata.js.