### PR TITLE
Navbar padding, help panel (x), copy mults (issue 855,962)

### DIFF
--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -33,7 +33,7 @@
             <div class="collapse navbar-collapse" id="op-main-nav-collapse">
                 <ul class="op-tab nav navbar-nav mr-auto op-main-site-tabs flex-column flex-sm-row" role="tablist">
                     <li class="nav-item external-link blogspot">
-                        <a class="nav-link" href="https://ringsnodesearchtool.blogspot.com/" target="_blank" aria-controls="blogspot">
+                        <a class="nav-link op-blog-link" href="https://ringsnodesearchtool.blogspot.com/" target="_blank" aria-controls="blogspot">
                             <div id="op-last-blog-update-date" class="container align-items-center d-flex h-100 my-auto" data-toggle="tooltip" data-placement="bottom" title="">
                                 <img class="newGIF" src="{{ STATIC_URL }}img/new_25.gif" alt="Recent Announcements"/>&nbsp;Recent Announcements
                             </div>

--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -281,7 +281,7 @@
 
         <!--sliding panel for the help menu items -->
         <div id="op-help-panel" class="card w-75">
-            <div class="card-header align-items-center h-auto pb-0 bg-secondary">
+            <div class="card-header align-items-center h-auto bg-secondary">
                 <h3 class='op-header-text'></h3>
                 <a class="close" aria-label="Close"><i class="far fa-times-circle fa-lg"></i></a>
             </div>

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -1925,6 +1925,11 @@ footer {
     top: 2em;
 }
 
+/* Make sure "x" in help panel is vertically aligned with header text */
+#op-help-panel .close {
+    margin-bottom: 0.5rem;
+}
+
 .op-open-help {
     float: right;
 }

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2165,8 +2165,8 @@ ul.ui-autocomplete a.ui-state-active {
     user-select: none;
 }
 
-/* Allow users to mouse over and select text in widgets */
-.op-input ul li {
+/* Allow users to mouse over and select texts & hints in widgets */
+.op-input ul label, .op-input ul span {
     -ms-user-select: text;
     user-select: text;
     -moz-user-select: text;

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2166,7 +2166,7 @@ ul.ui-autocomplete a.ui-state-active {
 }
 
 /* Allow users to mouse over and select text in widgets */
-.op-widget-main ul {
+.op-input ul li {
     -ms-user-select: text;
     user-select: text;
     -moz-user-select: text;

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -1925,7 +1925,7 @@ footer {
     top: 2em;
 }
 
-/* Make sure "x" in help panel is vertically aligned with header text */
+/* Make sure "x" in help panel is vertically aligned with the header text */
 #op-help-panel .close {
     margin-bottom: 0.5rem;
 }

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -69,7 +69,7 @@ even when the browser size is narrow. */
 
 /* Make sure the height of top navbar will not change when "Recent Announcement"
 appears & disappears. */
-.op-tab a {
+.op-tab .op-blog-link {
     padding-top: 0;
     padding-bottom: 0;
 }

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -1925,11 +1925,6 @@ footer {
     top: 2em;
 }
 
-/* Make sure "x" in help panel is vertically aligned with the header text */
-#op-help-panel .close {
-    margin-bottom: 0.5rem;
-}
-
 .op-open-help {
     float: right;
 }
@@ -2015,6 +2010,20 @@ footer {
 
 .op-header-text {
     display: inline-block;
+}
+
+/* Remove default h tag margin-bottom to center the title text in help panel */
+#op-help-panel .op-header-text {
+    margin-bottom: 0;
+}
+
+#op-help-panel .op-header-text h2 {
+    margin-bottom: 0;
+}
+
+/* Center the "x" icon in help panel */
+#op-help-panel .close {
+    display: flex;
 }
 
 #op-help-panel .card-body {

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -41,15 +41,23 @@ body.modal-open .navbar {
     width: 3em !important;
 }
 
+/* Keep the horizontal spacing between Search/Browse Results/Cart/Detail the same
+even when the browser size is narrow. */
+#op-main-nav .nav-link {
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+}
+
 @media (max-width: 992px) {
     #op-main-nav.navbar .navbar-brand {
         float: none;
         display: block;
     }
+
     #op-main-nav.navbar .navbar-nav>.nav-item {
         float: none;
-        margin-left: .1rem;
     }
+
     #op-main-nav.navbar .navbar-nav {
         float: none !important;
     }
@@ -58,6 +66,18 @@ body.modal-open .navbar {
     #op-main-nav-collapse.show, #op-main-nav-collapse.collapsing {
         display: flex;
     }
+}
+
+/* Make sure the height of top navbar will not change when "Recent Announcement"
+appears & disappears. */
+.op-tab a {
+    padding-top: 0;
+    padding-bottom: 0;
+}
+
+/* Make sure "OPUS" on the top left corner is not moving when browser gets narrow. */
+.op-reset-opus {
+    display: inline-block !important;
 }
 
 @media (max-width: 992px) {

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -51,7 +51,6 @@ even when the browser size is narrow. */
 @media (max-width: 992px) {
     #op-main-nav.navbar .navbar-brand {
         float: none;
-        display: block;
     }
 
     #op-main-nav.navbar .navbar-nav>.nav-item {
@@ -73,11 +72,6 @@ appears & disappears. */
 .op-tab a {
     padding-top: 0;
     padding-bottom: 0;
-}
-
-/* Make sure "OPUS" on the top left corner is not moving when browser gets narrow. */
-.op-reset-opus {
-    display: inline-block !important;
 }
 
 @media (max-width: 992px) {

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -682,6 +682,11 @@ button.op-mini-thumbnail-zoom {
     overflow-y: hidden;
 }
 
+/* Center the header text in select metadata modal */
+#op-select-metadata .modal-header {
+    align-items: center;
+}
+
 /* make modal width shrink smoothly with screen */
 #op-select-metadata .modal-dialog {
     /* max-width: 1100px; */
@@ -893,7 +898,7 @@ when window sized is narrow */
     z-index: 999;
 }
 
-#galleryView button.close, #op-select-metadata button.close {
+#galleryView button.close {
     position: absolute;
     float: right;
     top: .8em;

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2165,6 +2165,15 @@ ul.ui-autocomplete a.ui-state-active {
     user-select: none;
 }
 
+/* Allow users to mouse over and select text in widgets */
+.op-widget-main ul {
+    -ms-user-select: text;
+    user-select: text;
+    -moz-user-select: text;
+    -khtml-user-select: text;
+    -webkit-user-select: text;
+}
+
 /* prevents all click, state and cursor options on the specified HTML element */
 .op-prevent-pointer-events {
     pointer-events: none;

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -51,6 +51,7 @@ var o_widgets = {
         $("#op-search-widgets").sortable({
             items: "> li",
             cursor: "move",
+            cancel: ".multichoice span, .multichoice label, .singlechoice span, .singlechoice label",
             // we need the clone so that widgets in url gets changed only when sorting is stopped
             // Note: this will make radio buttons deselected when a widget with radio buttons is dragged.
             // We have to restore radio button checked status in stop event handler.

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -51,6 +51,8 @@ var o_widgets = {
         $("#op-search-widgets").sortable({
             items: "> li",
             cursor: "move",
+            // Specify the elements that will not trigger sorting when being grabbed. This is to make
+            // input texts and hints copiable in widgets with checkboxes and radio buttons.
             cancel: ".multichoice span, .multichoice label, .singlechoice span, .singlechoice label",
             // we need the clone so that widgets in url gets changed only when sorting is stopped
             // Note: this will make radio buttons deselected when a widget with radio buttons is dragged.

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -51,9 +51,6 @@ var o_widgets = {
         $("#op-search-widgets").sortable({
             items: "> li",
             cursor: "move",
-            // Specify the elements that will not trigger sorting when being grabbed. This is to make
-            // input texts and hints copiable in widgets with checkboxes and radio buttons.
-            cancel: ".multichoice span, .multichoice label, .singlechoice span, .singlechoice label",
             // we need the clone so that widgets in url gets changed only when sorting is stopped
             // Note: this will make radio buttons deselected when a widget with radio buttons is dragged.
             // We have to restore radio button checked status in stop event handler.


### PR DESCRIPTION
- Fixes #962, #855 
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - Database used: opus3_test_200107
  - All Django tests pass: Y
- Were any JavaScript or CSS files modified? Y
  - JSHINT run on all affected files: Y
  - Tested on Chrome, Firefox, Safari, and iOS: Y
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:
- Fixed the issue to keep the spacing between Search/Browse Results/Cart/Detail the same even when the browser gets narrower.
- Fixed the issue that the position of "OPUS" (on the top left corner) will jump a bit when browser gets narrow.
- Make input texts and hints copiable in widgets with checkboxes and radio buttons.  
- Make sure "x" in the help panel is vertically aligned with the header text.

Known problems:
- Hold & copy texts and hints for checkboxes and radio buttons will not work in iOS . (It should work by default, haven't found the solution for this.)