### PR TITLE
Catch cases where unit conversion results in an overflow

### DIFF
--- a/lib/opus_support.py
+++ b/lib/opus_support.py
@@ -6,6 +6,7 @@
 # MRS 6/5/18
 ################################################################################
 
+import math
 import numpy as np
 
 import julian
@@ -519,7 +520,11 @@ def convert_to_default_unit(val, default_unit, unit):
     if default_unit == unit:
         return val
     assert default_unit in UNIT_CONVERSION
-    return val * UNIT_CONVERSION[default_unit]['conversions'][unit][1]
+    ret = val * UNIT_CONVERSION[default_unit]['conversions'][unit][1]
+    if not math.isfinite(ret):
+        raise ValueError
+    return ret
+
 
 def convert_from_default_unit(val, default_unit, unit):
     if val is None:
@@ -527,7 +532,10 @@ def convert_from_default_unit(val, default_unit, unit):
     if default_unit is None or default_unit == unit:
         return val
     assert default_unit in UNIT_CONVERSION
-    return val / UNIT_CONVERSION[default_unit]['conversions'][unit][1]
+    ret = val / UNIT_CONVERSION[default_unit]['conversions'][unit][1]
+    if not math.isfinite(ret):
+        raise ValueError
+    return ret
 
 def get_valid_units(default_unit):
     default_unit_info = UNIT_CONVERSION.get(default_unit, None)

--- a/opus/application/apps/search/test_search.py
+++ b/opus/application/apps/search/test_search.py
@@ -2040,6 +2040,16 @@ class searchTests(TestCase):
         self.assertEqual(sql, expected)
         self.assertEqual(params, expected_params)
 
+    def test__range_query_any_left_side_unit_overflow(self):
+        "[test_search.py] range_query: multi column range with qtype=any, min only, unit overflow"
+        selections = {'obs_ring_geometry.ring_radius1': [1e307],
+                      'obs_ring_geometry.ring_radius2': [None]}
+        sql, params = get_range_query(selections, 'obs_ring_geometry.ring_radius1', ['any'], ['saturnradii'])
+        print(sql)
+        print(params)
+        self.assertIsNone(sql)
+        self.assertIsNone(params)
+
     def test__range_query_any_right_side_units_m(self):
         "[test_search.py] range_query: multi column range with qtype=any, max only, units default"
         selections = {'obs_ring_geometry.ring_radius1': [None],
@@ -2054,6 +2064,16 @@ class searchTests(TestCase):
         print(expected_params)
         self.assertEqual(sql, expected)
         self.assertEqual(params, expected_params)
+
+    def test__range_query_any_right_side_unit_overflow(self):
+        "[test_search.py] range_query: multi column range with qtype=any, max only, unit overflow"
+        selections = {'obs_ring_geometry.ring_radius1': [None],
+                      'obs_ring_geometry.ring_radius2': [1e307]}
+        sql, params = get_range_query(selections, 'obs_ring_geometry.ring_radius1', ['any'], ['saturnradii'])
+        print(sql)
+        print(params)
+        self.assertIsNone(sql)
+        self.assertIsNone(params)
 
     def test__range_query_any_both_side_units_m(self):
         "[test_search.py] range_query: multi column range with qtype=any, both min and max, units default"
@@ -2984,6 +3004,17 @@ class searchTests(TestCase):
         self.assertEqual(sql, expected)
         self.assertEqual(params, expected_params)
 
+    def test__construct_query_string_nojoin_unit_overflow(self):
+        "[test_search.py] construct_query_string: just obs_general, unit overflow"
+        selections = {'obs_general.observation_duration1': [1e307],
+                      'obs_general.observation_duration2': [None]}
+        extras = {'units': {'obs_general.observation_duration': 'days'}}
+        sql, params = construct_query_string(selections, extras)
+        print(sql)
+        print(params)
+        self.assertIsNone(sql)
+        self.assertIsNone(params)
+
     def test__construct_query_string_string(self):
         "[test_search.py] construct_query_string: a string"
         selections = {'obs_pds.primary_file_spec': ['C11399XX']}
@@ -3013,6 +3044,17 @@ class searchTests(TestCase):
         self.assertEqual(sql, expected)
         self.assertEqual(params, expected_params)
 
+    def test__construct_query_string_single_column_range_unit_overflow(self):
+        "[test_search.py] construct_query_string: a single column range, unit overflow"
+        selections = {'obs_ring_geometry.ring_center_phase1': [20.0],
+                      'obs_ring_geometry.ring_center_phase2': [1e307]}
+        extras = {'units': {'obs_ring_geometry.ring_center_phase': 'radians'}}
+        sql, params = construct_query_string(selections, extras)
+        print(sql)
+        print(params)
+        self.assertIsNone(sql)
+        self.assertIsNone(params)
+
     def test__construct_query_string_longitude_range(self):
         "[test_search.py] construct_query_string: a single column range"
         selections = {'obs_ring_geometry.J2000_longitude1': [240.],
@@ -3034,6 +3076,17 @@ class searchTests(TestCase):
         selections = {'obs_ring_geometry.J2000_longitude1': [240.],
                       'obs_ring_geometry.J2000_longitude2': [310.5]}
         extras = {'qtypes': {'obs_ring_geometry.J2000_longitude': ['fred']}}
+        sql, params = construct_query_string(selections, extras)
+        print(sql)
+        print(params)
+        self.assertIsNone(sql)
+        self.assertIsNone(params)
+
+    def test__construct_query_string_longitude_range_unit_overflow(self):
+        "[test_search.py] construct_query_string: a single column range, unit overflow"
+        selections = {'obs_ring_geometry.J2000_longitude1': [1e307],
+                      'obs_ring_geometry.J2000_longitude2': [310.5]}
+        extras = {'units': {'obs_ring_geometry.J2000_longitude': ['radians']}}
         sql, params = construct_query_string(selections, extras)
         print(sql)
         print(params)

--- a/opus/application/apps/search/views.py
+++ b/opus/application/apps/search/views.py
@@ -590,14 +590,14 @@ def url_to_search_params(request_get, allow_errors=False, return_slugs=False,
             sourceunit_val = request_get[sourceunit_slug]
             if (valid_sourceunits is None or
                 sourceunit_val not in valid_sourceunits):
+                log.error('url_to_search_params: Bad sourceunit value'
+                          +' for "%s": %s', sourceunit_slug,
+                          str(sourceunit_val))
                 if allow_errors: # pragma: no cover
                     # We never actually hit this because normalizeurl catches
                     # the bad unit first
                     sourceunit_val = None
                 else:
-                    log.error('url_to_search_params: Bad sourceunit value'
-                              +' for "%s": %s', sourceunit_slug,
-                              str(sourceunit_val))
                     return None, None
 
         if form_type in settings.MULT_FORM_TYPES:
@@ -694,12 +694,28 @@ def url_to_search_params(request_get, allow_errors=False, return_slugs=False,
                                     raise ValueError
 
                             if is_sourceunit or sourceunit_val is not None:
-                                default_val = opus_support.convert_to_default_unit(
-                                        new_value, param_info.units,
-                                        sourceunit_val)
-                                new_value = opus_support.convert_from_default_unit(
-                                        default_val, param_info.units,
-                                        unit_val)
+                                default_val = (opus_support
+                                               .convert_to_default_unit(
+                                                    new_value,
+                                                    param_info.units,
+                                                    sourceunit_val))
+                                new_value = (opus_support
+                                             .convert_from_default_unit(
+                                                    default_val,
+                                                    param_info.units,
+                                                    unit_val))
+
+                            # Do a conversion of the given value to the default
+                            # units. We do this so that if the conversion throws
+                            # an error (like overflow), we mark this search
+                            # term as invalid, since it will fail later in
+                            # construct_query_string anyway. This allows
+                            # normalizeinput to report it as bad immediately.
+                            default_val = (opus_support
+                                           .convert_to_default_unit(
+                                                new_value,
+                                                param_info.units,
+                                                unit_val))
 
                             if pretty_results:
                                 new_value = format_metadata_number_or_func(
@@ -709,9 +725,10 @@ def url_to_search_params(request_get, allow_errors=False, return_slugs=False,
                             new_value = None
                             if not allow_errors:
                                 log.error('url_to_search_params: Function "%s" '
-                                          +'slug "%s" '
-                                          +'threw ValueError(%s) for %s',
-                                          func, slug, e, value_to_use)
+                                          +'slug "%s" source unit "%s" unit '
+                                          +'"%s" threw ValueError(%s) for %s',
+                                          func, slug, sourceunit_val, unit_val,
+                                          e, value_to_use)
                                 return None, None
                     else:
                         new_value = None
@@ -1521,6 +1538,12 @@ def get_range_query(selections, param_qualified_name, qtypes, units):
                       unit, param_qualified_name, str(selections), str(qtypes),
                       str(units))
             return None, None
+        except ValueError:
+            log.error('get_range_query: Unit "%s" on "%s" conversion failed '
+                      +'*** Selections %s *** Qtypes %s *** Units %s',
+                      unit, param_qualified_name, str(selections), str(qtypes),
+                      str(units))
+            return None, None
 
         qtype = qtypes[idx]
 
@@ -1647,6 +1670,13 @@ def get_longitude_query(selections, param_qualified_name, qtypes, units):
                                                              unit)
         except KeyError:
             log.error('get_longitude_query: Unknown unit "%s" for "%s" '
+                      +'*** Selections %s *** Qtypes %s *** Units %s',
+                      unit, param_qualified_name, str(selections), str(qtypes),
+                      str(units))
+            return None, None
+        except ValueError:
+            log.error('get_longitude_query: Unit "%s" on "%s" conversion '
+                      +'failed '
                       +'*** Selections %s *** Qtypes %s *** Units %s',
                       unit, param_qualified_name, str(selections), str(qtypes),
                       str(units))

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -377,7 +377,8 @@ var o_search = {
             o_hash.updateURLFromCurrentHash();
         });
 
-        // range behaviors and string behaviors for search widgets - qtype select dropdown
+        // range behaviors and string behaviors for search widgets - qtype and unit
+        // select dropdowns
         $('#search').on("change", "select", function() {
             let isInputSetEmpty = true;
             // Use this flag to determine if a normalize input api with sourceunit is called.
@@ -474,20 +475,18 @@ var o_search = {
                         let qtypeWithId =`${qtypeSlug}_${uniqueid}`;
                         let unitWithId = `${unitSlug}_${uniqueid}`;
                         let sourceunitWithId = `${sourceunitSlug}_${uniqueid}`;
-                        if (opus.rangeInputFieldsValidation[slug1WithId] !== false) {
-                            let minInputVal = $(eachInputSet).find(".op-range-input-min").val();
-                            if (minInputVal) {
-                                let slug1EncodedSelections = o_hash.encodeSlugValues([minInputVal]);
-                                hash.push(slug1WithId + "=" + slug1EncodedSelections[0]);
-                            }
-                        }
-                        if (opus.rangeInputFieldsValidation[slug2WithId] !== false) {
-                            let maxInputVal = $(eachInputSet).find(".op-range-input-max").val();
-                            if (maxInputVal) {
-                                let slug2EncodedSelections = o_hash.encodeSlugValues([maxInputVal]);
-                                hash.push(slug2WithId + "=" + slug2EncodedSelections[0]);
-                            }
 
+                        // Always reevaluate these values even if they're currently marked as
+                        // invalid. It's possible with the new units they will no longer be invalid.
+                        let minInputVal = $(eachInputSet).find(".op-range-input-min").val();
+                        if (minInputVal) {
+                            let slug1EncodedSelections = o_hash.encodeSlugValues([minInputVal]);
+                            hash.push(slug1WithId + "=" + slug1EncodedSelections[0]);
+                        }
+                        let maxInputVal = $(eachInputSet).find(".op-range-input-max").val();
+                        if (maxInputVal) {
+                            let slug2EncodedSelections = o_hash.encodeSlugValues([maxInputVal]);
+                            hash.push(slug2WithId + "=" + slug2EncodedSelections[0]);
                         }
 
                         if (qtypeSlug in opus.extras) {

--- a/opus/application/test_api/test_search_api.py
+++ b/opus/application/test_api/test_search_api.py
@@ -398,6 +398,18 @@ class ApiSearchTests(TestCase, ApiTestHelper):
         expected = {"wavelength1": "0.75", "wavelength2": "300", "reqno": 123}
         self._run_json_equal(url, expected)
 
+    def test__api_normalizeinput_unit_overflow(self):
+        "[test_search_api.py] /api/normalizeinput: wavelength overflow basic unit"
+        url = '/opus/__api/normalizeinput.json?wavelength1=1e307&unit-wavelength=cm&reqno=123'
+        expected = {"wavelength1": None, "reqno": 123}
+        self._run_json_equal(url, expected)
+
+    def test__api_normalizeinput_unit_overflow_conversion(self):
+        "[test_search_api.py] /api/normalizeinput: wavelength overflow unit conversion"
+        url = '/opus/__api/normalizeinput.json?wavelength1=1e307&sourceunit-wavelength=cm&unit-wavelength=microns&reqno=123'
+        expected = {"wavelength1": None, "reqno": 123}
+        self._run_json_equal(url, expected)
+
             ########################################################
             ######### /__api/stringsearchchoices API TESTS #########
             ########################################################


### PR DESCRIPTION
- Fixes #936 

Previously if you selected ring radius units of "Rs" and entered "1e307", it would accept the value as valid, but then during search it would throw an error that wasn't caught by the UI, resulting in infinite spinners. Also if you then tried to change the units to something better, it would put "inf" in the input field.

Both of these cases are now fixed. The handling of bad units is still slightly weird, since it treats the "invalid" value as the starting value for the next unit conversion, but this doesn't seem particularly important and I don't know how we'd want it to work differently anyway.
