### PR TITLE
Fixed issue that Input fields don't work under iOS (issue 961)

### DIFF
--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -60,6 +60,15 @@ var o_search = {
     performInputValidation: {},
 
     addSearchBehaviors: function() {
+        // Manually focus in the input field if it's not focused after the 1st click.
+        // This is to fix the issue that the input field will not be focused after
+        // the 1st click in iOS.
+        $("#search").on("click", "input[type='text']", function(e) {
+            if (!$(this).is(":focus")) {
+                $(this).focus();
+            }
+        });
+
         // Avoid the orange blinking on border color, and also display proper border when input is in focus
         $("#search").on("focus", "input.RANGE", function(e) {
             let inputName = $(this).attr("name");


### PR DESCRIPTION
- Fixes #961 
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - Database used: opus3_test_200107
  - All Django tests pass: Y
- Were any JavaScript or CSS files modified? Y (search.js)
  - JSHINT run on all affected files: Y
  - Tested on Chrome, Firefox, Safari, and iOS: Y (Both Safari & Chrome in iOS)
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:
Manually focus in the input field if it's not focused after the 1st click. This is to fix the issue that the input field will not be focused after the 1st click in iOS.

Known problems: (Fixed)
In iOS, users can't focus in the input fields to type texts.