### PR TITLE
Tooltip support for mobile devices. Fixes #796.

### DIFF
--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2611,6 +2611,26 @@ at the right of -- OR -- label. */
     padding-right: 3px;
 }
 
+/* Tooltips */
+
+[title] {
+    cursor: default;
+}
+
+/* This is for touch screens */
+.op-tooltip-text {
+    position: fixed;
+    top: 80px;
+    left: 10%;
+    right: 10%;
+    border: 2px solid rgba(0, 0, 0, 0.2);
+    background-color: white;
+    box-shadow: 2px 2px 6px;
+    padding: 0.3em;
+    line-height: 17px;
+    z-index: 20000;
+}
+
 /* Style for print - automatic creation of PDF files */
 
 @media print {

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -721,6 +721,16 @@ var opus = {
             o_widgets.attachStringDropdownToInput();
         });
 
+        // Support for tooltips on touch screens
+        $(window).on("touchstart", function () {
+            // The DOM may have changed since the last touch, so remove
+            // the click handler on the remaining tooltip elements and then
+            // add it to all of them. This way we don't end up with duplicate
+            // handlers.
+            $("i[title]").off("click", opus.tooltipClickHandler);
+            $("i[title]").on("click", opus.tooltipClickHandler);
+        });
+
         // Add the navbar clicking behaviors, selecting which tab to view
         $("#op-main-nav").on("click", ".op-main-site-tabs .nav-item", function() {
             if ($(this).hasClass("external-link") || $(this).children().hasClass("op-show-msg")) {
@@ -863,6 +873,19 @@ var opus = {
                     break;
             }
         });
+    },
+
+    tooltipClickHandler: function () {
+        opus.tooltipRemoveHandler();
+        let title = $(this).attr("title");
+        $(this).append(`<span class="op-tooltip-text">${title}</span>`);
+        $(window).on("touchstart", opus.tooltipRemoveHandler);
+        return false;
+    },
+
+    tooltipRemoveHandler: function() {
+        $(".op-tooltip-text").remove();
+        $(window).off("touchstart", opus.tooltipRemoveHandler);
     },
 
     displayHelpPane: function(action) {


### PR DESCRIPTION
- Fixes #796
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - Database used: N/A
  - All Django tests pass: N/A
- Were any JavaScript or CSS files modified? Y
  - JSHINT run on all affected files: Y
  - Tested on Chrome, Firefox, Safari, and iOS: Y (and Android)
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): N/A

Description of changes:

When a touch event happens, a handler is added to each (i) element that has a title. When that (i) is finger-clicked, the tooltip text shows up top-center in the browser window. Any subsequent touch of any kind makes it go away, unless it's another (i) in which case the text is replaced (well first it goes away, then it comes back again). I didn't make the tooltip show up near the (i) that was touched because 1) it was really painful to make that work and 2) this solves all problems about tooltips running off the edge of the screen and having to be intelligently oriented. I made a fairly obvious border so people would see it there.

Known problems:

None.
