### PR TITLE
Fix freeze caused by rapidly resizing browser. Fixes #904.

### DIFF
--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -119,6 +119,9 @@ var opus = {
     // current splash page version for storing in the visited cookie
     splashVersion: 1,
 
+    // Used by checkBrowserSize
+    browserSizeActionInProgress: false,
+
     currentBrowser: "",
 
     // Max number of input sets per (RANGE or STRING) widget
@@ -1126,15 +1129,41 @@ var opus = {
          * than 275px. If so, display a modal to inform the user to
          * resize the browser size.
          */
-        let modalMsg = (`Please resize your browser. OPUS requires a browser
-                        size of at least ${opus.browserSupport.width} pixels by
-                        ${opus.browserSupport.height} pixels.`);
-        $("#op-browser-size-msg .modal-body").html(modalMsg);
+
+         if (opus.browserSizeActionInProgress) {
+             return;
+         }
+
+         let modal = $("#op-browser-size-msg");
+
+         // This is required to handle problems of rapid hide/show sequencing
+         // See: https://github.com/twbs/bootstrap/issues/3902
+         function showCompleted() {
+             opus.browserSizeActionInProgress = false;
+             modal.off("shown.bs.modal", showCompleted);
+         }
+         function hideCompleted() {
+             opus.browserSizeActionInProgress = false;
+             modal.off("hidden.bs.modal", hideCompleted);
+         }
+
         if ($(window).width() < opus.browserSupport.width ||
             $(window).height() < opus.browserSupport.height) {
-            $("#op-browser-size-msg").modal("show");
+            if (!$("#op-browser-size-msg").hasClass("show")) {
+                let modalMsg = (`Please resize your browser. OPUS requires a browser
+                                size of at least ${opus.browserSupport.width} pixels by
+                                ${opus.browserSupport.height} pixels.`);
+                $("#op-browser-size-msg .modal-body").html(modalMsg);
+                opus.browserSizeActionInProgress = true;
+                modal.on("shown.bs.modal", showCompleted);
+                modal.modal("show");
+            }
         } else {
-            $("#op-browser-size-msg").modal("hide");
+            if ($("#op-browser-size-msg").hasClass("show")) {
+                opus.browserSizeActionInProgress = true;
+                modal.on("hidden.bs.modal", hideCompleted);
+                modal.modal("hide");
+            }
         }
     },
 


### PR DESCRIPTION
- Fixes #904 
- It's still possible to get the browser size dialog to be in the wrong state (i.e. not showing when it should show) but that only happens if the user is doing pathological browser motions and it won't freeze everything anymore.
