### PR TITLE
Add STIS Proposed Aperture field (Fixes #984)

### DIFF
--- a/opus/application/apps/search/models.py
+++ b/opus/application/apps/search/models.py
@@ -1593,6 +1593,7 @@ class ObsMissionHubble(models.Model):
     filter_name = models.CharField(max_length=23)
     filter_type = models.CharField(max_length=3)
     aperture_type = models.CharField(max_length=22)
+    proposed_aperture_type = models.CharField(max_length=18)
     exposure_type = models.CharField(max_length=20)
     gain_mode_id = models.CharField(max_length=5)
     instrument_mode_id = models.CharField(max_length=10)

--- a/opus/application/apps/search/models.py
+++ b/opus/application/apps/search/models.py
@@ -1111,6 +1111,19 @@ class MultObsMissionHubblePc1Flag(models.Model):
         db_table = 'mult_obs_mission_hubble_pc1_flag'
 
 
+class MultObsMissionHubbleProposedApertureType(models.Model):
+    id = models.PositiveIntegerField(primary_key=True)
+    value = models.CharField(max_length=100, blank=True, null=True)
+    label = models.CharField(max_length=60)
+    disp_order = models.IntegerField()
+    display = models.CharField(max_length=1)
+    timestamp = models.DateTimeField(blank=True, null=True)
+
+    class Meta:
+        managed = False
+        db_table = 'mult_obs_mission_hubble_proposed_aperture_type'
+
+
 class MultObsMissionHubbleTargetedDetectorId(models.Model):
     id = models.PositiveIntegerField(primary_key=True)
     value = models.CharField(max_length=100, blank=True, null=True)
@@ -1594,6 +1607,7 @@ class ObsMissionHubble(models.Model):
     mult_obs_mission_hubble_filter_name = models.ForeignKey(MultObsMissionHubbleFilterName, models.DO_NOTHING, db_column='mult_obs_mission_hubble_filter_name')
     mult_obs_mission_hubble_filter_type = models.ForeignKey(MultObsMissionHubbleFilterType, models.DO_NOTHING, db_column='mult_obs_mission_hubble_filter_type')
     mult_obs_mission_hubble_aperture_type = models.ForeignKey(MultObsMissionHubbleApertureType, models.DO_NOTHING, db_column='mult_obs_mission_hubble_aperture_type')
+    mult_obs_mission_hubble_proposed_aperture_type = models.ForeignKey(MultObsMissionHubbleProposedApertureType, models.DO_NOTHING, db_column='mult_obs_mission_hubble_proposed_aperture_type')
     mult_obs_mission_hubble_exposure_type = models.ForeignKey(MultObsMissionHubbleExposureType, models.DO_NOTHING, db_column='mult_obs_mission_hubble_exposure_type')
     mult_obs_mission_hubble_gain_mode = models.ForeignKey(MultObsMissionHubbleGainModeId, models.DO_NOTHING)
     mult_obs_mission_hubble_instrument_mode = models.ForeignKey(MultObsMissionHubbleInstrumentModeId, models.DO_NOTHING)

--- a/opus/application/test_api/responses/api_metadata2_hst_09975_acs_j8n410lbq_cats_pds_hubble_constraints_csv.csv
+++ b/opus/application/test_api/responses/api_metadata2_hst_09975_acs_j8n410lbq_cats_pds_hubble_constraints_csv.csv
@@ -2,5 +2,5 @@ PDS Constraints
 Volume ID,Data Set ID,Product ID,Product Creation Time,Primary File Spec,OPUS ID,Note
 HSTJ0_9975,HST-M-ACS-5-ID9975-V1.0,J8N410LBQ,2013-06-17T00:00:00.000,HSTJ0_9975/DATA/VISIT_10/J8N410LBQ.LBL,hst-09975-acs-j8n410lbq,
 Hubble Mission Constraints
-Detector [Hubble],Filter Name [Hubble],Filter Type [Hubble],STIS Optical Element [Hubble],Aperture Type [Hubble],HST Proposal ID [Hubble],PI Name [Hubble],STScI File Name [Hubble],HST Target Name [Hubble],WFPC2 Targeted Detector [Hubble],WFPC2 PC1 Flag [Hubble],WFPC2 WF2 Flag [Hubble],WFPC2 WF3 Flag [Hubble],WFPC2 WF4 Flag [Hubble],Exposure Type [Hubble],Fine Guidance System Lock [Hubble],Gain Mode [Hubble],Instrument Mode [Hubble],Publication Date [Hubble]
-ACS-HRC,ACS-F435W,Broadband,NULL,ACS-HRC,9975,"James, Philip B.",J8N410LBQ,MARS-CML015,NULL,NULL,NULL,NULL,NULL,Normal,Fine,N/A,ACCUM,2003-08-07T00:00:00.000
+Detector [Hubble],Filter Name [Hubble],Filter Type [Hubble],STIS Optical Element [Hubble],Aperture Type [Hubble],STIS Proposed Aperture Type [Hubble],HST Proposal ID [Hubble],PI Name [Hubble],STScI File Name [Hubble],HST Target Name [Hubble],WFPC2 Targeted Detector [Hubble],WFPC2 PC1 Flag [Hubble],WFPC2 WF2 Flag [Hubble],WFPC2 WF3 Flag [Hubble],WFPC2 WF4 Flag [Hubble],Exposure Type [Hubble],Fine Guidance System Lock [Hubble],Gain Mode [Hubble],Instrument Mode [Hubble],Publication Date [Hubble]
+ACS-HRC,ACS-F435W,Broadband,NULL,ACS-HRC,NULL,9975,"James, Philip B.",J8N410LBQ,MARS-CML015,NULL,NULL,NULL,NULL,NULL,Normal,Fine,N/A,ACCUM,2003-08-07T00:00:00.000

--- a/opus/application/test_api/responses/api_metadata2_hst_09975_acs_j8n410lbq_cats_pds_hubble_constraints_html.html
+++ b/opus/application/test_api/responses/api_metadata2_hst_09975_acs_j8n410lbq_cats_pds_hubble_constraints_html.html
@@ -16,6 +16,7 @@
 <dt>Filter Type</dt><dd>Broadband</dd>
 <dt>STIS Optical Element</dt><dd>NULL</dd>
 <dt>Aperture Type</dt><dd>ACS-HRC</dd>
+<dt>STIS Proposed Aperture Type</dt><dd>NULL</dd>
 <dt>HST Proposal ID</dt><dd>9975</dd>
 <dt>PI Name</dt><dd>James, Philip B.</dd>
 <dt>STScI File Name</dt><dd>J8N410LBQ</dd>

--- a/opus/application/test_api/responses/api_metadata2_hst_09975_acs_j8n410lbq_cats_pds_hubble_constraints_json.json
+++ b/opus/application/test_api/responses/api_metadata2_hst_09975_acs_j8n410lbq_cats_pds_hubble_constraints_json.json
@@ -14,6 +14,7 @@
     "HSTfiltertype": "Broadband",
     "HSTopticalelement": "NULL",
     "HSTaperturetype": "ACS-HRC",
+    "HSTproposedaperturetype": "NULL",
     "HSTproposalid": "9975",
     "HSTpiname": "James, Philip B.",
     "HSTstscigroupid": "J8N410LBQ",

--- a/opus/application/test_api/responses/api_metadata_hst_09975_acs_j8n410lbq_cats_pds_hubble_constraints_csv.csv
+++ b/opus/application/test_api/responses/api_metadata_hst_09975_acs_j8n410lbq_cats_pds_hubble_constraints_csv.csv
@@ -2,5 +2,5 @@ PDS Constraints
 Volume ID,Data Set ID,Product ID,Product Creation Time,Primary File Spec,OPUS ID,Note
 HSTJ0_9975,HST-M-ACS-5-ID9975-V1.0,J8N410LBQ,2013-06-17T00:00:00.000,HSTJ0_9975/DATA/VISIT_10/J8N410LBQ.LBL,hst-09975-acs-j8n410lbq,
 Hubble Mission Constraints
-Detector [Hubble],Filter Name [Hubble],Filter Type [Hubble],STIS Optical Element [Hubble],Aperture Type [Hubble],HST Proposal ID [Hubble],PI Name [Hubble],STScI File Name [Hubble],HST Target Name [Hubble],WFPC2 Targeted Detector [Hubble],WFPC2 PC1 Flag [Hubble],WFPC2 WF2 Flag [Hubble],WFPC2 WF3 Flag [Hubble],WFPC2 WF4 Flag [Hubble],Exposure Type [Hubble],Fine Guidance System Lock [Hubble],Gain Mode [Hubble],Instrument Mode [Hubble],Publication Date [Hubble]
-ACS-HRC,ACS-F435W,W,,ACS-HRC,9975,"James, Philip B.",J8N410LBQ,MARS-CML015,,,,,,NORMAL,FINE,N/A,ACCUM,2003-08-07T00:00:00.000
+Detector [Hubble],Filter Name [Hubble],Filter Type [Hubble],STIS Optical Element [Hubble],Aperture Type [Hubble],STIS Proposed Aperture Type [Hubble],HST Proposal ID [Hubble],PI Name [Hubble],STScI File Name [Hubble],HST Target Name [Hubble],WFPC2 Targeted Detector [Hubble],WFPC2 PC1 Flag [Hubble],WFPC2 WF2 Flag [Hubble],WFPC2 WF3 Flag [Hubble],WFPC2 WF4 Flag [Hubble],Exposure Type [Hubble],Fine Guidance System Lock [Hubble],Gain Mode [Hubble],Instrument Mode [Hubble],Publication Date [Hubble]
+ACS-HRC,ACS-F435W,W,,ACS-HRC,,9975,"James, Philip B.",J8N410LBQ,MARS-CML015,,,,,,NORMAL,FINE,N/A,ACCUM,2003-08-07T00:00:00.000

--- a/opus/application/test_api/responses/api_metadata_hst_09975_acs_j8n410lbq_cats_pds_hubble_constraints_html.html
+++ b/opus/application/test_api/responses/api_metadata_hst_09975_acs_j8n410lbq_cats_pds_hubble_constraints_html.html
@@ -16,6 +16,7 @@
 <dt>Filter Type</dt><dd>W</dd>
 <dt>STIS Optical Element</dt><dd>None</dd>
 <dt>Aperture Type</dt><dd>ACS-HRC</dd>
+<dt>STIS Proposed Aperture Type</dt><dd>None</dd>
 <dt>HST Proposal ID</dt><dd>9975</dd>
 <dt>PI Name</dt><dd>James, Philip B.</dd>
 <dt>STScI File Name</dt><dd>J8N410LBQ</dd>

--- a/opus/application/test_api/responses/api_metadata_hst_09975_acs_j8n410lbq_cats_pds_hubble_constraints_json.json
+++ b/opus/application/test_api/responses/api_metadata_hst_09975_acs_j8n410lbq_cats_pds_hubble_constraints_json.json
@@ -14,6 +14,7 @@
     "filter_type": "W",
     "optical_element": null,
     "aperture_type": "ACS-HRC",
+    "proposed_aperture_type": null,
     "hst_proposal_id": "9975",
     "hst_pi_name": "James, Philip B.",
     "stsci_group_id": "J8N410LBQ",

--- a/opus/import/populate_obs_mission_hubble.py
+++ b/opus/import/populate_obs_mission_hubble.py
@@ -965,6 +965,20 @@ def populate_obs_mission_hubble_aperture_type(**kwargs):
     ret = instrument[3:] + '-' + aperture
     return (ret, ret)
 
+def populate_obs_mission_hubble_HSTx_proposed_aperture_type(**kwargs):
+    return None
+
+populate_obs_mission_hubble_HSTACS_proposed_aperture_type = populate_obs_mission_hubble_HSTx_proposed_aperture_type
+populate_obs_mission_hubble_HSTNICMOS_proposed_aperture_type = populate_obs_mission_hubble_HSTx_proposed_aperture_type
+populate_obs_mission_hubble_HSTWFC3_proposed_aperture_type = populate_obs_mission_hubble_HSTx_proposed_aperture_type
+populate_obs_mission_hubble_HSTWFPC2_proposed_aperture_type = populate_obs_mission_hubble_HSTx_proposed_aperture_type
+
+def populate_obs_mission_hubble_HSTSTIS_proposed_aperture_type(**kwargs):
+    metadata = kwargs['metadata']
+    index_row = metadata['index_row']
+    aperture = index_row['PROPOSED_APERTURE_TYPE'].upper()
+    return (aperture, aperture)
+
 def populate_obs_mission_hubble_HSTACS_targeted_detector_id(**kwargs):
     return None
 

--- a/opus/import/table_schemas/obs_mission_hubble.json
+++ b/opus/import/table_schemas/obs_mission_hubble.json
@@ -342,6 +342,32 @@
         "pi_units": null
     },
     {
+        "field_name": "proposed_aperture_type",
+        "field_type": "char18",
+        "field_notnull": false,
+        "field_key": true,
+        "data_source": [
+            "FUNCTION",
+            "obs_mission_hubble_<INST>_proposed_aperture_type"
+        ],
+        "pi_category_name": "obs_mission_hubble",
+        "pi_dict_context": "HST",
+        "pi_dict_name": "PROPOSED_APERTURE_TYPE",
+        "definition": "For STIS, the proposed name of the aperture used for the observation. Only differs from Aperture Type when pseudo-aperture positions are used.",
+        "pi_disp_order": 45,
+        "pi_display": 1,
+        "pi_display_results": 1,
+        "pi_form_type": "GROUP",
+        "pi_intro": null,
+        "pi_label": "STIS Proposed Aperture Type",
+        "pi_label_results": "STIS Proposed Aperture Type",
+        "pi_old_slug": null,
+        "pi_slug": "HSTproposedaperturetype",
+        "pi_sub_heading": null,
+        "pi_tooltip": null,
+        "pi_units": null
+    },
+    {
         "field_name": "exposure_type",
         "field_type": "char20",
         "field_notnull": true,


### PR DESCRIPTION
- Fixes #984
- Were any Django, import pipeline, table_schema, or dictionary files modified? Y
  - Database used: opus3_test_200212_stis_proposed
  - All Django tests pass: Y
- Were any JavaScript or CSS files modified? N
  - JSHINT run on all affected files: N/A
  - Tested on Chrome, Firefox, Safari, and iOS: N/A
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): N/A

Description of changes:

Added Hubble STIS Proposed Aperture field and updated tests. Requires new database listed above to run. This will not be merged into master until Danny finishes the changes to the HST volumes, at which point it will need to be tested again.

Known problems:
