### PR TITLE
Another approach to fix issue 944 (search tab jumps up when clicking a link in help menu)

### DIFF
--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -199,7 +199,7 @@
                                 <li class="list-inline-item">
                                     <a href="#" class="text-info" data-toggle="modal" data-target="#op-restore-recycle-bin" title="Restore all observations from the recycle bin to the cart"><i class="fas fa-undo"></i>
                                         &nbsp;Restore Recycle Bin to Cart&nbsp;<span id="op-recycled-count" class="badge badge-primary">0</span></a>
-                                </li>                           
+                                </li>
                             </div>
                             <div class="op-cart-toggle-download-panel">
                                 <button type="button" class="op-cart-slide-download-panel btn btn-secondary btn-sm nav-link text-dark font-weight-bold p-1" title="Slide over download data panel">
@@ -457,20 +457,6 @@
         {% endblock %}
 
     </div><!--/.container-fluid-->
-
-    <!--sliding panel for the help menu items -->
-    <div id="op-help-panel" class="card w-75">
-        <div class="card-header align-items-center h-auto pb-0 bg-secondary">
-            <h3 class="op-header-text"></h3>
-            <a class="close" aria-label="Close"><i class="far fa-times-circle fa-lg"></i></a>
-        </div>
-        <div class="card-body bg-light">
-            <div class="op-card-contents">
-                Loading... please wait.
-            </div>
-            <div class="loader"></div>
-        </div>
-    </div>
     <div class="op-overlay"></div>
 
     {% include "ui/footer.html" %}

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -94,7 +94,7 @@ body.modal-open .navbar {
 
 #search {
     height: 100%;
-    position: absolute;
+    position: fixed;
     left: 0;
     margin: 0;
     /* Make the whole search page shrink proportionally when window
@@ -1869,7 +1869,7 @@ footer {
 
 #op-help-panel {
     display: none;
-    position: fixed;
+    position: absolute;
     right: 0;
     z-index: 9999;
     top: 2em;


### PR DESCRIPTION
- Another approach to fix #944 
- Here are the changes:
  - Remove duplicated #op-help-panel.
  - Update #search position to fixed.
  - Update #op-help-panel position back to absolute.