### PR TITLE
Update the sortable handler to only allow drag from the card-title.

### DIFF
--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -307,6 +307,10 @@ ul.op-search-menu {
     text-decoration: none;
 }
 
+.widget .card-header:hover {
+    cursor: move;
+}
+
 /* Rotate the chevron on a widget header to indicate its open/closed status */
 .widget .card-header .icon-action {
     transition: .3s;

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -308,7 +308,7 @@ ul.op-search-menu {
 }
 
 .widget .card-header:hover {
-    cursor: move;
+    cursor: grab;
 }
 
 /* Rotate the chevron on a widget header to indicate its open/closed status */

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -50,7 +50,7 @@ var o_widgets = {
     addWidgetBehaviors: function() {
         $("#op-search-widgets").sortable({
             items: "> li",
-            cursor: "move",
+            cursor: "grab",
             handle: ".card-title",
             // we need the clone so that widgets in url gets changed only when sorting is stopped
             // Note: this will make radio buttons deselected when a widget with radio buttons is dragged.
@@ -61,6 +61,9 @@ var o_widgets = {
             opacity: 0.8,
             tolerance: "pointer",
             stop: function(event, ui) {
+                // this is a workaround for safari - set it back to what it was beforehand
+                $(event.target).css("cursor", "default");
+                
                 // Restore radio button checked status.
                 for (const input of $(ui.item).find("input[type='radio']")) {
                     if ($(input).attr("data-checked") === "true") {
@@ -71,6 +74,9 @@ var o_widgets = {
                 o_widgets.widgetDrop(this);
             },
             start: function(event, ui) {
+                // this is a workaround for safari
+                $(event.target).css('cursor', 'grab');
+
                 o_widgets.getMaxScrollTopVal(event.target);
             },
             sort: function(event, ui) {

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -51,6 +51,7 @@ var o_widgets = {
         $("#op-search-widgets").sortable({
             items: "> li",
             cursor: "move",
+            handle: ".card-title",
             // we need the clone so that widgets in url gets changed only when sorting is stopped
             // Note: this will make radio buttons deselected when a widget with radio buttons is dragged.
             // We have to restore radio button checked status in stop event handler.


### PR DESCRIPTION
- Fixes #802 
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - Database used: opus3_test_200107
  - All Django tests pass: NA
- Were any JavaScript or CSS files modified? Y
  - JSHINT run on all affected files: Y
  - Tested on Chrome, Firefox, Safari, and iOS: Y
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:
 - added 'handle' parameter to point to the title DOM element

Known problems:
 -N/A