### PR TITLE
Remove units from GOSSI frame_duration

### DIFF
--- a/opus/import/find_unknown_warnings.sh
+++ b/opus/import/find_unknown_warnings.sh
@@ -31,10 +31,7 @@ echo $S
 echo 22 `cat __tmp2 | grep "$S" | wc -l`
 cat __tmp2 | grep -v "$S" > __tmp1
 
-S="obs_instrument_gossi/frame_duration"
-echo $S
-echo 1 `cat __tmp1 | grep "$S" | wc -l`
-cat __tmp1 | grep -v "$S" > __tmp2
+cp __tmp1 __tmp2
 
 S="Empty opus_product key"
 echo $S
@@ -102,5 +99,3 @@ echo 332 `cat __tmp2 | grep "$S" | wc -l`
 cat __tmp2 | grep -v "$S" > __tmp1
 
 cat __tmp1
-
-

--- a/opus/import/table_schemas/obs_instrument_gossi.json
+++ b/opus/import/table_schemas/obs_instrument_gossi.json
@@ -218,7 +218,7 @@
         "pi_slug": "GOSSIframeduration",
         "pi_sub_heading": null,
         "pi_tooltip": "",
-        "pi_units": "seconds",
+        "pi_units": null,
         "comments": "Definition is from GOSSI label."
     },
     {


### PR DESCRIPTION
- Fixes #779 
- This bug was originally just to remove a warning from the import pipeline, but it turns out it breaks completely now that units have been implemented. Try this:

https://tools.pds-rings.seti.org/opus/#/unit-GOSSIframeduration=seconds&instrument=Galileo+SSI&cols=opusid,instrument,planet,target,time1,observationduration&widgets=GOSSIframeduration,instrument&order=time1,opusid&view=search&browse=gallery&cart_browse=gallery&startobs=1&cart_startobs=1&detail=
