### PR TITLE
Change help panel position to 'fixed'

### DIFF
--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -1869,7 +1869,7 @@ footer {
 
 #op-help-panel {
     display: none;
-    position: absolute;
+    position: fixed;
     right: 0;
     z-index: 9999;
     top: 2em;


### PR DESCRIPTION
#944 
Setting the help panel position to 'fixed' keeps it from moving on the Search tab when clicking on a link.