### PR TITLE
Fix nav bar colors (721)

### DIFF
--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -54,6 +54,16 @@ even when the browser size is narrow. */
     padding-right: 0.5rem;
 }
 
+/* Override style.css so that the navbar buttons are always dark when the mouse
+   is away, and always light when the mouse is hovering. This makes them
+   consistent with the other nav items which go from dark grey to light grey. */
+#op-main-nav .navbar-nav .nav-link.active {
+    color: #2f353a;
+}
+#op-main-nav .navbar-nav .nav-link.active:hover {
+    color: #fff;
+}
+
 @media (max-width: 992px) {
     #op-main-nav.navbar .navbar-brand {
         float: none;

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -63,11 +63,11 @@ even when the browser size is narrow. */
 #op-main-nav .navbar-nav .nav-link.show,
 #op-main-nav .navbar-nav .show>.nav-link
 {
-    color: #2f353a;
+    color: var(--dark); /* From style.css */
 }
 #op-main-nav .navbar-nav .nav-link.active:hover,
 #op-main-nav .navbar-nav .nav-link.open:hover {
-    color: #fff;
+    color: var(--white); /* From style.css */
 }
 
 /* Remove annoying dotted border in Firefox */

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -57,11 +57,22 @@ even when the browser size is narrow. */
 /* Override style.css so that the navbar buttons are always dark when the mouse
    is away, and always light when the mouse is hovering. This makes them
    consistent with the other nav items which go from dark grey to light grey. */
-#op-main-nav .navbar-nav .nav-link.active {
+#op-main-nav .navbar-nav .nav-link.active,
+#op-main-nav .navbar-nav .nav-link.open,
+#op-main-nav .navbar-nav .active>.nav-link,
+#op-main-nav .navbar-nav .nav-link.show,
+#op-main-nav .navbar-nav .show>.nav-link
+{
     color: #2f353a;
 }
-#op-main-nav .navbar-nav .nav-link.active:hover {
+#op-main-nav .navbar-nav .nav-link.active:hover,
+#op-main-nav .navbar-nav .nav-link.open:hover {
     color: #fff;
+}
+
+/* Remove annoying dotted border in Firefox */
+#op-main-nav .navbar-nav .nav-link {
+    outline: none; !important
 }
 
 @media (max-width: 992px) {


### PR DESCRIPTION
- Fixes #721
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - Database used: N/A
  - All Django tests pass: NA
- Were any JavaScript or CSS files modified? Y
  - JSHINT run on all affected files: N/A
  - Tested on Chrome, Firefox, Safari, and iOS: Y
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): N/A

Description of changes:

Make main nav bar tabs always dark when mouse not hovering and always light when mouse is hovering.

Known problems:

Under iOS, it appears the mouse is always "hovering", so the buttons are always white. I don't think this is a big deal.
