### PR TITLE
Issue of selecting text nodes in mults widgets

### DIFF
--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2289,7 +2289,8 @@ ul.ui-autocomplete a.ui-state-active {
 }
 
 /* Allow users to mouse over and select texts & hints in widgets */
-.op-input ul label, .op-input ul span {
+.op-input ul label, .op-input ul span,
+.op-hints-info, .op-hints-description {
     -ms-user-select: text;
     user-select: text;
     -moz-user-select: text;
@@ -2670,7 +2671,9 @@ at the right of -- OR -- label. */
     }
 }
 
-/* Make sure label names in mults have a caret cursor when users mouseover. */
-.op-choice-label-name {
+/* Make sure label names & hints in wdigets have a caret cursor when users mouseover. */
+.op-choice-label-name,
+.op-hints-description,
+.op-hints-info {
     cursor: text;
 }

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -956,7 +956,7 @@ var o_search = {
             });
             // for mults
             $(".hints").each(function() {
-                $(this).html("<span>?</span>");
+                $(this).html(`<span class="${rangeHintsTextClass}">?</span>`);
             });
 
             if (removeSpinner) {
@@ -1225,10 +1225,11 @@ var o_search = {
               }
             },
             error:function(xhr, ajaxOptions, thrownError) {
+                let hintsTextClass = "op-hints-info";
                 $(`#widget__${slug} .spinner`).fadeOut();
                 // checkbox hints are "?" when wrong values of url is pasted
                 $(".hints").each(function() {
-                    $(this).html("<span>?</span>");
+                    $(this).html(`<span class="${hintsTextClass}">?</span>`);
                 });
             }
         }); // end mults ajax

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -105,12 +105,14 @@ var o_search = {
         });
 
         // When clicking inside a widget body, if the clicked element is not input,
-        // select, hints, and text, we will disable the default behavior of mousedown
+        // select, hints, and text nodes, we will disable the default behavior of mousedown
         // event. This will prevent input from focusing out when clicking on preprogrammed
         // ranges dropdown, and also keep the ability to copy text & hints for mults.
         $("#search").on("mousedown", ".widget .card-body", function(e) {
             if (!$(e.target).is("input") && !$(e.target).is("select")
-                && !$(e.target).is("label") && !$(e.target).hasClass("hints")) {
+                && !$(e.target).is("label") && !$(e.target).hasClass("hints")
+                && !$(e.target).hasClass("op-choice-hints-text")
+                && !$(e.target).hasClass("op-choice-label-name")) {
                 e.preventDefault();
             }
         });
@@ -1166,17 +1168,18 @@ var o_search = {
                 let widget = "widget__" + dataSlug;
                 let mults = multdata.mults;
                 $('#' + widget + ' input').each( function() {
+                    let hintsTextClass = "op-choice-hints-text";
                     let value = $(this).attr("value");
-                    let id = '#hint__' + slug + "_" + value.replace(/ /g,'-').replace(/[^\w\s]/gi, '');  // id of hinting span, defined in widgets.js getWidget
+                    let id = "#hint__" + slug + "_" + value.replace(/ /g, "-").replace(/[^\w\s]/gi, "");  // id of hinting span, defined in widgets.js getWidget
 
                     if (!hideHintsForNonSelectedRadioButtons) {
                         if (mults[value]) {
-                            $(id).html('<span>' + mults[value] + '</span>');
+                            $(id).html(`<span class=${hintsTextClass}>` + mults[value] + "</span>");
                             if ($(id).parent().hasClass("fadey")) {
                                 $(id).parent().removeClass("fadey");
                             }
                         } else {
-                            $(id).html('<span>0</span>');
+                            $(id).html(`<span class=${hintsTextClass}>0</span>`);
                             $(id).parent().addClass("fadey");
                         }
                     } else {
@@ -1184,16 +1187,16 @@ var o_search = {
                         $(id).parent().removeClass("fadey");
                         if (mults[value]) {
                             if ($(this).is(":checked")) {
-                                $(id).html('<span>' + mults[value] + '</span>');
+                                $(id).html(`<span class=${hintsTextClass}>` + mults[value] + "</span>");
                             } else {
-                                $(id).html('<span>--</span>');
+                                $(id).html(`<span class=${hintsTextClass}>--</span>`);
                             }
                         } else {
                             if ($(this).is(":checked")) {
-                                $(id).html('<span>0</span>');
+                                $(id).html(`<span class=${hintsTextClass}>0</span>`);
 
                             } else {
-                                $(id).html('<span>--</span>');
+                                $(id).html(`<span class=${hintsTextClass}>--</span>`);
                             }
                         }
                     }

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -110,11 +110,11 @@ var o_search = {
         // ranges dropdown, and also keep the ability to copy text & hints in mults
         // and hints in ranges widgets.
         $("#search").on("mousedown", ".widget .card-body", function(e) {
-            if (!$(e.target).is("input") && !$(e.target).is("select")
-                && !$(e.target).is("label") && !$(e.target).hasClass("hints")
-                && !$(e.target).hasClass("op-hints-info")
-                && !$(e.target).hasClass("op-hints-description")
-                && !$(e.target).hasClass("op-choice-label-name")) {
+            if (!$(e.target).is("input") && !$(e.target).is("select") &&
+                !$(e.target).is("label") && !$(e.target).hasClass("hints") &&
+                !$(e.target).hasClass("op-hints-info") &&
+                !$(e.target).hasClass("op-hints-description") &&
+                !$(e.target).hasClass("op-choice-label-name")) {
                 e.preventDefault();
             }
         });

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -107,11 +107,13 @@ var o_search = {
         // When clicking inside a widget body, if the clicked element is not input,
         // select, hints, and text nodes, we will disable the default behavior of mousedown
         // event. This will prevent input from focusing out when clicking on preprogrammed
-        // ranges dropdown, and also keep the ability to copy text & hints for mults.
+        // ranges dropdown, and also keep the ability to copy text & hints in mults
+        // and hints in ranges widgets.
         $("#search").on("mousedown", ".widget .card-body", function(e) {
             if (!$(e.target).is("input") && !$(e.target).is("select")
                 && !$(e.target).is("label") && !$(e.target).hasClass("hints")
-                && !$(e.target).hasClass("op-choice-hints-text")
+                && !$(e.target).hasClass("op-hints-info")
+                && !$(e.target).hasClass("op-hints-description")
                 && !$(e.target).hasClass("op-choice-label-name")) {
                 e.preventDefault();
             }
@@ -940,11 +942,16 @@ var o_search = {
             $("#op-result-count").text("?");
             // set hinting info to ? when any range input has invalid value
             // for range
+            let rangeHintsDescription = "op-hints-description";
+            let rangeHintsTextClass = "op-hints-info";
             $(".op-range-hints").each(function() {
                 if ($(this).children().length > 0) {
-                    $(this).html(`<span>Min:&nbsp;<span class="op-hints-info">?</span></span>
-                                  <span>Max:&nbsp;<span class="op-hints-info">?</span></span>
-                                  <span>Nulls:&nbsp;<span class="op-hints-info">?</span></span>`);
+                    $(this).html(`<span><span class="${rangeHintsDescription}">Min:&nbsp;</span>
+                                  <span class="${rangeHintsTextClass}">?</span></span>
+                                  <span><span class="${rangeHintsDescription}">Max:&nbsp;</span>
+                                  <span class="${rangeHintsTextClass}">?</span></span>
+                                  <span><span class="${rangeHintsDescription}">Nulls:&nbsp;</span>
+                                  <span class="${rangeHintsTextClass}">?</span></span>`);
                 }
             });
             // for mults
@@ -1122,14 +1129,19 @@ var o_search = {
         $.ajax({url: url,
             dataType:"json",
             success: function(multdata) {
+                let rangeHintsDescription = "op-hints-description";
+                let rangeHintsTextClass = "op-hints-info";
                 $(`#widget__${slug} .spinner`).fadeOut();
 
-                if (multdata.reqno< o_search.slugEndpointsReqno[slug]) {
+                if (multdata.reqno < o_search.slugEndpointsReqno[slug]) {
                     return;
                 }
-                $('#hint__' + slug).html(`<span>Min:&nbsp;<span class="op-hints-info">${multdata.min}</span></span>
-                                          <span>Max:&nbsp;<span class="op-hints-info">${multdata.max}</span></span>
-                                          <span>Nulls:&nbsp;<span class="op-hints-info">${multdata.nulls}</span></span>`);
+                $("#hint__" + slug).html(`<span><span class="${rangeHintsDescription}">Min:&nbsp;</span>
+                                          <span class="${rangeHintsTextClass}">${multdata.min}</span></span>
+                                          <span><span class="${rangeHintsDescription}">Max:&nbsp;</span>
+                                          <span class="${rangeHintsTextClass}">${multdata.max}</span></span>
+                                          <span><span class="${rangeHintsDescription}">Nulls:&nbsp;</span>
+                                          <span class="${rangeHintsTextClass}">${multdata.nulls}</span></span>`);
             },
             statusCode: {
                 404: function() {
@@ -1137,11 +1149,16 @@ var o_search = {
                 }
             },
             error:function(xhr, ajaxOptions, thrownError) {
+                let rangeHintsDescription = "op-hints-description";
+                let rangeHintsTextClass = "op-hints-info";
                 $(`#widget__${slug} .spinner`).fadeOut();
                 // range input hints are "?" when wrong values of url is pasted
-                $(`#hint__${slug}`).html(`<span>Min:&nbsp;<span class="op-hints-info">?</span></span>
-                                          <span>Max:&nbsp;<span class="op-hints-info">?</span></span>
-                                          <span>Nulls:&nbsp;<span class="op-hints-info">?</span></span>`);
+                $(`#hint__${slug}`).html(`<span><span class="${rangeHintsDescription}">Min:&nbsp;</span>
+                                          <span class="${rangeHintsTextClass}">?</span></span>
+                                          <span><span class="${rangeHintsDescription}">Max:&nbsp;</span>
+                                          <span class="${rangeHintsTextClass}">?</span></span>
+                                          <span><span class="${rangeHintsDescription}">Nulls:&nbsp;</span>
+                                          <span class="${rangeHintsTextClass}">?</span></span>`);
             }
         }); // end mults ajax
     },
@@ -1168,18 +1185,18 @@ var o_search = {
                 let widget = "widget__" + dataSlug;
                 let mults = multdata.mults;
                 $("#" + widget + " input").each( function() {
-                    let hintsTextClass = "op-choice-hints-text";
+                    let hintsTextClass = "op-hints-info";
                     let value = $(this).attr("value");
                     let id = "#hint__" + slug + "_" + value.replace(/ /g, "-").replace(/[^\w\s]/gi, "");  // id of hinting span, defined in widgets.js getWidget
 
                     if (!hideHintsForNonSelectedRadioButtons) {
                         if (mults[value]) {
-                            $(id).html(`<span class=${hintsTextClass}>` + mults[value] + "</span>");
+                            $(id).html(`<span class="${hintsTextClass}">` + mults[value] + "</span>");
                             if ($(id).parent().hasClass("fadey")) {
                                 $(id).parent().removeClass("fadey");
                             }
                         } else {
-                            $(id).html(`<span class=${hintsTextClass}>0</span>`);
+                            $(id).html(`<span class="${hintsTextClass}">0</span>`);
                             $(id).parent().addClass("fadey");
                         }
                     } else {
@@ -1187,16 +1204,16 @@ var o_search = {
                         $(id).parent().removeClass("fadey");
                         if (mults[value]) {
                             if ($(this).is(":checked")) {
-                                $(id).html(`<span class=${hintsTextClass}>` + mults[value] + "</span>");
+                                $(id).html(`<span class="${hintsTextClass}">` + mults[value] + "</span>");
                             } else {
-                                $(id).html(`<span class=${hintsTextClass}>--</span>`);
+                                $(id).html(`<span class="${hintsTextClass}">--</span>`);
                             }
                         } else {
                             if ($(this).is(":checked")) {
-                                $(id).html(`<span class=${hintsTextClass}>0</span>`);
+                                $(id).html(`<span class="${hintsTextClass}">0</span>`);
 
                             } else {
-                                $(id).html(`<span class=${hintsTextClass}>--</span>`);
+                                $(id).html(`<span class="${hintsTextClass}">--</span>`);
                             }
                         }
                     }

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -1163,11 +1163,11 @@ var o_search = {
                 }
 
                 let dataSlug = multdata.field_id;
-                $("#widget__" + dataSlug + " .spinner").fadeOut('');
+                $("#widget__" + dataSlug + " .spinner").fadeOut("");
 
                 let widget = "widget__" + dataSlug;
                 let mults = multdata.mults;
-                $('#' + widget + ' input').each( function() {
+                $("#" + widget + " input").each( function() {
                     let hintsTextClass = "op-choice-hints-text";
                     let value = $(this).attr("value");
                     let id = "#hint__" + slug + "_" + value.replace(/ /g, "-").replace(/[^\w\s]/gi, "");  // id of hinting span, defined in widgets.js getWidget


### PR DESCRIPTION
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - Database used: opus3_test_200107
  - All Django tests pass: Y
- Were any JavaScript or CSS files modified? Y
  - JSHINT run on all affected files: Y
  - Tested on Chrome, Firefox, Safari, and iOS: Y
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:
Make sure we can click and drag to copy input and hints text nodes in mults widgets. Default mousedown behavior will not be disabled when clicked targets are input and hints text nodes.

Known problems:
None