### PR TITLE
Issue 872 UI change for surface geometry searching

### DIFF
--- a/opus/application/apps/help/templates/help/gettingstarted.html
+++ b/opus/application/apps/help/templates/help/gettingstarted.html
@@ -118,6 +118,19 @@ data OPUS has to offer.</p>
     minimum/maximum values or date/times, or the number of results for each
     multiple-choice item, based on your current search criteria.</p>
 
+<p>The <b>Surface Geometry Target Name</b> search field is special. Only one
+    surface geometry target can be selected at a time. When you select a surface
+    geometry target, a new <b>[Target] Surface Geometry Constraints</b>
+    category will become available providing search fields for that single
+    target. If you later change the surface geometry target, all of
+    the existing target-specific fields you selected will automatically switch
+    to the new target but keep their existing search values. This is useful
+    for cases such as searching for similar lighting geometry for different
+    targets. In addition, any metadata fields you selected for the previous
+    target will be duplicated for the new target. If you close the
+    <b>Surface Geometry Target Name</b>, all target-specific search fields will
+    also be closed.</p>
+
 <p>Once you have entered some search constraints, it's time to browse the
     results.</p>
 

--- a/opus/application/apps/results/views.py
+++ b/opus/application/apps/results/views.py
@@ -1577,9 +1577,9 @@ def get_triggered_tables(selections, extras, api_code=None):
             if (trigger_tab == 'obs_surface_geometry' and
                 trigger_val.upper() ==
                 selections['obs_surface_geometry.target_name'][0].upper()):
-                if (trigger_val.upper() in
-                    [r['target_name'].upper() for r in results]):
-                    triggered_tables.append(partable)
+                # If the selected surfacegeo target has no result, we
+                # still want to have related menu item displayed.
+                triggered_tables.append(partable)
 
     # Now hack in the proper ordering of tables
     final_table_list = []

--- a/opus/application/apps/results/views.py
+++ b/opus/application/apps/results/views.py
@@ -1578,7 +1578,7 @@ def get_triggered_tables(selections, extras, api_code=None):
                 trigger_val.upper() ==
                 selections['obs_surface_geometry.target_name'][0].upper()):
                 # If the selected surfacegeo target has no result, we
-                # still want to have related menu item displayed.
+                # still want to have the related menu item displayed.
                 triggered_tables.append(partable)
 
     # Now hack in the proper ordering of tables

--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -485,6 +485,17 @@
             draggable=False
             close_by_keyboard="esc"
         %}
+        {% include "ui/confirm_modal.html" with
+            id_name="op-close-surfacegeo-widgets"
+            confirm_title="Confirm Close All Surfacegeometry Widgets"
+            confirm_msg="Are you sure you want to close all surfacegeometry widgets?"
+            target="op-close-surfacegeo-widgets"
+            yes_text="Yes"
+            no_text="No"
+            allow_close=True
+            draggable=True
+            close_by_keyboard="esc"
+        %}
 
         {% endblock %}
 

--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -487,8 +487,8 @@
         %}
         {% include "ui/confirm_modal.html" with
             id_name="op-close-surfacegeo-widgets"
-            confirm_title="Confirm Close All Surfacegeometry Widgets"
-            confirm_msg="Are you sure you want to close all surfacegeometry widgets?"
+            confirm_title="Confirm Close All Surface Geometry Search Fields"
+            confirm_msg="Closing the Surface Geometry Target Name search field will also close all target-specific search fields. Are you sure you wish to proceed?"
             target="op-close-surfacegeo-widgets"
             yes_text="Yes"
             no_text="No"

--- a/opus/application/apps/ui/templates/ui/widget.html
+++ b/opus/application/apps/ui/templates/ui/widget.html
@@ -11,7 +11,7 @@
         <h6 class="card-title mt-0">
             <div>
                 <i class="fas fa-info-circle" title="{{ tooltip|safe }}"></i>
-                {{ label }}&nbsp;
+                <span class="op-widget-title">{{ label }}&nbsp;</span>
                 {% if units %}
                     <select class="op-unit-{{ slug }}" name="unit-{{ slug }}" tabindex="0">
                         {% for unit, display_name in units.items %}

--- a/opus/application/apps/ui/views.py
+++ b/opus/application/apps/ui/views.py
@@ -289,7 +289,8 @@ def api_get_widget(request, **kwargs):
                               +'</span>'
                               +'<span class="mult_group_label">'
                               +str(glabel) + '</span></div>'
-                              +'<ul class="mult_group">'
+                              +'<ul class="mult_group"'
+                              +' data-group=' + str(glabel) + '>'
                               +SearchForm(form_vals,
                                           auto_id = '%s_' + str(gvalue),
                                           grouping=gvalue).as_ul()

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1613,7 +1613,9 @@ var o_browse = {
 
     getDataURL: function(view, startObs, customizedLimitNum=undefined) {
         let base_url = "/opus/__api/dataimages.json?";
-        let hashString = o_hash.getHash();
+        // We use getFullHashStr instead of getHash because we want the updated
+        // version of cols= even if the main URL hasn't been updated yet
+        let hashString = o_hash.getFullHashStr();
 
         //TODO: we should be able to combine these url tweaker functions into a single function, perhaps in hash.js
         let url = hashString + '&reqno=' + opus.lastLoadDataRequestNo[view];
@@ -1891,6 +1893,9 @@ var o_browse = {
         // then after the load is complete, instead of hiding the galleryView slide, update the metadata.
         let updateMetadataBox = $("#op-select-metadata").hasClass("show") && $("#galleryView").hasClass("show") ;
 
+        // Note: Increment the reqno here instead of getDataURL because infiniteScroll path also use getDataURL,
+        // and we don't want to increment the reqno for infiniteScroll path.
+        opus.lastLoadDataRequestNo[view] += 1;
         // Note: when browse page is refreshed, startObs passed in (from activateBrowseTab) will start from 1
         let url = o_browse.getDataURL(view, startObs, customizedLimitNum);
         viewNamespace.loadDataInProgress = true;

--- a/opus/application/static_media/js/hash.js
+++ b/opus/application/static_media/js/hash.js
@@ -404,7 +404,6 @@ var o_hash = {
         if (!hash) {
             return [undefined, undefined];
         }
-
         hash = (hash.search("&") > -1 ? hash.split("&") : [hash]);
         hash = o_hash.decodeHashArray(hash);
         let selections = {};  // the new set of pairs that will not include the result_table specific session vars
@@ -641,9 +640,9 @@ var o_hash = {
                     let slugCounter = o_utils.getSlugOrDataTrailingCounterStr(slug);
                     slug = slugNoCounter;
 
-                    // For surfacegeometrytargetname, we have to assign the init value
-                    // to opus.oldSurfacegeoTarget here if the page reloads with URL
-                    // that has surfacegeometrytargetname.
+                    // If there is a value specified for surfacegeometrytargetname in the URL,
+                    // we have to initialize opus.oldSurfacegeoTarget with it so that we can
+                    // properly handle changes to surfacegeometrytargetname in the future.
                     if (slug === "surfacegeometrytargetname") {
                         opus.oldSurfacegeoTarget = o_utils.getSurfacegeoTargetSlug(value);
                     }

--- a/opus/application/static_media/js/hash.js
+++ b/opus/application/static_media/js/hash.js
@@ -641,6 +641,13 @@ var o_hash = {
                     let slugCounter = o_utils.getSlugOrDataTrailingCounterStr(slug);
                     slug = slugNoCounter;
 
+                    // For surfacegeometrytargetname, we have to assign the init value
+                    // to opus.oldSurfacegeoTarget here if the page reloads with URL
+                    // that has surfacegeometrytargetname.
+                    if (slug === "surfacegeometrytargetname") {
+                        opus.oldSurfacegeoTarget = o_utils.getSurfacegeoTargetSlug(value);
+                    }
+
                     if (slugCounter > opus.maxAllowedInputSets) {
                         return; // continue to next iteration
                     }

--- a/opus/application/static_media/js/menu.js
+++ b/opus/application/static_media/js/menu.js
@@ -17,15 +17,15 @@ var o_menu = {
      *
      **/
 
-     addMenuBehaviors: function() {
-         // click param in menu get new widget
-         $("#sidebar").on("click", ".submenu li a", function() {
+    addMenuBehaviors: function() {
+        // click param in menu get new widget
+        $("#sidebar").on("click", ".submenu li a", function() {
 
-             let slug = $(this).data("slug");
-             if (!slug) { return; }
-             if ($.inArray(slug, opus.widgetsDrawn) > -1) {
-                 // widget is already showing do not fetch another
-                 try {
+            let slug = $(this).data("slug");
+            if (!slug) { return; }
+            if ($.inArray(slug, opus.widgetsDrawn) > -1) {
+                // widget is already showing do not fetch another
+                try {
                     // scroll to widget and highlight it
                     o_widgets.scrollToWidget(`widget__#{slug}`);
 
@@ -34,15 +34,14 @@ var o_menu = {
                 }
                 return false;
 
-             } else {
-                  o_menu.markMenuItem(this);
-                  o_widgets.getWidget(slug,'#op-search-widgets');
-             }
+            } else {
+                o_menu.markMenuItem(this);
+                o_widgets.getWidget(slug,'#op-search-widgets');
+            }
 
-             o_hash.updateURLFromCurrentHash();
-             return false;
-         });
-
+            o_hash.updateURLFromCurrentHash();
+            return false;
+        });
 
         // menu state - keep track of what menu items are open
         $("#sidebar").on("click", ".dropdown-toggle", function(e) {
@@ -60,11 +59,11 @@ var o_menu = {
                 }
             }
         });
-     },
+    },
 
-     getNewSearchMenu: function() {
+    getNewSearchMenu: function() {
         let spinnerTimer = setTimeout(function() {
-             $(".op-menu-text.spinner").addClass("op-show-spinner"); }, opus.spinnerDelay);
+            $(".op-menu-text.spinner").addClass("op-show-spinner"); }, opus.spinnerDelay);
         let hash = o_hash.getHash();
 
         $("#sidebar").load("/opus/__menu.html?" + hash, function() {
@@ -87,9 +86,9 @@ var o_menu = {
             $('.op-menu-text.spinner').removeClass("op-show-spinner");
             clearTimeout(spinnerTimer);
         });
-     },
+    },
 
-     markMenuItem: function(selector, selected) {
+    markMenuItem: function(selector, selected) {
         if (selected == undefined || selected == "select") {
             $(selector).css({"background": "gainsboro"});
             // We use find() here instead of just adding to the selector because
@@ -99,7 +98,7 @@ var o_menu = {
             $(selector).css({"background": "initial"});
             $(selector).find(".op-search-param-checkmark").css({'opacity': 0});
         }
-     },
+    },
 
     markCurrentMenuItems: function() {
         $.each(opus.prefs.widgets, function(index, slug) {
@@ -107,17 +106,17 @@ var o_menu = {
         });
     },
 
-     // type = cat/group
-     getCatGroupFromSlug: function(slug) {
-         let cat = "";
-         let group = "";
-         $("ul.menu_list>li a", "#search").each(function() {
-             if (slug == $(this).data("slug")) {
-                 cat = $(this).data("cat");
-                 group = $(this).data("group");
-                 return false; // this is how you break in an each!
-             }
-         });
-         return {"cat":cat, "group":group};
-     },
+    // type = cat/group
+    getCatGroupFromSlug: function(slug) {
+        let cat = "";
+        let group = "";
+        $("ul.menu_list>li a", "#search").each(function() {
+            if (slug == $(this).data("slug")) {
+                cat = $(this).data("cat");
+                group = $(this).data("group");
+                return false; // this is how you break in an each!
+            }
+        });
+        return {"cat":cat, "group":group};
+    },
 };

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -143,6 +143,7 @@ var opus = {
         }
     },
 
+    oldSurfacegeoTarget: null,
 
     //------------------------------------------------------------------------------------
     // Functions to update the result count and hinting numbers on any change to the search

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -370,7 +370,7 @@ var opus = {
         // so retrieve a new one.
         o_menu.getNewSearchMenu();
 
-        // Finally, update all the
+        // Finally, update all the hints
         $.each(opus.prefs.widgets, function(index, slug) {
             if (slug === "surfacegeometrytargetname" && !o_search.isAllSURFACEGEOSelectionsEmpty()) {
                 o_search.getValidMults(slug, true);

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -834,6 +834,9 @@ var opus = {
                         case "op-addall-to-cart":
                             o_cart.addAllToCart();
                             break;
+                        case "op-close-surfacegeo-widgets":
+                            o_widgets.closeAllSURFACEGEOWidgets();
+                            break;
                     }
                     $(`#${target}`).modal("hide");
                     break;

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -301,7 +301,6 @@ var opus = {
         // If there are more normalized data requests in the queue, don't trigger
         // spurious result counts that we won't use anyway
         if (normalizedData.reqno < o_search.lastSlugNormalizeRequestNo) {
-            delete opus.normalizeInputForAllFieldsInProgress[opus.allSlug];
             return;
         }
 

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -370,9 +370,13 @@ var opus = {
         // so retrieve a new one.
         o_menu.getNewSearchMenu();
 
-        // Finally, update all the hints
+        // Finally, update all the
         $.each(opus.prefs.widgets, function(index, slug) {
-            o_search.getHinting(slug);
+            if (slug === "surfacegeometrytargetname" && !o_search.isAllSURFACEGEOSelectionsEmpty()) {
+                o_search.getValidMults(slug, true);
+            } else {
+                o_search.getHinting(slug);
+            }
         });
     },
 

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -376,12 +376,8 @@ var o_search = {
             if (!opus.areRangeInputsValid()) {
                 opus.updateOPUSLastSelectionsWithOPUSSelections();
             }
-            console.log(`Change event in choice change`);
-            console.log(JSON.stringify(opus.selections));
-            o_hash.updateURLFromCurrentHash();
 
-            // opus.oldSurfacegeoTarget = newTargetSlug;
-            console.log(`opus.oldSurfacegeoTarget: ${opus.oldSurfacegeoTarget}`);
+            o_hash.updateURLFromCurrentHash();
         });
 
         // range behaviors and string behaviors for search widgets - qtype select dropdown

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -559,6 +559,20 @@ var o_search = {
         return isInputSetEmpty;
     },
 
+    isAllSURFACEGEOSelectionsEmpty: function() {
+        let isInputSetEmpty = true;
+        for (const slug in opus.selections) {
+            if (slug.match(/^SURFACEGEO/)) {
+                isInputSetEmpty = o_search.isSlugSelectionsEmpty(opus.selections[slug], isInputSetEmpty);
+                if (!isInputSetEmpty) {
+                    break;
+                }
+            }
+        }
+
+        return isInputSetEmpty;
+    },
+
     areAllInputsValInAWidgetEmpty: function(inputs, isInputSetEmpty) {
         /**
          * Check if all inputs value are empty. Iterate through all inputs
@@ -1115,7 +1129,7 @@ var o_search = {
         }); // end mults ajax
     },
 
-    getValidMults: function(slug) {
+    getValidMults: function(slug, hideHintsForSurfacegeoTarget=false) {
         // turn on spinner
         $(`#widget__${slug} .spinner`).fadeIn();
 
@@ -1138,14 +1152,33 @@ var o_search = {
                     let value = $(this).attr("value");
                     let id = '#hint__' + slug + "_" + value.replace(/ /g,'-').replace(/[^\w\s]/gi, '');  // id of hinting span, defined in widgets.js getWidget
 
-                    if (mults[value]) {
-                          $(id).html('<span>' + mults[value] + '</span>');
-                          if ($(id).parent().hasClass("fadey")) {
-                            $(id).parent().removeClass("fadey");
-                          }
+                    if (!hideHintsForSurfacegeoTarget) {
+                        if (mults[value]) {
+                            $(id).html('<span>' + mults[value] + '</span>');
+                            if ($(id).parent().hasClass("fadey")) {
+                                $(id).parent().removeClass("fadey");
+                            }
+                        } else {
+                            $(id).html('<span>0</span>');
+                            $(id).parent().addClass("fadey");
+                        }
                     } else {
-                        $(id).html('<span>0</span>');
-                        $(id).parent().addClass("fadey");
+                        // Display "--" next to surfacegeometrytargetname inputs if the input is not selected.
+                        $(id).parent().removeClass("fadey");
+                        if (mults[value]) {
+                            if ($(this).is(":checked")) {
+                                $(id).html('<span>' + mults[value] + '</span>');
+                            } else {
+                                $(id).html('<span>--</span>');
+                            }
+                        } else {
+                            if ($(this).is(":checked")) {
+                                $(id).html('<span>0</span>');
+
+                            } else {
+                                $(id).html('<span>--</span>');
+                            }
+                        }
                     }
                 });
             },

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -333,6 +333,8 @@ var o_search = {
             // mult widget gets changed
             let id = $(this).attr("id").split("_")[0];
             let value = $(this).attr("value");
+            let newTargetSlug = $(this).attr("data-slug");
+            opus.oldSurfacegeoTarget = opus.oldSurfacegeoTarget || newTargetSlug;
 
             if ($(this).is(":checked")) {
                 let values = [];
@@ -374,7 +376,12 @@ var o_search = {
             if (!opus.areRangeInputsValid()) {
                 opus.updateOPUSLastSelectionsWithOPUSSelections();
             }
+            console.log(`Change event in choice change`);
+            console.log(JSON.stringify(opus.selections));
             o_hash.updateURLFromCurrentHash();
+
+            // opus.oldSurfacegeoTarget = newTargetSlug;
+            console.log(`opus.oldSurfacegeoTarget: ${opus.oldSurfacegeoTarget}`);
         });
 
         // range behaviors and string behaviors for search widgets - qtype select dropdown

--- a/opus/application/static_media/js/utils.js
+++ b/opus/application/static_media/js/utils.js
@@ -109,7 +109,18 @@ var o_utils = {
     // or inner objects. In our case, we only have arrays as values.
     deepCloneObj: function(obj) {
         return JSON.parse(JSON.stringify(obj));
-    }
+    },
+
+    getSurfacegeoTargetSlug: function(target) {
+        /**
+         * Take in a surface geo target pretty name and return a slug name
+         * for the target.
+         */
+        let slugName = target.toLowerCase();
+        // remove all "_", "/", and " "
+        slugName = slugName.replace(/_/g, "").replace(/\//g, "").replace(/ /g, "");
+        return slugName;
+    },
 };
 
 /**

--- a/opus/application/static_media/js/utils.js
+++ b/opus/application/static_media/js/utils.js
@@ -111,6 +111,7 @@ var o_utils = {
         return JSON.parse(JSON.stringify(obj));
     },
 
+    // This function is patterned after slug_name_for_sfc_target in import_util.py.
     getSurfacegeoTargetSlug: function(target) {
         /**
          * Take in a surface geo target pretty name and return a slug name

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -164,15 +164,17 @@ var o_widgets = {
 
                 // Update metadata selections
                 let currentMetadataSelections = opus.prefs.cols.slice();
+                let newSurfacegeoMetadataSelections = [];
                 for (const col of currentMetadataSelections) {
                     if (col.match(oldTargetStr)) {
                         let newCol = col.replace(oldTargetStr, newTargetStr);
                         if (!opus.prefs.cols.includes(newCol)) {
-                            let idxToInsert = opus.prefs.cols.indexOf(col);
-                            opus.prefs.cols.splice(idxToInsert, 0, newCol);
+                            newSurfacegeoMetadataSelections.push(newCol);
                         }
                     }
                 }
+                // New metadata selections will be added to the end of the list.
+                opus.prefs.cols.push(...newSurfacegeoMetadataSelections);
 
                 // Update unit record in opus.currentUnitBySlug
                 o_widgets.updateSURFACEGEODataObj(opus.currentUnitBySlug, oldTargetStr, newTargetStr);

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -93,37 +93,19 @@ var o_widgets = {
             }
         });
 
-        // close opened surfacegeo widget if user select another surfacegeo target
+        // Update surfacegeo widgets in place if user selects another surfacegeo target.
+        // 1. Update surfacegeo attributes/text in DOMs of all related surfacegeo widgets.
+        // 2. Update selections (opus.selection, opus.extras) & widgets.
         $('#search').on('change', 'input.singlechoice', function() {
-            // $('a[data-slug^="SURFACEGEO"]').each( function(index) {
-            //     let slug = $(this).data('slug');
-            //     o_widgets.closeWidget(slug);
-            //     let id = "#widget__"+slug;
-            //     try {
-            //         $(id).remove();
-            //     } catch (e) {
-            //         console.log("error on close widget, id="+id);
-            //     }
-            // });
-            console.log(`==========Change event in singlechoice in widgets.js`);
-            console.log(JSON.stringify(opus.selections));
-            console.log(JSON.stringify(opus.extras));
             let newTargetPrettyName = $(this).attr("value");
             let newTargetSlug = $(this).attr("data-slug");
             opus.oldSurfacegeoTarget = opus.oldSurfacegeoTarget || newTargetSlug;
             let oldTargetStr = `SURFACEGEO${opus.oldSurfacegeoTarget}`;
             let newTargetStr = `SURFACEGEO${newTargetSlug}`;
-            console.log(`before opus.oldSurfacegeoTarget: ${opus.oldSurfacegeoTarget}`);
-            // 1. Update surfacegeo attributes/text in DOMs of all related surfacegeo widgets.
-            // 2. Update selections (opus.selection, opus.extras) & widgets
-            for (const eachSurfacegeoWidget of $(".widget[id^='widget__SURFACEGEO']")) {
-                // Update attributes card header
-                let currentWidget = $(eachSurfacegeoWidget);
-                // let currenSlug = currentWidget.attr("id").match(/^widget__(.*)/)[1];
-                // let newSlug = currenSlug.replace(oldTargetStr, newTargetStr);
-                // console.log(`newSlug: ${newSlug}`);
-                // console.log(`currenSlug: ${currenSlug}`);
 
+            for (const eachSurfacegeoWidget of $(".widget[id^='widget__SURFACEGEO']")) {
+                let currentWidget = $(eachSurfacegeoWidget);
+                // Update attributes in widget and card header.
                 let oldWidgetTitle = currentWidget.find(".op-widget-title").text();
                 let newWidgetTitle = oldWidgetTitle.replace(/\[.*\]/, `[${newTargetPrettyName}]`);
                 let unitInput = currentWidget.find("select[class^='op-unit']");
@@ -158,12 +140,7 @@ var o_widgets = {
                     o_widgets.updateSURFACEGEOattrInPlace(addBtns, newTargetSlug, "data-widget");
                     o_widgets.updateSURFACEGEOattrInPlace(addBtns, newTargetSlug, "data-slug");
                 }
-                // Update the hint for new target
-                // o_search.getHinting(newSlug);
-
             }
-            console.log(JSON.stringify(opus.selections));
-            console.log(JSON.stringify(opus.extras));
 
             // Update selections & extras
             for (const slug in opus.selections) {
@@ -188,13 +165,7 @@ var o_widgets = {
                 }
             });
 
-            console.log(`after update @@@@@`);
-            console.log(JSON.stringify(opus.selections));
-            console.log(JSON.stringify(opus.extras));
-            console.log("break=========");
-
             opus.oldSurfacegeoTarget = newTargetSlug;
-            console.log(`after all opus.oldSurfacegeoTarget: ${opus.oldSurfacegeoTarget}`);
         });
 
         // When user selects a ranges info item, update input fields and opus.selections

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -95,16 +95,28 @@ var o_widgets = {
 
         // close opened surfacegeo widget if user select another surfacegeo target
         $('#search').on('change', 'input.singlechoice', function() {
-            $('a[data-slug^="SURFACEGEO"]').each( function(index) {
-                let slug = $(this).data('slug');
-                o_widgets.closeWidget(slug);
-                let id = "#widget__"+slug;
-                try {
-                    $(id).remove();
-                } catch (e) {
-                    console.log("error on close widget, id="+id);
-                }
+            // $('a[data-slug^="SURFACEGEO"]').each( function(index) {
+            //     let slug = $(this).data('slug');
+            //     o_widgets.closeWidget(slug);
+            //     let id = "#widget__"+slug;
+            //     try {
+            //         $(id).remove();
+            //     } catch (e) {
+            //         console.log("error on close widget, id="+id);
+            //     }
+            // });
+            console.log(`==========Change event in singlechoice in widgets.js`);
+            console.log(JSON.stringify(opus.selections));
+            console.log(JSON.stringify(opus.extras));
+            let newTargetSlug = $(this).attr("data-slug");
+            opus.oldSurfacegeoTarget = opus.oldSurfacegeoTarget || newTargetSlug;
+            console.log(`before opus.oldSurfacegeoTarget: ${opus.oldSurfacegeoTarget}`);
+            $.each($(".widget[id^='widget__SURFACEGEO']"), function(idx, eachSurfacegeoWidget) {
+                console.log($(eachSurfacegeoWidget).attr("id"));
             });
+
+            opus.oldSurfacegeoTarget = newTargetSlug;
+            console.log(`after all opus.oldSurfacegeoTarget: ${opus.oldSurfacegeoTarget}`);
         });
 
         // When user selects a ranges info item, update input fields and opus.selections
@@ -743,24 +755,13 @@ var o_widgets = {
                // corresponding radio input.
                $.each($("input[type='radio']"), function(idx, eachChoice) {
                    let surfacegeoTarget = $(eachChoice).attr("value");
-                   let surfacegeoTargetSlug = o_widgets.getSurfacegeoTargetSlug(surfacegeoTarget);
+                   let surfacegeoTargetSlug = o_utils.getSurfacegeoTargetSlug(surfacegeoTarget);
                    $(eachChoice).attr("data-slug", surfacegeoTargetSlug);
                });
                break;
            //
 
         }
-    },
-
-    getSurfacegeoTargetSlug: function(target) {
-        /**
-         * Take in a surface geo target pretty name and return a slug name
-         * for the target.
-         */
-        let slugName = target.toLowerCase();
-        // remove all "_", "/", and " "
-        slugName = slugName.replace(/_/g, "").replace(/\//g, "").replace(/ /g, "");
-        return slugName;
     },
 
     // adjusts the widths of the widgets in the main column so they fit users screen size

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -41,10 +41,10 @@ var o_widgets = {
     // want to perform a search when a widget has just opened.
     isGetWidgetDone: false,
 
-    // This flag is used to determined if we are closing any widget with empty input.
+    // This flag is used to determine if we are closing any widget with empty input.
     // In a series of closing widget actions, if there is one input in a widget with a
     // value, we will make sure a search is performed after updating URL. If none of
-    // inputs has value, we don't need to perform a search.
+    // inputs have values, we don't need to perform a search.
     isRemovingEmptyWidget: true,
 
     addWidgetBehaviors: function() {
@@ -203,7 +203,7 @@ var o_widgets = {
 
     updateSURFACEGEOattrInPlace: function(targetElement, newSurfacegeoTargetSlug, attribute) {
         /**
-         * Update surfacegeo attributes in place with newly select target
+         * Update surfacegeo attributes in place with newly selected target
          */
         if (targetElement.length === 0) {
             return;
@@ -811,33 +811,61 @@ var o_widgets = {
     // this is called after a widget is drawn
     customWidgetBehaviors: function(slug) {
         switch(slug) {
+            // planet checkboxes open target groupings:
+            case "planet":
+                // user checks a planet box - open the corresponding target group
+                // adding a behavior: checking a planet box opens the corresponding targets
+                $("#search").on("change", '#widget__planet input:checkbox:checked', function(e) {
+                    o_widgets.expandInputGroupBySelectedPlanet($(this));
+                });
+
+                break;
             case "target":
+                // when target widget is drawn, look for any checked planets:
+                // usually for when a planet checkbox is checked on page load
+                $('#widget__planet input:checkbox:checked', '#search').each(function() {
+                    // confine to param/vals - not other input controls
+                    if ($(this).attr('id') && $(this).attr('id').split('_')[0] == 'planet') {
+                       o_widgets.expandInputGroupBySelectedPlanet($(this));
+                    }
+                });
+
                 // When target widget is drawn, look for any checked intended target
                 // and expand the group with the selected target.
                 let intendedTargetInputs = $(`#widget__${slug} input[type="checkbox"]:checked`);
-                o_widgets.expandInputGroup(intendedTargetInputs, slug);
+                o_widgets.expandInputGroupBySelectedTarget(intendedTargetInputs, slug);
+
                 break;
-
             case "surfacegeometrytargetname":
-               // When surfacegeometrytargetname widget is drawn, look for any checked singlechoice input
-               // and expand the group with the selected target.
-               let surfacegeoTargetInputs = $(`#widget__${slug} input[type="radio"]:checked`);
-               o_widgets.expandInputGroup(surfacegeoTargetInputs, slug);
+                // when target widget is drawn, look for any checked planets:
+                // usually for when a planet checkbox is checked on page load
+                $('#widget__planet input:checkbox:checked', '#search').each(function() {
+                    // confine to param/vals - not other input controls
+                    if ($(this).attr('id') && $(this).attr('id').split('_')[0] == 'planet') {
+                        o_widgets.expandInputGroupBySelectedPlanet($(this));
+                    }
+                });
 
-               // Put each surfacegeo target slug into the data-slug attribute of the
-               // corresponding radio input.
-               $.each($("input[type='radio']"), function(idx, eachChoice) {
-                   let surfacegeoTarget = $(eachChoice).attr("value");
-                   let surfacegeoTargetSlug = o_utils.getSurfacegeoTargetSlug(surfacegeoTarget);
-                   $(eachChoice).attr("data-slug", surfacegeoTargetSlug);
-               });
-               break;
+                // When surfacegeometrytargetname widget is drawn, look for any checked singlechoice input
+                // and expand the group with the selected target.
+                let surfacegeoTargetInputs = $(`#widget__${slug} input[type="radio"]:checked`);
+                o_widgets.expandInputGroupBySelectedTarget(surfacegeoTargetInputs, slug);
+
+                // Put each surfacegeo target slug into the data-slug attribute of the
+                // corresponding radio input.
+                $.each($("input[type='radio']"), function(idx, eachChoice) {
+                    let surfacegeoTarget = $(eachChoice).attr("value");
+                    let surfacegeoTargetSlug = o_utils.getSurfacegeoTargetSlug(surfacegeoTarget);
+                    $(eachChoice).attr("data-slug", surfacegeoTargetSlug);
+                });
+
+                break;
         }
     },
 
-    expandInputGroup: function(targetInputs, slug) {
+    expandInputGroupBySelectedTarget: function(targetInputs, slug) {
         /**
-         * Loop through targetInputs and expand the group with selected inputs. 
+         * Loop through targetInputs and expand the group with selected inputs.
          */
         for (const input of targetInputs) {
             if ($(input).attr("id") && $(input).attr("id").split("_")[0] === slug) {
@@ -849,6 +877,16 @@ var o_widgets = {
                 multGroup.slideDown("fast");
             }
         }
+    },
+
+    expandInputGroupBySelectedPlanet: function(selectedPlanet) {
+        /**
+         * Expand the corresponding input groups based on the selected planet.
+         */
+        let mult_id = ".mult_group_" + selectedPlanet.attr("value");
+        $(mult_id).find(".indicator").addClass("fa-minus");
+        $(mult_id).find(".indicator").removeClass("fa-plus");
+        $(mult_id).next().slideDown("fast");
     },
 
     // adjusts the widths of the widgets in the main column so they fit users screen size

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -143,20 +143,9 @@ var o_widgets = {
             }
 
             // Update selections & extras
-            for (const slug in opus.selections) {
-                if (slug.match(oldTargetStr)) {
-                    let newSlug = slug.replace(oldTargetStr, newTargetStr);
-                    opus.selections[newSlug] = opus.selections[slug];
-                    delete opus.selections[slug];
-                }
-            }
-            for (const extras in opus.extras) {
-                if (extras.match(oldTargetStr)) {
-                    let newSlug = extras.replace(oldTargetStr, newTargetStr);
-                    opus.extras[newSlug] = opus.extras[extras];
-                    delete opus.extras[extras];
-                }
-            }
+            o_widgets.updateSURFACEGEODataObj(opus.selections, oldTargetStr, newTargetStr);
+            o_widgets.updateSURFACEGEODataObj(opus.extras, oldTargetStr, newTargetStr);
+
             // Update widgets column in opus.prefs
             $.each(opus.prefs.widgets, function(widgetIdx, widget) {
                 if (widget.match(oldTargetStr)) {
@@ -164,6 +153,9 @@ var o_widgets = {
                     opus.prefs.widgets[widgetIdx] = newWidget;
                 }
             });
+            
+            // Update unit record in opus.currentUnitBySlug
+            o_widgets.updateSURFACEGEODataObj(opus.currentUnitBySlug, oldTargetStr, newTargetStr);
 
             opus.oldSurfacegeoTarget = newTargetSlug;
         });
@@ -207,6 +199,21 @@ var o_widgets = {
         let newTargetStr = `SURFACEGEO${newSurfacegeoTargetSlug}`;
         let newTargetAttr = targetElement.attr(attribute).replace(oldTargetStr, newTargetStr);
         targetElement.attr(attribute, newTargetAttr);
+    },
+
+    updateSURFACEGEODataObj: function(dataObj, oldTargetStr, newTargetStr) {
+        /**
+         * Update data object (opus.selections, opus.extras, and opus.currentUnitBySlug)
+         * in place with newly select target.
+         * NOTE: the passed in dataObj will be modified.
+         */
+        for (const oldTargetSlug in dataObj) {
+            if (oldTargetSlug.match(oldTargetStr)) {
+                let newSlug = oldTargetSlug.replace(oldTargetStr, newTargetStr);
+                dataObj[newSlug] = dataObj[oldTargetSlug];
+                delete dataObj[oldTargetSlug];
+            }
+        }
     },
 
     getMaxScrollTopVal: function(target) {
@@ -708,6 +715,8 @@ var o_widgets = {
 
         delete opus.extras[`qtype-${slugNoNum}`];
         delete opus.extras[`unit-${slugNoNum}`];
+        // Remove unit record
+        delete opus.currentUnitBySlug[slugNoNum];
 
         let selector = `.op-search-menu li [data-slug='${slug}']`;
         o_menu.markMenuItem(selector, "unselect");

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -811,44 +811,18 @@ var o_widgets = {
     // this is called after a widget is drawn
     customWidgetBehaviors: function(slug) {
         switch(slug) {
-
-            // planet checkboxes open target groupings:
-            case 'planet':
-                // user checks a planet box - open the corresponding target group
-                // adding a behavior: checking a planet box opens the corresponding targets
-                $('#search').on('change', '#widget__planet input:checkbox:checked', function() {
-                    // a planet is .chosen_columns, and its corresponding target is not already open
-                    let mult_id = '.mult_group_' + $(this).attr('value');
-                    $(mult_id).find('.indicator').addClass('fa-minus');
-                    $(mult_id).find('.indicator').removeClass('fa-plus');
-                    $(mult_id).next().slideDown("fast");
-                });
+            case "target":
+                // When target widget is drawn, look for any checked intended target
+                // and expand the group with the selected target.
+                let intendedTargetInputs = $(`#widget__${slug} input[type="checkbox"]:checked`);
+                o_widgets.expandInputGroup(intendedTargetInputs, slug);
                 break;
 
-            case 'target':
-                // when target widget is drawn, look for any checked planets:
-                // usually for when a planet checkbox is checked on page load
-                $('#widget__planet input:checkbox:checked', '#search').each(function() {
-                    if ($(this).attr('id') && $(this).attr('id').split('_')[0] == 'planet') { // confine to param/vals - not other input controls
-                        let mult_id = '.mult_group_' + $(this).attr('value');
-                        $(mult_id).find('.indicator').addClass('fa-minus');
-                        $(mult_id).find('.indicator').removeClass('fa-plus');
-                        $(mult_id).next().slideDown("fast");
-                    }
-                });
-                break;
-
-            case 'surfacegeometrytargetname':
-               // when target widget is drawn, look for any checked planets:
-               // usually for when a planet checkbox is checked on page load
-               $('#widget__planet input:checkbox:checked', '#search').each(function() {
-                   if ($(this).attr('id') && $(this).attr('id').split('_')[0] == 'planet') { // confine to param/vals - not other input controls
-                       let mult_id = '.mult_group_' + $(this).attr('value');
-                       $(mult_id).find('.indicator').addClass('fa-minus');
-                       $(mult_id).find('.indicator').removeClass('fa-plus');
-                       $(mult_id).next().slideDown("fast");
-                   }
-               });
+            case "surfacegeometrytargetname":
+               // When surfacegeometrytargetname widget is drawn, look for any checked singlechoice input
+               // and expand the group with the selected target.
+               let surfacegeoTargetInputs = $(`#widget__${slug} input[type="radio"]:checked`);
+               o_widgets.expandInputGroup(surfacegeoTargetInputs, slug);
 
                // Put each surfacegeo target slug into the data-slug attribute of the
                // corresponding radio input.
@@ -858,8 +832,22 @@ var o_widgets = {
                    $(eachChoice).attr("data-slug", surfacegeoTargetSlug);
                });
                break;
-           //
+        }
+    },
 
+    expandInputGroup: function(targetInputs, slug) {
+        /**
+         * Loop through targetInputs and expand the group with selected inputs. 
+         */
+        for (const input of targetInputs) {
+            if ($(input).attr("id") && $(input).attr("id").split("_")[0] === slug) {
+                let multGroup = $(input).parents(".mult_group");
+                let groupName = $(input).parents(".mult_group").attr("data-group");
+                let multGroupLabel = $(`.mult_group_${groupName}`);
+                multGroupLabel.find('.indicator').addClass('fa-minus');
+                multGroupLabel.find('.indicator').removeClass('fa-plus');
+                multGroup.slideDown("fast");
+            }
         }
     },
 

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -259,7 +259,7 @@ var o_widgets = {
         try {
             $(id).remove();
         } catch (e) {
-            opus.logError(`error on close widget, id = ${id}`);
+            opus.logError(`Error on close widget (closeAndRemoveWidgetFromDOM), id = ${id}`);
         }
     },
 

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -738,10 +738,29 @@ var o_widgets = {
                        $(mult_id).next().slideDown("fast");
                    }
                });
+
+               // Put each surfacegeo target slug into the data-slug attribute of the
+               // corresponding radio input.
+               $.each($("input[type='radio']"), function(idx, eachChoice) {
+                   let surfacegeoTarget = $(eachChoice).attr("value");
+                   let surfacegeoTargetSlug = o_widgets.getSurfacegeoTargetSlug(surfacegeoTarget);
+                   $(eachChoice).attr("data-slug", surfacegeoTargetSlug);
+               });
                break;
            //
 
         }
+    },
+
+    getSurfacegeoTargetSlug: function(target) {
+        /**
+         * Take in a surface geo target pretty name and return a slug name
+         * for the target.
+         */
+        let slugName = target.toLowerCase();
+        // remove all "_", "/", and " "
+        slugName = slugName.replace(/_/g, "").replace(/\//g, "").replace(/ /g, "");
+        return slugName;
     },
 
     // adjusts the widths of the widgets in the main column so they fit users screen size

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -167,8 +167,10 @@ var o_widgets = {
                 for (const col of currentMetadataSelections) {
                     if (col.match(oldTargetStr)) {
                         let newCol = col.replace(oldTargetStr, newTargetStr);
-                        let idxToInsert = opus.prefs.cols.indexOf(col);
-                        opus.prefs.cols.splice(idxToInsert, 0, newCol);
+                        if (!opus.prefs.cols.includes(newCol)) {
+                            let idxToInsert = opus.prefs.cols.indexOf(col);
+                            opus.prefs.cols.splice(idxToInsert, 0, newCol);
+                        }
                     }
                 }
 

--- a/opus/import/import_util.py
+++ b/opus/import/import_util.py
@@ -263,7 +263,7 @@ def table_name_for_sfc_target(target_name):
     return encode_target_name(target_name)
 
 # NOTE: whenever we change this function, we will have to change
-# getSurfacegeoTargetSlug in widgets.js as well.
+# getSurfacegeoTargetSlug in JS codes as well.
 def slug_name_for_sfc_target(target_name):
     if target_name.upper() in TARGET_NAME_MAPPING:
         target_name = TARGET_NAME_MAPPING[target_name.upper()]

--- a/opus/import/import_util.py
+++ b/opus/import/import_util.py
@@ -262,6 +262,8 @@ def table_name_for_sfc_target(target_name):
         target_name = TARGET_NAME_MAPPING[target_name.upper()]
     return encode_target_name(target_name)
 
+# NOTE: whenever we change this function, we will have to change
+# getSurfacegeoTargetSlug in widgets.js as well.
 def slug_name_for_sfc_target(target_name):
     if target_name.upper() in TARGET_NAME_MAPPING:
         target_name = TARGET_NAME_MAPPING[target_name.upper()]

--- a/opus/import/import_util.py
+++ b/opus/import/import_util.py
@@ -263,7 +263,7 @@ def table_name_for_sfc_target(target_name):
     return encode_target_name(target_name)
 
 # NOTE: whenever we change this function, we will have to change
-# getSurfacegeoTargetSlug in JS codes as well.
+# getSurfacegeoTargetSlug in JS code (in utils.js) as well.
 def slug_name_for_sfc_target(target_name):
     if target_name.upper() in TARGET_NAME_MAPPING:
         target_name = TARGET_NAME_MAPPING[target_name.upper()]


### PR DESCRIPTION
- Fixes #872
- Fixes #663 
- Run JSHint on: search.js, widgets.js, menu.js, hash.js
- Test on latest: Chrome, Firefox, Safari, and Opera.
- One issue: getting mults hints when switching to a different surfacegeo target:
  -  We not only change surfacegeo target name, but also change all related surfacegeo slugs to new target ones. So the mults hints displayed in surface target name is the correct return from api call but it will not be the result count for the future next click. For example, switching in surfacegeo target name from surfacegeometrytargetname=Mimas&SURFACEGEOmimasplanetographiclatitude1=7 (Pallene has 1 result) to surfacegeometrytargetname=Pallene&SURFACEGEOpalleneplanetographiclatitude1=7 (Pallene actually has 0 result, not 1). 

