### PR TITLE
Fix (issue 903) the gallery reflows at bad widths by fixing the calculation of width

### DIFF
--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -2284,19 +2284,14 @@ var o_browse = {
 
     calculateGalleryWidth: function(view) {
         let tab = opus.getViewTab(view);
-        let width = $(`${tab} .gallery-contents`).width();
+        // This is the width of container that contains all thumbnail images.
+        let width = $(`${tab} .gallery-contents .gallery`).width();
         if (width <= 0) {
             width = $(window).width();
             if (tab === "#cart") {
                 let leftPanelWidth = parseInt($(".cart_details").css("min-width"));
                 width -= leftPanelWidth;
             }
-        } else {
-            // We don't know why, but the .gallery-contents container is always
-            // a little bit too wide, but it's consistent between browsers.
-            // It's like there's a hidden margin that the browser is using to
-            // compute reflow. This hack fixes that.
-            width -= (tab === "#cart" ? 4 : 6);
         }
         return width;
     },

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -2356,7 +2356,6 @@ var o_browse = {
     },
 
     cartButtonInfo: function(status) {
-        let tab = opus.getViewTab();
         let browse_icon = "fas fa-cart-plus";
         let browse_title = "Add to cart";
         let browse_rangeTitle = "add range";


### PR DESCRIPTION
- Fixes issue #903 
- Run browse.js in jshint.
- Test at latest Chrome, FF, Safari, and Opera.
- Note: the issue was caused by miscalculation of width in calculateGalleryWidth which also results in wrong x (the number images per row) at some widths and messes up the calculation in updateSliderHandle. Now we get the width from the direct container (```$(`${tab} .gallery-contents .gallery`)```) that contains thumbnail images, we don't need to worry about future padding or margin styling that could cause miscalculation on the width. Previously we get the width from the higher parent (```$(`${tab} .gallery-contents)```) and in cart tab, there is a ml-1 in .just-content-start (which is 4px) and in browse tab there is a padding-left: 1.5em (which is about 21px, not 6px) in .gallery. To get the correct width, we have to minus these values correspondingly.   
But in browse view, instead of subtracting 21, we were subtracting 6, that's why sometimes the whole calculation went wrong.