### PR TITLE
Remember nav bar clicks during normalizeinput so we can process them later

### DIFF
--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2493,12 +2493,6 @@ wiggling when mouse over autocomplete menu items */
     margin: 0;
 }
 
-/* Use to disable nav link (for the case that disables browse tab when
-we have an invalid search) */
-.op-disabled-nav-link {
-    pointer-events: none;
-}
-
 /* Styling for the button to delete a set of inputs in a widget */
 .op-remove-inputs {
     margin-left: 10px;

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -94,6 +94,11 @@ var opus = {
     // An object that stores normalize input validation result for each range input.
     rangeInputFieldsValidation: {},
 
+    // Remember nav clicks during normalize input so we can actually process them
+    // later if the inputs are valid.
+    navLinksNormalizeInProgress: false,
+    navLinkRemembered: null,
+
     force_load: true, // set this to true to force load() when selections haven't changed
 
     // searching - ui
@@ -313,11 +318,9 @@ var opus = {
             // Remove spinning effect on browse counts and mark as unknown.
             $("#op-result-count").text("?");
             $("#browse .op-observation-number").html("?");
-            $(".op-browse-tab").addClass("op-disabled-nav-link");
             delete opus.normalizeInputForAllFieldsInProgress[opus.allSlug];
             return;
         } else {
-            $(".op-browse-tab").removeClass("op-disabled-nav-link");
             $("#sidebar").removeClass("search_overlay");
         }
 
@@ -437,6 +440,17 @@ var opus = {
          * bar tabs (views).
          */
 
+        if (opus.navLinksNormalizeInProgress) {
+            opus.navLinkRemembered = tab;
+            return false;
+        }
+
+        opus.navLinkRemembered = null;
+
+        if (!opus.areRangeInputsValid()) {
+            return false;
+        }
+
         // First hide everything and stop any interval timers
         $("#search, #detail, #cart, #browse").hide();
         o_browse.hideMenu();
@@ -488,6 +502,7 @@ var opus = {
                 o_search.activateSearchTab();
         }
 
+        return true;
     },
 
     hideHelpPanel: function() {
@@ -735,12 +750,7 @@ var opus = {
 
             // little hack in case something calls onclick programmatically
             tab = tab ? tab : "search";
-            opus.changeTab(tab);
-        });
-
-        // Make sure browse tab nav link does nothing when it's been disabled.
-        $("#op-main-nav").on("click", ".op-main-site-tabs .nav-item.op-disabled-nav-link a", function() {
-            return false;
+            return opus.changeTab(tab);
         });
 
         $(".op-help-item").on("click", function(e) {

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -339,6 +339,9 @@ var opus = {
             }
         }
         delete opus.normalizeInputForAllFieldsInProgress[opus.allSlug];
+
+        opus.changeTabToRemembered();
+
         // Execute the query and return the result count
         opus.lastResultCountRequestNo++;
         return $.getJSON(`/opus/__api/meta/result_count.json?${o_hash.getHash()}&reqno=${opus.lastResultCountRequestNo}`);
@@ -431,6 +434,16 @@ var opus = {
                 $("#op-last-blog-update-date").attr("title", "");
             }
         });
+    },
+
+    changeTabToRemembered: function() {
+        // If the user had clicked on a nav tab during the normalizeinput
+        // process, go ahead and execute that tab switch now
+        if (opus.navLinkRemembered !== null) {
+            opus.prefs.view = opus.navLinkRemembered;
+            opus.navLinkRemembered = null;
+            opus.triggerNavbarClick();
+        }
     },
 
     changeTab: function(tab) {
@@ -1054,6 +1067,9 @@ var opus = {
             return elementBottom > viewportTop && elementTop < viewportBottom;
         };
 
+        if (opus.isAnyNormalizeInputInProgress()) {
+            opus.navLinkRemembered = opus.prefs.view;
+        }
         opus.triggerNavbarClick();
     },
 

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -96,7 +96,6 @@ var opus = {
 
     // Remember nav clicks during normalize input so we can actually process them
     // later if the inputs are valid.
-    navLinksNormalizeInProgress: false,
     navLinkRemembered: null,
 
     force_load: true, // set this to true to force load() when selections haven't changed
@@ -440,7 +439,7 @@ var opus = {
          * bar tabs (views).
          */
 
-        if (opus.navLinksNormalizeInProgress) {
+        if (opus.isAnyNormalizeInputInProgress()) {
             opus.navLinkRemembered = tab;
             return false;
         }

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -988,10 +988,7 @@ var o_search = {
             $("#sidebar").removeClass("search_overlay");
             delete opus.normalizeInputForAllFieldsInProgress[slug];
 
-            if (opus.navLinkRemembered !== null) {
-                opus.prefs.view = opus.navLinkRemembered;
-                opus.triggerNavbarClick();
-            }
+            opus.changeTabToRemembered();
         });
     },
 

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -114,13 +114,6 @@ var o_search = {
             let slug = o_utils.getSlugOrDataWithoutCounter(inputName);
             let uniqueid = $(this).attr("data-uniqueid");
             let slugWithId = `${slug}_${uniqueid}`;
-            // Disable browse tab nav link when user focuses out and there is a change of value
-            // in range input. The button will be enabled or keep disabled based on the
-            // result of input validation in parseFinalNormalizedInputDataAndUpdateURL.
-            if ((currentValue && currentValue !== o_search.slugRangeInputValidValueFromLastSearch[slugWithId]) ||
-                (!currentValue && o_search.slugRangeInputValidValueFromLastSearch[slugWithId])) {
-                opus.navLinksNormalizeInProgress = true;
-            }
 
             $(this).removeClass("input_currently_focused");
             if ($(this).hasClass("search_input_invalid")) {
@@ -957,7 +950,6 @@ var o_search = {
          * Parse the return data from a normalize input API call. validateRangeInput
          * is called here.
          */
-        opus.navLinksNormalizeInProgress = true;
         $.getJSON(url, function(normalizedInputData) {
             // Make sure data is from the final normalize input call before parsing
             // normalizedInputData
@@ -965,7 +957,6 @@ var o_search = {
                 delete opus.normalizeInputForAllFieldsInProgress[slug];
                 return;
             }
-            opus.navLinksNormalizeInProgress = false;
 
             // check each range input, if it's not valid, change its background to red
             // and also remove spinner.

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -119,7 +119,7 @@ var o_search = {
             // result of input validation in parseFinalNormalizedInputDataAndUpdateURL.
             if ((currentValue && currentValue !== o_search.slugRangeInputValidValueFromLastSearch[slugWithId]) ||
                 (!currentValue && o_search.slugRangeInputValidValueFromLastSearch[slugWithId])) {
-                $(".op-browse-tab").addClass("op-disabled-nav-link");
+                opus.navLinksNormalizeInProgress = true;
             }
 
             $(this).removeClass("input_currently_focused");
@@ -957,6 +957,7 @@ var o_search = {
          * Parse the return data from a normalize input API call. validateRangeInput
          * is called here.
          */
+        opus.navLinksNormalizeInProgress = true;
         $.getJSON(url, function(normalizedInputData) {
             // Make sure data is from the final normalize input call before parsing
             // normalizedInputData
@@ -964,14 +965,16 @@ var o_search = {
                 delete opus.normalizeInputForAllFieldsInProgress[slug];
                 return;
             }
+            opus.navLinksNormalizeInProgress = false;
+
             // check each range input, if it's not valid, change its background to red
             // and also remove spinner.
             o_search.validateRangeInput(normalizedInputData, true, slug, unit);
 
             // When search is invalid, we disabled browse tab in nav link.
             if (!opus.areRangeInputsValid()) {
-                $(".op-browse-tab").addClass("op-disabled-nav-link");
                 delete opus.normalizeInputForAllFieldsInProgress[slug];
+                opus.navLinkRemembered = null;
                 return;
             }
 
@@ -991,9 +994,13 @@ var o_search = {
                 }
             });
 
-            $(".op-browse-tab").removeClass("op-disabled-nav-link");
             $("#sidebar").removeClass("search_overlay");
             delete opus.normalizeInputForAllFieldsInProgress[slug];
+
+            if (opus.navLinkRemembered !== null) {
+                opus.prefs.view = opus.navLinkRemembered;
+                opus.triggerNavbarClick();
+            }
         });
     },
 

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -616,9 +616,6 @@ var o_widgets = {
                                 o_search.getHinting(eachSlug);
                             });
                         }
-                        $(".op-browse-tab").removeClass("op-disabled-nav-link");
-                    } else {
-                        $(".op-browse-tab").addClass("op-disabled-nav-link");
                     }
 
                     if (opus.areRangeInputsValid()) {
@@ -827,9 +824,6 @@ var o_widgets = {
                         o_search.getHinting(eachSlug);
                     });
                 }
-                $(".op-browse-tab").removeClass("op-disabled-nav-link");
-            } else {
-                $(".op-browse-tab").addClass("op-disabled-nav-link");
             }
 
             // If the closing widget has empty values, don't perform a search.


### PR DESCRIPTION
- Fixes #853 
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - Database used: N/A
  - All Django tests pass: NA
- Were any JavaScript or CSS files modified? Y
  - JSHINT run on all affected files: Y
  - Tested on Chrome, Firefox, Safari, and iOS: Y
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): Y

Description of changes:

Previously we simply turned off clicks for the browse tab when calling normalizeinput, since if the inputs came back invalid we didn't want to switch tabs. Now we remember which tab the user clicked on, and when normalizeinput is done we jump to that tab, if any. Note we now do this for all tabs, not just browse, so that when the user has an illegal input we don't let them leave the search tab.

Known problems:

None.
