### PR TITLE
Fix issue 736 (sortable widgets and metadata selections broken)

### DIFF
--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -735,6 +735,10 @@ narrow */
 .op-selected-metadata-column {
     border: 0;
     z-index: 9999;
+    /* The following stylings are required for sortable metadata selections */
+    overflow-x: auto !important;
+    overflow-y: hidden !important;
+    overscroll-behavior: contain;
 }
 
 .op-selected-metadata-column ul li {

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -1584,6 +1584,7 @@ panel are properly separated */
 
 /* This is to make sortable scrolling (when sorting happened) works with ps */
 #widget-container {
+    overflow-x: auto !important;
     overflow-y: hidden !important;
     overscroll-behavior: contain;
 }

--- a/opus/application/static_media/js/mutationObserver.js
+++ b/opus/application/static_media/js/mutationObserver.js
@@ -187,6 +187,12 @@ var o_mutationObserver = {
         });
 
         let selectedMetadataObserver = new MutationObserver(function(mutationsList) {
+            // If sortable metadata selections is sorting, we don't want to set 
+            // the scrollbar position.
+            if (o_selectMetadata.isSortingHappening) {
+                return;
+            }
+
             let lastMutationIdx = mutationsList.length - 1;
             mutationsList.forEach((mutation, idx) => {
                 if (idx === lastMutationIdx) {

--- a/opus/application/static_media/js/selectMetadata.js
+++ b/opus/application/static_media/js/selectMetadata.js
@@ -4,7 +4,7 @@
 /* jshint nonbsp: true, nonew: true */
 /* jshint varstmt: true */
 /* globals $, PerfectScrollbar */
-/* globals o_browse, o_hash, o_menu, o_utils, opus */
+/* globals o_browse, o_hash, o_menu, o_utils, o_widgets, opus */
 
 /******************************************/
 /********* SELECT METADATA DIALOG *********/
@@ -13,7 +13,10 @@
 var o_selectMetadata = {
 /* jshint varstmt: true */
     selectMetadataDrawn: false,
-
+    // A flag to determine if the sortable item sorting is happening. This
+    // will be used in mutation observer to determine if scrollbar location should 
+    // be set.
+    isSortingHappening: false,
     // metadata selector behaviors
     addBehaviors: function() {
         // Global within this function so behaviors can communicate
@@ -134,7 +137,19 @@ var o_selectMetadata = {
                 $(".op-selected-metadata-column > ul").sortable({
                     items: "li",
                     cursor: "grab",
-                    stop: function(event, ui) { o_selectMetadata.metadataDragged(this); }
+                    containment: "parent",
+                    tolerance: "pointer",
+                    stop: function(event, ui) {
+                        o_selectMetadata.metadataDragged(this);
+                        o_selectMetadata.isSortingHappening = false;
+                    },
+                    start: function(event, ui) {
+                        o_widgets.getMaxScrollTopVal(event.target);
+                        o_selectMetadata.isSortingHappening = true;
+                    },
+                    sort: function(event, ui) {
+                        o_widgets.preventContinuousDownScrolling(event.target);
+                    }
                 });
                 if (opus.prefs.cols.length <= 1) {
                     $(".op-selected-metadata-column .op-selected-metadata-unselect").hide();

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -47,13 +47,30 @@ var o_widgets = {
             cursor: "move",
             // we need the clone so that widgets in url gets changed only when sorting is stopped
             helper: "clone",
-            scrollSensitivity: 100,
+            containment: "parent",
             axis: "y",
             opacity: 0.8,
-            cursorAt: {top: 10, left: 10},
+            tolerance: "pointer",
             stop: function(event, ui) {
                 o_widgets.widgetDrop(this);
             },
+            start: function(event, ui) {
+                // When sorting starts:
+                // Get the max scrollable height in current container.
+                let scrollContainer = $(event.target).data("ui-sortable").scrollParent;
+                let maxScrollTop = scrollContainer[0].scrollHeight - scrollContainer.height() - ui.helper.outerHeight();
+                $(event.target).data("maxScrollTop", maxScrollTop);
+            },
+            sort: function(event, ui) {
+                // When sorting is happening:
+                // Use the max scrollable height to prevent continuous down scrolling when user
+                // keeps dragging the item down after scrollbar reaches to the bottom-end.
+                let scrollContainer = $(event.target).data("ui-sortable").scrollParent;
+                let maxScrollTop = $(event.target).data("maxScrollTop");
+                if (scrollContainer.scrollTop() >= maxScrollTop) {
+                    scrollContainer.scrollTop(maxScrollTop);
+                }
+            }
         });
 
         $("#op-search-widgets").on( "sortchange", function(event, ui) {

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -55,21 +55,10 @@ var o_widgets = {
                 o_widgets.widgetDrop(this);
             },
             start: function(event, ui) {
-                // When sorting starts:
-                // Get the max scrollable height in current container.
-                let scrollContainer = $(event.target).data("ui-sortable").scrollParent;
-                let maxScrollTop = scrollContainer[0].scrollHeight - scrollContainer.height() - ui.helper.outerHeight();
-                $(event.target).data("maxScrollTop", maxScrollTop);
+                o_widgets.getMaxScrollTopVal(event.target);
             },
             sort: function(event, ui) {
-                // When sorting is happening:
-                // Use the max scrollable height to prevent continuous down scrolling when user
-                // keeps dragging the item down after scrollbar reaches to the bottom-end.
-                let scrollContainer = $(event.target).data("ui-sortable").scrollParent;
-                let maxScrollTop = $(event.target).data("maxScrollTop");
-                if (scrollContainer.scrollTop() >= maxScrollTop) {
-                    scrollContainer.scrollTop(maxScrollTop);
-                }
+                o_widgets.preventContinuousDownScrolling(event.target);
             }
         });
 
@@ -144,6 +133,31 @@ var o_widgets = {
 
         o_widgets.addPreprogrammedRangesBehaviors();
         o_widgets.addAttachOrRemoveInputsBehaviors();
+    },
+
+    getMaxScrollTopVal: function(target) {
+        /**
+         * Callback function for jquery ui sortable start event.
+         * When sorting starts:
+         * Get the max scrollable height in current container.
+         */
+        let scrollContainer = $(target).data("ui-sortable").scrollParent;
+        let maxScrollTop = scrollContainer[0].scrollHeight - scrollContainer.height();
+        $(target).data("maxScrollTop", maxScrollTop);
+    },
+
+    preventContinuousDownScrolling: function(target) {
+        /**
+         * Callback function for jquery ui sortable sort event.
+         * When sorting is happening:
+         * Use the max scrollable height to prevent continuous down scrolling when user
+         * keeps dragging the item down after scrollbar reaches to the bottom-end.
+         */
+        let scrollContainer = $(target).data("ui-sortable").scrollParent;
+        let maxScrollTop = $(target).data("maxScrollTop");
+        if (scrollContainer.scrollTop() >= maxScrollTop) {
+            scrollContainer.scrollTop(maxScrollTop);
+        }
     },
 
     attachAddInputIcon: function(slug, addInputIcon) {


### PR DESCRIPTION
- Fixes #736 
- Run JSHint on: widgets.js, selectMetadata.js, and mutationObserver.js
- Test on latest Chrome, FF, Opera, and Safari.