### PR TITLE
Fix sort order of product types and add NH alternate

### DIFF
--- a/opus/import/do_import.py
+++ b/opus/import/do_import.py
@@ -1465,15 +1465,22 @@ def get_pdsfile_rows_for_filespec(filespec, obs_general_id, opus_id, volume_id,
     # Keep a running list of all products by type, sorted by version
     for product_type in products:
         (category, sort_order_num, short_name, full_name) = product_type
-        pref = (category[:3]+category[-3:]).upper()
         if category == 'standard':
-            pref = '000001'
+            pref = 'ZZZZZ1'
         elif category == 'metadata':
-            pref = '000002'
+            pref = 'ZZZZZ2'
         elif category == 'browse':
-            pref = '000003'
+            pref = 'ZZZZZ3'
         elif category == 'diagram':
-            pref = '000004'
+            pref = 'ZZZZZ4'
+        else:
+            pref_list = category.split(' ')
+            pref = pref_list[0][:3]
+            if len(pref_list) == 1:
+                pref += pref_list[0][-3:]
+            else:
+                pref += pref_list[-1][:3]
+            pref = pref.upper()
         sort_order = pref + ('%03d' % sort_order_num)
         list_of_sublists = products[product_type]
         for sublist in list_of_sublists:

--- a/opus/import/table_schemas/internal_def_product_types.json
+++ b/opus/import/table_schemas/internal_def_product_types.json
@@ -121,6 +121,16 @@
     },
     {
         "pi_dict_context": "OPUS_PRODUCT_TYPE",
+        "pi_dict_name": "nh-raw-alternate",
+        "definition": "Raw image files (*_eng.fit) for New Horizons LORRI and MVIC. Images are in FITS format, uncalibrated, and in units of DN (data number). Associated labels (*.LBL) are text files that contain information about the image. These are duplicate New Horizons images that were downlinked using alternate settings (e.g. lossy, compressed, or binned). The best version is provided as the primary Raw Image and lesser-quality images are included here when available."
+    },
+    {
+        "pi_dict_context": "OPUS_PRODUCT_TYPE",
+        "pi_dict_name": "nh-calib-alternate",
+        "definition": "Calibrated image files (*_sci.fit) for New Horizons LORRI and MVIC. Images are in FITS format and have been calibrated by the New Horizons team. They are in units of calibrated DN (data number). Associated labels (*.LBL) are text files that contain information about the image and its calibration. The best version is provided as the primary Calibrated Image and lesser-quality images are included here when available."
+    },
+    {
+        "pi_dict_context": "OPUS_PRODUCT_TYPE",
         "pi_dict_name": "gossi-raw",
         "definition": "Raw image files (*.IMG) for Galileo SSI. Images are in VICAR format, uncalibrated, and in units of DN (data number). Associated labels (*.LBL) are text files that contain information about the image. Also included are RTLMTAB.FMT, which describes the format of the VICAR binary header, and RLINEPRX.FMT, which describes the format of the binary prefix at the beginning of each line of imaging data."
     },


### PR DESCRIPTION
- Fixes #833 
- Should be coordinated with changes to pds-webtools (rules/NHxxxx_xxxx.py) made on 11/27/2019.
- Only affects newly imported databases
