### PR TITLE
Make welcome splash dialog responsive. Also make help menu responsive.

### DIFF
--- a/opus/application/apps/help/templates/help/splash.html
+++ b/opus/application/apps/help/templates/help/splash.html
@@ -7,12 +7,13 @@
         </td>
     </tr>
 </table>
-<br/>
-<p>Whether you're a new or experienced user, we strongly recommend taking a
-    few minutes to read the
-    <a href="#" class="op-open-getting-started"><b>Getting Started</b></a>
-    guide available under the <b>Help</b> menu.</p>
-<p>Only have time for a brief update? Read the <b>What's new in OPUS3</b>
-    section in the <a href="#" class="op-open-faq"><b>FAQ</b></a>.</p>
-<p>We want to hear what you think of OPUS3. Please send us comments, questions,
-    or suggestions by clicking on the tab shown at the right.</p>
+<span class="op-splash-text">
+    <p>Whether you're a new or experienced user, we strongly recommend taking a
+        few minutes to read the
+        <a href="#" class="op-open-getting-started"><b>Getting Started</b></a>
+        guide available under the <b>Help</b> menu.</p>
+    <p>Only have time for a brief update? Read the <b>What's new in OPUS3</b>
+        section in the <a href="#" class="op-open-faq"><b>FAQ</b></a>.</p>
+    <p>We want to hear what you think of OPUS3. Please send us comments, questions,
+        or suggestions by clicking on the tab shown at the right.</p>
+</span>

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -125,8 +125,17 @@ appears & disappears. */
 
 /* Add padding to (?)help when main nav has the hamburger */
 #op-help-menu {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+}
+
+@media (max-height: 490px) {
+    #op-help a {
+        padding-top: 2px;
+        padding-bottom: 2px;
+        padding-left: 10px;
+        padding-right: 10px;
+    }
 }
 
 #op-tab img.newGIF {
@@ -2082,6 +2091,26 @@ footer {
 }
 
 /* End of API Guide */
+
+/* Styling for the Splash welcome message */
+
+#op-new-user-msg .modal-body {
+    padding: 10px;
+}
+
+#op-new-user-msg p:first-child {
+    margin-top: 10px;
+}
+
+#op-new-user-msg p {
+    margin-bottom: 12px;
+}
+
+#op-new-user-msg p:last-child {
+    margin-bottom: 0px;
+}
+
+/* End of Splash welcome message */
 
 .op-header-text {
     display: inline-block;

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -717,6 +717,7 @@ var opus = {
             adjustBrowseDialogPSDB();
             displayCartLeftPaneDB();
             opus.checkBrowserSize();
+            opus.hideOrShowSplashText();
             o_widgets.attachStringDropdownToInput();
         });
 
@@ -997,9 +998,18 @@ var opus = {
                     $("#op-new-user-msg").modal("hide");
                     opus.displayHelpPane("faq");
                 });
+                opus.hideOrShowSplashText();
                 $("#op-new-user-msg").modal("show");
             }
         });
+    },
+
+    hideOrShowSplashText: function() {
+        if ($(window).height() < 540) {
+            $(".op-splash-text").hide();
+        } else {
+            $(".op-splash-text").show();
+        }
     },
 
     opusInitialization: function() {


### PR DESCRIPTION
- Fixes #852
- Were any Django, import pipeline, table_schema, or dictionary files modified? Y
  - Database used: opus3_test_200107
  - All Django tests pass: Y
- Were any JavaScript or CSS files modified? Y
  - JSHINT run on all affected files: Y
  - Tested on Chrome, Firefox, Safari, and iOS: Y
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): N/A

Description of changes:

Make welcome dialog text disappear when browser is too short. Made help menu padding shrink when browser is short.

Known problems:

None
