### PR TITLE
Allow clicking on whitespace to right of categories and menu options (issue 729)

### DIFF
--- a/opus/application/apps/ui/templates/ui/menu.html
+++ b/opus/application/apps/ui/templates/ui/menu.html
@@ -4,15 +4,19 @@
             <li class="list-group-item py-0 op-search-menu-category">
                 {#  Each div has a top-level catgory  #}
                 {% if div.start_expanded %}
-                    <a href="#{{ which }}-submenu-{{ div.table_name }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle py-2 op-submenu-category" data-cat="{{ div.table_name }}">
+                    <span class="op-general-search-category">
+                        <a href="#{{ which }}-submenu-{{ div.table_name }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle py-2 op-submenu-category" data-cat="{{ div.table_name }}">
+                            <span class="title">{{ div.label }}</span>
+                        </a>
+                        <span class="op-menu-text spinner">&nbsp;</span>
+                    </span>
                 {% else %}
                     <a href="#{{ which }}-submenu-{{ div.table_name }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle collapsed py-2 op-submenu-category" data-cat="{{ div.table_name }}">
+                        <span class="title">{{ div.label }}</span>
+                    </a>
                 {% endif %}
-                    <span class="title">{{ div.label }}</span>
-                </a>
 
                 {% if div.start_expanded %}
-                    <span class="op-menu-text spinner">&nbsp;</span>
                     <ul class="list-group list-group-flush submenu collapse show op-submenu-item-list" id="{{ which }}-submenu-{{ div.table_name }}">
                 {% else %}
                     <ul class="list-group list-group-flush submenu collapse op-submenu-item-list" id="{{ which }}-submenu-{{ div.table_name }}">

--- a/opus/application/apps/ui/templates/ui/menu.html
+++ b/opus/application/apps/ui/templates/ui/menu.html
@@ -50,20 +50,22 @@
                                                             {{ p.body_qualified_label }}
                                                         {% endif %}
                                                       " data-slug="{{ p.slug }}" class="op-search-param" href="#">
-                                                        <span class="op-search-param-checkmark">
-                                                            <i class="fa fa-check"></i>
+                                                        <span>
+                                                            <span class="op-search-param-checkmark">
+                                                                <i class="fa fa-check"></i>
+                                                            </span>
+                                                            {% if menu.data.labels_view == 'selector' %}
+                                                                {% if p.get_tooltip_results %}
+                                                                    <i class="fas fa-info-circle" title="{{ p.get_tooltip_results }}"></i>
+                                                                {% endif %}
+                                                                {{ p.label_results }}
+                                                            {% else %}
+                                                                {% if p.get_tooltip %}
+                                                                    <i class="fas fa-info-circle" title="{{ p.get_tooltip }}"></i>
+                                                                {% endif %}
+                                                                {{ p.label }}
+                                                            {% endif %}
                                                         </span>
-                                                        {% if menu.data.labels_view == 'selector' %}
-                                                            {% if p.get_tooltip_results %}
-                                                                <i class="fas fa-info-circle" title="{{ p.get_tooltip_results }}"></i>
-                                                            {% endif %}
-                                                            {{ p.label_results }}
-                                                        {% else %}
-                                                            {% if p.get_tooltip %}
-                                                                <i class="fas fa-info-circle" title="{{ p.get_tooltip }}"></i>
-                                                            {% endif %}
-                                                            {{ p.label }}
-                                                        {% endif %}
                                                     </a>
                                                 </li>
                                             {% endif %}
@@ -90,24 +92,26 @@
                                             {{ p.body_qualified_label }}
                                         {% endif %}
                                       " data-slug="{{ p.slug }}" class="op-search-param" href="#">
-                                        <span class="op-search-param-checkmark">
-                                            <i class="fa fa-check"></i>
-                                        </span>
-                                        {% if menu.data.labels_view == 'selector' %}
-                                            {% if p.get_tooltip_results %}
-                                                <i class="fas fa-info-circle" title="{{ p.get_tooltip_results }}"></i>
-                                            {% endif %}
-                                            {% if div.table_name == 'search_fields' %}
-                                                {{ p.body_qualified_label_results }}
+                                        <span>
+                                            <span class="op-search-param-checkmark">
+                                                <i class="fa fa-check"></i>
+                                            </span>
+                                            {% if menu.data.labels_view == 'selector' %}
+                                                {% if p.get_tooltip_results %}
+                                                    <i class="fas fa-info-circle" title="{{ p.get_tooltip_results }}"></i>
+                                                {% endif %}
+                                                {% if div.table_name == 'search_fields' %}
+                                                    {{ p.body_qualified_label_results }}
+                                                {% else %}
+                                                    {{ p.label_results }}
+                                                {% endif %}
                                             {% else %}
-                                                {{ p.label_results }}
+                                                {% if p.get_tooltip %}
+                                                    <i class="fas fa-info-circle" title="{{ p.get_tooltip }}"></i>
+                                                {% endif %}
+                                                {{ p.label }}
                                             {% endif %}
-                                        {% else %}
-                                            {% if p.get_tooltip %}
-                                                <i class="fas fa-info-circle" title="{{ p.get_tooltip }}"></i>
-                                            {% endif %}
-                                            {{ p.label }}
-                                        {% endif %}
+                                        </span>
                                     </a>
                                 </li>
                             {% endfor %}

--- a/opus/application/apps/ui/templates/ui/menu.html
+++ b/opus/application/apps/ui/templates/ui/menu.html
@@ -13,9 +13,9 @@
 
                 {% if div.start_expanded %}
                     <span class="op-menu-text spinner">&nbsp;</span>
-                    <ul class="list-group list-group-flush submenu collapse show" id="{{ which }}-submenu-{{ div.table_name }}">
+                    <ul class="list-group list-group-flush submenu collapse show op-submenu-item-list" id="{{ which }}-submenu-{{ div.table_name }}">
                 {% else %}
-                    <ul class="list-group list-group-flush submenu collapse" id="{{ which }}-submenu-{{ div.table_name }}">
+                    <ul class="list-group list-group-flush submenu collapse op-submenu-item-list" id="{{ which }}-submenu-{{ div.table_name }}">
                 {% endif %}
 
                 <!-- all div labels have level 2 submenu to list params-->

--- a/opus/application/apps/ui/templates/ui/menu.html
+++ b/opus/application/apps/ui/templates/ui/menu.html
@@ -1,12 +1,12 @@
 {% block menu %}
     <ul class="op-search-menu list-group list-group-flush">
         {% for div in menu.divs %}
-            <li class="list-group-item py-2 op-search-menu-category">
+            <li class="list-group-item py-0 op-search-menu-category">
                 {#  Each div has a top-level catgory  #}
                 {% if div.start_expanded %}
-                    <a href="#{{ which }}-submenu-{{ div.table_name }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle" data-cat="{{ div.table_name }}">
+                    <a href="#{{ which }}-submenu-{{ div.table_name }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle py-2" data-cat="{{ div.table_name }}">
                 {% else %}
-                    <a href="#{{ which }}-submenu-{{ div.table_name }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle collapsed" data-cat="{{ div.table_name }}">
+                    <a href="#{{ which }}-submenu-{{ div.table_name }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle collapsed py-2" data-cat="{{ div.table_name }}">
                 {% endif %}
                     <span class="title">{{ div.label }}</span>
                 </a>
@@ -30,7 +30,7 @@
                             {#  this div has sub_headings, level-3 menu sections... start sub_heading loop  #}
                             {% for sub_head,params in info.data.items %}
                                 <li class="list-group-item py-0 pl-0">
-                                    <a href="#{{ which }}-submenu-{{ div.table_name|slugify }}-{{ sub_head|slugify }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle collapsed" data-cat="{{ div.table_name|slugify }}-{{ sub_head|slugify }}">
+                                    <a href="#{{ which }}-submenu-{{ div.table_name|slugify }}-{{ sub_head|slugify }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle collapsed py-2" data-cat="{{ div.table_name|slugify }}-{{ sub_head|slugify }}">
                                         <span class="menu-text title">{{ sub_head }}</span>
                                     </a>
                                     <ul class="list-group list-group-flush submenu collapse" id="{{ which }}-submenu-{{ div.table_name|slugify }}-{{ sub_head|slugify }}">

--- a/opus/application/apps/ui/templates/ui/menu.html
+++ b/opus/application/apps/ui/templates/ui/menu.html
@@ -30,7 +30,7 @@
                             {#  this div has sub_headings, level-3 menu sections... start sub_heading loop  #}
                             {% for sub_head,params in info.data.items %}
                                 <li class="list-group-item py-0 pl-0">
-                                    <a href="#{{ which }}-submenu-{{ div.table_name|slugify }}-{{ sub_head|slugify }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle collapsed py-2" data-cat="{{ div.table_name|slugify }}-{{ sub_head|slugify }}">
+                                    <a href="#{{ which }}-submenu-{{ div.table_name|slugify }}-{{ sub_head|slugify }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle collapsed" data-cat="{{ div.table_name|slugify }}-{{ sub_head|slugify }}">
                                         <span class="menu-text title">{{ sub_head }}</span>
                                     </a>
                                     <ul class="list-group list-group-flush submenu collapse" id="{{ which }}-submenu-{{ div.table_name|slugify }}-{{ sub_head|slugify }}">

--- a/opus/application/apps/ui/templates/ui/menu.html
+++ b/opus/application/apps/ui/templates/ui/menu.html
@@ -4,9 +4,9 @@
             <li class="list-group-item py-0 op-search-menu-category">
                 {#  Each div has a top-level catgory  #}
                 {% if div.start_expanded %}
-                    <a href="#{{ which }}-submenu-{{ div.table_name }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle py-2" data-cat="{{ div.table_name }}">
+                    <a href="#{{ which }}-submenu-{{ div.table_name }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle py-2 op-submenu-category" data-cat="{{ div.table_name }}">
                 {% else %}
-                    <a href="#{{ which }}-submenu-{{ div.table_name }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle collapsed py-2" data-cat="{{ div.table_name }}">
+                    <a href="#{{ which }}-submenu-{{ div.table_name }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle collapsed py-2 op-submenu-category" data-cat="{{ div.table_name }}">
                 {% endif %}
                     <span class="title">{{ div.label }}</span>
                 </a>
@@ -30,7 +30,7 @@
                             {#  this div has sub_headings, level-3 menu sections... start sub_heading loop  #}
                             {% for sub_head,params in info.data.items %}
                                 <li class="list-group-item py-0 pl-0">
-                                    <a href="#{{ which }}-submenu-{{ div.table_name|slugify }}-{{ sub_head|slugify }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle collapsed" data-cat="{{ div.table_name|slugify }}-{{ sub_head|slugify }}">
+                                    <a href="#{{ which }}-submenu-{{ div.table_name|slugify }}-{{ sub_head|slugify }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle collapsed op-submenu-category" data-cat="{{ div.table_name|slugify }}-{{ sub_head|slugify }}">
                                         <span class="menu-text title">{{ sub_head }}</span>
                                     </a>
                                     <ul class="list-group list-group-flush submenu collapse" id="{{ which }}-submenu-{{ div.table_name|slugify }}-{{ sub_head|slugify }}">

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -703,14 +703,13 @@ button.op-mini-thumbnail-zoom {
     right: 1.25em;
 }
 
-/* Make sure the a tags for categories take up full width in select metadata menu */
-.op-search-menu-category > a {
-    display: flex;
+/* Make sure the a tags for categories take up full width in select metadata
+and search sidebar menu */
+a[href^="#selector-submenu-search"], a[href^="#selector-submenu-obs"], 
+a[href^="#search-submenu-obs"] {
+    display: block;
     margin-top: 0 !important;
     margin-bottom: 0 !important;
-    flex: 0 0 100%;
-    /* Vertically align arrow icon with the category text */
-    align-items: center;
 }
 
 /* Make white space (padding) in metadata selector modal responsive */
@@ -1543,10 +1542,13 @@ panel are properly separated */
 }
 
 .op-search-menu a.op-search-param {
-    margin-top: 5px;
-    margin-bottom: 12px;
+    /* margin-top: 5px;
+    margin-bottom: 12px; */
+    margin-top: 1px;
+    margin-bottom: 2px;
     font-weight: 70;
     color: initial;
+    display: block;
 }
 
 .op-search-menu a.op-search-param:hover {
@@ -1555,6 +1557,11 @@ panel are properly separated */
 
 .op-search-menu .list-group li:nth-child(1) {
     border-top: 0 none;
+}
+
+/* Make sure full width of white space in search sidebar is clickable */
+.op-search-menu .list-group-item {
+    padding-right: 0;
 }
 
 /* Reduce left space in each widget (from 50px to 10px) */

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -705,7 +705,7 @@ button.op-mini-thumbnail-zoom {
 
 /* Make sure the a tags for categories take up full width in select metadata
 and search sidebar menu */
-a[href^="#selector-submenu-search"], a[href^="#selector-submenu-obs"], 
+a[href^="#selector-submenu-search"], a[href^="#selector-submenu-obs"],
 a[href^="#search-submenu-obs"] {
     display: block;
     margin-top: 0 !important;
@@ -1542,12 +1542,11 @@ panel are properly separated */
 }
 
 .op-search-menu a.op-search-param {
-    /* margin-top: 5px;
-    margin-bottom: 12px; */
     margin-top: 1px;
     margin-bottom: 2px;
     font-weight: 70;
     color: initial;
+    /* Make sure each menu option takes up full width */
     display: block;
 }
 

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -703,6 +703,16 @@ button.op-mini-thumbnail-zoom {
     right: 1.25em;
 }
 
+/* Make sure the a tags for categories take up full width in select metadata menu */
+.op-search-menu-category > a {
+    display: flex;
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+    flex: 0 0 100%;
+    /* Vertically align arrow icon with the category text */
+    align-items: center;
+}
+
 /* Make white space (padding) in metadata selector modal responsive */
 .op-all-metadata-column-header, .op-selected-metadata-column-header {
     padding-left: calc(1.5% + 4px);

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -1541,8 +1541,10 @@ panel are properly separated */
 }
 
 .op-search-menu a.op-search-param {
+    /* Note: margin top and bottom need to be the same so that each search term
+    is vertically centered. */
     margin-top: 1px;
-    margin-bottom: 2px;
+    margin-bottom: 1px;
     font-weight: 70;
     color: initial;
     /* Make sure each menu option takes up full width */

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -711,6 +711,15 @@ and search sidebar menu */
     margin-bottom: 0 !important;
 }
 
+/* Shift the whole search term list up to reduce the spacing between the category
+name and search term in search sidebar and select metadata menu. Need to set both
+margin-top and margin-bottom to avoid the animation glitch when a category is
+collapsing. */
+.op-submenu-item-list {
+    margin-top: -0.35rem;
+    margin-bottom: 0.35rem;
+}
+
 /* Make white space (padding) in metadata selector modal responsive */
 .op-all-metadata-column-header, .op-selected-metadata-column-header {
     padding-left: calc(1.5% + 4px);

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -703,6 +703,25 @@ button.op-mini-thumbnail-zoom {
     right: 1.25em;
 }
 
+/* Make sure general constraints search title text is vertically aligned with
+.op-menu-text */
+.op-general-search-category {
+    display: flex;
+    align-items: center;
+}
+
+/* Make sure genreal constraints search category anchor tag takes the full width
+when spinner is not there. */
+.op-general-search-category .op-submenu-category {
+    flex: 1 0 auto;
+}
+
+/* Make sure .op-menu text spinner stays next to general constraints search title
+when it's spinning. */
+.op-general-search-category .op-menu-text {
+    flex: 100 0 auto;
+}
+
 /* Make sure the a tags for categories take up full width in select metadata
 and search sidebar menu */
 .op-submenu-category {

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -108,6 +108,9 @@ body.modal-open .navbar {
 
 #search .op-search-param {
     font-size: 90%;
+    margin-top: 1.5px;
+    margin-bottom: 1.5px;
+    display: flex;
 }
 
 #browse, #cart, #detail {
@@ -775,6 +778,11 @@ collapsing. */
 narrow */
 .op-all-metadata-column .list-group-item {
     padding-right: 0;
+}
+
+/* Make the first category name closer to the border line above it. */
+.op-all-metadata-column .op-general-search-category .op-submenu-category {
+    padding-top: 0 !important;
 }
 
 .op-selected-metadata-column ul {
@@ -1569,10 +1577,6 @@ panel are properly separated */
 }
 
 .op-search-menu a.op-search-param {
-    /* Note: margin top and bottom need to be the same so that each search term
-    is vertically centered. */
-    margin-top: 1px;
-    margin-bottom: 1px;
     font-weight: 70;
     color: initial;
     /* Make sure each menu option takes up full width */

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -705,8 +705,7 @@ button.op-mini-thumbnail-zoom {
 
 /* Make sure the a tags for categories take up full width in select metadata
 and search sidebar menu */
-a[href^="#selector-submenu-search"], a[href^="#selector-submenu-obs"],
-a[href^="#search-submenu-obs"] {
+.op-submenu-category {
     display: block;
     margin-top: 0 !important;
     margin-bottom: 0 !important;

--- a/opus/application/static_media/js/menu.js
+++ b/opus/application/static_media/js/menu.js
@@ -90,15 +90,11 @@ var o_menu = {
 
     markMenuItem: function(selector, selected) {
         if (selected == undefined || selected == "select") {
-            // Use this line if we want to have the full width of menu options highlighted.
-            // $(selector).css({"background": "gainsboro"});
             $(selector).children().css({"background": "gainsboro"});
             // We use find() here instead of just adding to the selector because
             // selector might be a string or it might be an actual DOM object
             $(selector).find(".op-search-param-checkmark").css({'opacity': 1});
         } else {
-            // Use this line if we want to remove the full width highlight of menu options.
-            // $(selector).css({"background": "initial"});
             $(selector).children().css({"background": "initial"});
             $(selector).find(".op-search-param-checkmark").css({'opacity': 0});
         }

--- a/opus/application/static_media/js/menu.js
+++ b/opus/application/static_media/js/menu.js
@@ -90,12 +90,16 @@ var o_menu = {
 
     markMenuItem: function(selector, selected) {
         if (selected == undefined || selected == "select") {
-            $(selector).css({"background": "gainsboro"});
+            // Use this line if we want to have the full width of menu options highlighted.
+            // $(selector).css({"background": "gainsboro"});
+            $(selector).children().css({"background": "gainsboro"});
             // We use find() here instead of just adding to the selector because
             // selector might be a string or it might be an actual DOM object
             $(selector).find(".op-search-param-checkmark").css({'opacity': 1});
         } else {
-            $(selector).css({"background": "initial"});
+            // Use this line if we want to remove the full width highlight of menu options.
+            // $(selector).css({"background": "initial"});
+            $(selector).children().css({"background": "initial"});
             $(selector).find(".op-search-param-checkmark").css({'opacity': 0});
         }
     },

--- a/opus/application/static_media/js/mutationObserver.js
+++ b/opus/application/static_media/js/mutationObserver.js
@@ -160,7 +160,7 @@ var o_mutationObserver = {
             let lastMutationIdx = mutationsList.length - 1;
             mutationsList.forEach((mutation, idx) => {
                 if (idx === lastMutationIdx) {
-                    if (mutation.target.classList.value.match(/submenu.collapse/)) {
+                    if (mutation.target.classList.value.match(/submenu.*collapse/)) {
                         // If a collapse/expand happened (attribute changes),
                         // we only update ps at the last mutation when the animation
                         // finishes and class/style are finalized.
@@ -187,7 +187,7 @@ var o_mutationObserver = {
         });
 
         let selectedMetadataObserver = new MutationObserver(function(mutationsList) {
-            // If sortable metadata selections is sorting, we don't want to set 
+            // If sortable metadata selections is sorting, we don't want to set
             // the scrollbar position.
             if (o_selectMetadata.isSortingHappening) {
                 return;


### PR DESCRIPTION
- Fixes #729 
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - Database used: opus3_test_200107
  - All Django tests pass: Y
- Were any JavaScript or CSS files modified? Y
  - JSHINT run on all affected files: Y (menu.js)
  - Tested on Chrome, Firefox, Safari, and iOS: Y
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:
- Make the whitespace to right of categories and menu options clickable in search sidebar menu and select metadata menu.
