### PR TITLE
Prevent mini-thumbnails from disappearing when the width of the screen shrinks

### DIFF
--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -623,7 +623,7 @@ th.sticky-header {
 
 .op-mini-thumbnail img {
     transition: transform .1s;
-    width: 68%;
+    height: 21px;
 }
 
 /* zoom the mini-thumbnail on hover */


### PR DESCRIPTION
- Fixes #960 
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - Database used: opus3_test_200107
  - All Django tests pass: NA
- Were any JavaScript or CSS files modified? Y
  - JSHINT run on all affected files: NA
  - Tested on Chrome, Firefox, Safari, and iOS: Y
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable):NA

Description of changes:
 - Set the height to a specific value instead of a percentage.  This takes care of both the disappearing image and the height being diff sizes when an image is taller.

Known problems:
 - none