### PR TITLE
Fix the issue that search sidebar submenu will collapse when a widget is opened/closed

### DIFF
--- a/opus/application/apps/ui/templates/ui/menu.html
+++ b/opus/application/apps/ui/templates/ui/menu.html
@@ -30,7 +30,7 @@
                             {#  this div has sub_headings, level-3 menu sections... start sub_heading loop  #}
                             {% for sub_head,params in info.data.items %}
                                 <li class="list-group-item py-0 pl-0">
-                                    <a href="#{{ which }}-submenu-{{ div.table_name|slugify }}-{{ sub_head|slugify }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle collapsed" data-cat="{{ sub_head|slugify }}">
+                                    <a href="#{{ which }}-submenu-{{ div.table_name|slugify }}-{{ sub_head|slugify }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle collapsed" data-cat="{{ div.table_name|slugify }}-{{ sub_head|slugify }}">
                                         <span class="menu-text title">{{ sub_head }}</span>
                                     </a>
                                     <ul class="list-group list-group-flush submenu collapse" id="{{ which }}-submenu-{{ div.table_name|slugify }}-{{ sub_head|slugify }}">

--- a/opus/application/static_media/js/menu.js
+++ b/opus/application/static_media/js/menu.js
@@ -71,7 +71,7 @@ var o_menu = {
             // open menu items that were open before
             $("#sidebar").toggleClass("op-redraw-menu");
             $.each(opus.menuState.cats, function(key, category) {
-                if ($(`#sidebar #search-submenu-${category}`).length != 0) {
+                if ($(`#sidebar #search-submenu-${category}`).length !== 0) {
                     $(`#sidebar #search-submenu-${category}`).collapse("show");
                 } else {
                     // this is if the surface geometry target is no longer applicable so it's not

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -156,6 +156,12 @@ var opus = {
         [opus.selections, opus.extras] = o_hash.alignDataInSelectionsAndExtras(opus.selections,
                                                                                opus.extras);
 
+        // If we just open a widget, we don't want to perform a search.
+        if (o_widgets.isGetWidgetDone) {
+            opus.updateOPUSLastSelectionsWithOPUSSelections();
+            o_widgets.isGetWidgetDone = false;
+        }
+
         // Note: When URL has an empty hash, both selections and extras returned from
         // getSelectionsExtrasFromHash will be undefined. There won't be a case when only
         // one of them is undefined.

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -37,6 +37,9 @@ var o_widgets = {
 
     uniqueIdForInputs: 100,
     centerOrLabelDone: false,
+    // This is flag is used to let opus.load know that a widget just opened and we don't
+    // want to perform a search when a widget is open.
+    isGetWidgetDone: false,
 
     addWidgetBehaviors: function() {
         $("#op-search-widgets").sortable({
@@ -555,7 +558,7 @@ var o_widgets = {
     },
 
     closeWidget: function(slug) {
-
+        let isRemovingEmptyWidget = true;
         let slugNoNum;
         try {
             slugNoNum = slug.match(/(.*)[1|2]$/)[1];
@@ -593,6 +596,13 @@ var o_widgets = {
         o_menu.markMenuItem(selector, "unselect");
 
         let inputs = $(`#widget__${slugNoNum} input`);
+        // Check if the widget to be removed has empty values on all inputs.
+        for (const input of inputs) {
+            if ($(input).val() && $(input).val().trim()) {
+                isRemovingEmptyWidget = false;
+            }
+        }
+
         o_widgets.removeInputsValidationInfo(inputs);
 
         o_search.allNormalizeInputApiCall().then(function(normalizedData) {
@@ -617,6 +627,11 @@ var o_widgets = {
                 $(".op-browse-tab").removeClass("op-disabled-nav-link");
             } else {
                 $(".op-browse-tab").addClass("op-disabled-nav-link");
+            }
+
+            // If the closing widget has empty values, don't perform a search.
+            if (isRemovingEmptyWidget) {
+                opus.updateOPUSLastSelectionsWithOPUSSelections();
             }
 
             if (opus.areRangeInputsValid()) {
@@ -1057,6 +1072,7 @@ var o_widgets = {
             o_widgets.customWidgetBehaviors(slug);
             o_widgets.scrollToWidget(widget);
             o_search.getHinting(slug);
+            o_widgets.isGetWidgetDone = true;
         }); // end callback for .done()
     }, // end getWidget function
 


### PR DESCRIPTION
- Fix the issue that search sidebar submenu will collapse when a widget is opened/closed.
- Tested on latest FF, Chrome, Safari, Opera.
- Run opus.js/widgets.js/menu.js in JSHint.