### PR TITLE
987 problems with selecting text for mults

### DIFF
--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2644,3 +2644,8 @@ at the right of -- OR -- label. */
         page-break-before: always;
     }
 }
+
+/* Make sure label names in mults have a caret cursor when users mouseover. */
+.choiceLabelName {
+    cursor: text;
+}

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -95,7 +95,8 @@ even when the browser size is narrow. */
 }
 
 /* Make sure the height of top navbar will not change when "Recent Announcement"
-appears & disappears. */
+appears & disappears. Padding-top & bottom need to match ones for .op-user-msg
+so that both "Recent Announcements" and "Message" can be vertically aligned. */
 .op-tab .op-blog-link {
     padding-top: 0;
     padding-bottom: 0;
@@ -109,8 +110,12 @@ appears & disappears. */
     }
 }
 
+/* Padding-top & bottom need to match ones for .op-blog-link so that both
+"Recent Announcements" and "Message" can be vertically aligned. */
 .op-user-msg {
     display: none;
+    padding-top: 0;
+    padding-bottom: 0;
 }
 
 /* display normalized url message */

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2646,6 +2646,6 @@ at the right of -- OR -- label. */
 }
 
 /* Make sure label names in mults have a caret cursor when users mouseover. */
-.choiceLabelName {
+.op-choice-label-name {
     cursor: text;
 }

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -1324,7 +1324,7 @@ var o_widgets = {
                 for (const label of allChoiceLabels) {
                     $(label).contents().filter(function() {
                         return this.nodeType === 3;
-                    }).wrap("<span class='choiceLabelName'></span>");
+                    }).wrap("<span class='op-choice-label-name'></span>");
                 }
             }
 

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -1316,6 +1316,18 @@ var o_widgets = {
                 }
             }
 
+            // Wrap mults label names with span tag, we will style the span tag to have a caret cursor
+            // so that users know that they can select and copy the text.
+            if (widgetInputs.hasClass("multichoice") || widgetInputs.hasClass("singlechoice")) {
+                let choiceClass = widgetInputs.hasClass("multichoice") ? ".multichoice" : ".singlechoice";
+                let allChoiceLabels = $(`#widget__${slug} ul${choiceClass} label`);
+                for (const label of allChoiceLabels) {
+                    $(label).contents().filter(function() {
+                        return this.nodeType === 3;
+                    }).wrap("<span class='choiceLabelName'></span>");
+                }
+            }
+
             opus.widgetsDrawn.unshift(slug);
             o_widgets.customWidgetBehaviors(slug);
             o_widgets.scrollToWidget(widget);


### PR DESCRIPTION
- Fixes #987 
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - Database used: opus3_test_200107
  - All Django tests pass: Y
- Were any JavaScript or CSS files modified? Y
  - JSHINT run on all affected files: Y (widgets.js)
  - Tested on Chrome, Firefox, Safari, and iOS: Y (drag and copy not working in iOS)
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:
-  Add caret cursor to the label text in mults. When caret cursor shows up, we can click and drag to copy text & number from both right or left hand sides in mults.
-  Add the styling to make sure "Recent Announcements" and "Message" are vertically aligned and centered.
 
Known problems:
None