### PR TITLE
Fix the issue that values are not properly converted when user changes unit selections

### DIFF
--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -416,7 +416,7 @@ var o_search = {
 
                         // Check if corresponding selections are empty to determine if we
                         // should perform a search.
-                        if (opus.selections[`${slugNoNum}`][idx]) {
+                        if (opus.selections[`${slug}`][idx]) {
                             isInputSetEmpty = false;
                         }
                         break;
@@ -513,6 +513,9 @@ var o_search = {
                     let url = "/opus/__api/normalizeinput.json?" + newHash + "&reqno=" + o_search.lastSlugNormalizeRequestNo;
                     performNormalizeInput = true;
                     o_search.parseFinalNormalizedInputDataAndUpdateURL(unitSlug, url, newUnitVal);
+                } else {
+                    // if normailze input api is not run, we update the record here.
+                    opus.currentUnitBySlug[slugNoNum] = newUnitVal;
                 }
             }
 


### PR DESCRIPTION
Inside the unit select change event handler at line 516, make sure opus.currentUnitBySlug gets updated properly when normalize input api call is NOT run with all inputs empty. (Normally the record is updated at the return of normalize input api call). This will solve the issue that values are not properly converted when user:
1. open a widget, select a unit 
2. type in or select a value
3. wait until search is done, change to another unit.