### PR TITLE
Issue of preprogrammed ranges disappearing right after a click

### DIFF
--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -113,7 +113,6 @@ var o_search = {
                 && !$(e.target).is("label") && !$(e.target).hasClass("hints")) {
                 e.preventDefault();
             }
-
         });
 
         /*

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -104,10 +104,10 @@ var o_search = {
             }
         });
 
-        // When clicking inside widget body, if it's not input, select, hints, and text,
-        // we will disable the default behavior of mousedown event. This will prevent
-        // input from focusing out when clicking on preprogrammed ranges dropdown, and
-        // also keep the ability to copy text & hints for mults.
+        // When clicking inside a widget body, if the clicked element is not input,
+        // select, hints, and text, we will disable the default behavior of mousedown
+        // event. This will prevent input from focusing out when clicking on preprogrammed
+        // ranges dropdown, and also keep the ability to copy text & hints for mults.
         $("#search").on("mousedown", ".widget .card-body", function(e) {
             if (!$(e.target).is("input") && !$(e.target).is("select")
                 && !$(e.target).is("label") && !$(e.target).hasClass("hints")) {

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -70,6 +70,7 @@ var o_search = {
         });
 
         // Avoid the orange blinking on border color, and also display proper border when input is in focus
+        // $("#search").on("blur", "input.RANGE", function(e) {
         $("#search").on("focus", "input.RANGE", function(e) {
             let inputName = $(this).attr("name");
             let currentValue = $(this).val().trim();
@@ -102,6 +103,18 @@ var o_search = {
                 o_widgets.isKeepingRangesDropdownOpen = true;
                 $(this).dropdown("toggle");
             }
+        });
+
+        // When clicking inside widget body, if it's not input, select, hints, and text,
+        // we will disable the default behavior of mousedown event. This will prevent
+        // input from focusing out when clicking on preprogrammed ranges dropdown, and
+        // also keep the ability to copy text & hints for mults.
+        $("#search").on("mousedown", ".widget .card-body", function(e) {
+            if (!$(e.target).is("input") && !$(e.target).is("select")
+                && !$(e.target).is("label") && !$(e.target).hasClass("hints")) {
+                e.preventDefault();
+            }
+
         });
 
         /*

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -70,7 +70,6 @@ var o_search = {
         });
 
         // Avoid the orange blinking on border color, and also display proper border when input is in focus
-        // $("#search").on("blur", "input.RANGE", function(e) {
         $("#search").on("focus", "input.RANGE", function(e) {
             let inputName = $(this).attr("name");
             let currentValue = $(this).val().trim();

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -655,14 +655,8 @@ var o_widgets = {
             $(".op-preprogrammed-ranges .container").collapse("hide");
         });
 
-        // Prevent dropdown from closing when clicking back on the input with dropdown open
+        // Prevent dropdown from closing when clicking on the focused input again
         $("#search").on("mousedown", "input.op-range-input-min", function(e) {
-            // let preprogrammedRangesDropdown = ($(this)
-            //                                    .next(".op-preprogrammed-ranges")
-            //                                    .find(".op-scrollable-menu"));
-            // if (preprogrammedRangesDropdown.hasClass("show")) {
-            //     o_widgets.isKeepingRangesDropdownOpen = true;
-            // }
             if ($(".op-scrollable-menu").hasClass("show") && $(e.target).is(":focus")) {
                 o_widgets.isKeepingRangesDropdownOpen = true;
             }

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -51,6 +51,7 @@ var o_widgets = {
         $("#op-search-widgets").sortable({
             items: "> li",
             cursor: "grab",
+            // Note: this will cause input to lose focus when clicking on preprogrammed dropdown.
             handle: ".card-title",
             // we need the clone so that widgets in url gets changed only when sorting is stopped
             // Note: this will make radio buttons deselected when a widget with radio buttons is dragged.
@@ -654,8 +655,14 @@ var o_widgets = {
             $(".op-preprogrammed-ranges .container").collapse("hide");
         });
 
-        // Prevent dropdown from closing when clicking on the focused input again
+        // Prevent dropdown from closing when clicking back on the input with dropdown open
         $("#search").on("mousedown", "input.op-range-input-min", function(e) {
+            // let preprogrammedRangesDropdown = ($(this)
+            //                                    .next(".op-preprogrammed-ranges")
+            //                                    .find(".op-scrollable-menu"));
+            // if (preprogrammedRangesDropdown.hasClass("show")) {
+            //     o_widgets.isKeepingRangesDropdownOpen = true;
+            // }
             if ($(".op-scrollable-menu").hasClass("show") && $(e.target).is(":focus")) {
                 o_widgets.isKeepingRangesDropdownOpen = true;
             }


### PR DESCRIPTION
- Were any Django, import pipeline, table_schema, or dictionary files modified? Y
  - Database used: opus3_test_200107
  - All Django tests pass: Y
- Were any JavaScript or CSS files modified? N
  - JSHINT run on all affected files: Y
  - Tested on Chrome, Firefox, Safari, and iOS: Y
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:
- In the mousedown event of widget body, if the clicked element is not input, select tag, text, and hints, we will disable the default behavior of mousedown. This will prevent input from focusing out when clicking on preprogrammed ranges dropdown, and also keep the ability to copy text & hints for mults.

Known problems:
None