### PR TITLE
Issue of page reload when continuously calling string choice api in the middle of a search

### DIFF
--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -861,7 +861,7 @@ var o_search = {
     },
 
     allNormalizeInputApiCall: function() {
-        let newHash = o_hash.getHashStrFromSelections(opus.selections, true);
+        let newHash = o_hash.getHashStrFromSelections(true);
 
         opus.normalizeInputForAllFieldsInProgress[opus.allSlug] = true;
         o_search.lastSlugNormalizeRequestNo++;

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -1537,12 +1537,6 @@ var o_widgets = {
                 o_widgets.lastStringSearchRequestNo++;
                 o_search.slugStringSearchChoicesReqno[slugWithCounter] = o_widgets.lastStringSearchRequestNo;
 
-                if (opus.selections[slug]) {
-                    opus.selections[slug][idx] = currentValue;
-                } else {
-                    opus.selections[slug] = [currentValue];
-                }
-
                 let newHash = o_hash.getHashStrFromSelections();
                 // // Make sure the existing STRING input value is not passed to stringsearchchoices
                 // // API call. This will make sure each autocomplete dropdown results for individual
@@ -1556,6 +1550,7 @@ var o_widgets = {
                         newHashArray.push(slugValuePair);
                     }
                 }
+                newHashArray.push(`${slugWithCounter}=${currentValue}`);
                 newHash = newHashArray.join("&");
 
                 // Avoid calling api when some inputs are not valid

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -1531,8 +1531,6 @@ var o_widgets = {
             minLength: 1,
             source: function(request, response) {
                 let currentValue = request.term;
-                let inputCounter = o_utils.getSlugOrDataTrailingCounterStr(slugWithCounter);
-                let idx = inputCounter ? parseInt(inputCounter)-1 : 0;
 
                 o_widgets.lastStringSearchRequestNo++;
                 o_search.slugStringSearchChoicesReqno[slugWithCounter] = o_widgets.lastStringSearchRequestNo;

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -1543,7 +1543,7 @@ var o_widgets = {
                 let newHashArray = [];
                 for (const slugValuePair of hashArray) {
                     let slugParam = slugValuePair.split("=")[0];
-                    if (slugParam === slugWithCounter || !slugParam.match(slug) ||
+                    if (!slugParam.match(slug) ||
                         slugParam === `qtype-${slugWithCounter}`) {
                         newHashArray.push(slugValuePair);
                     }


### PR DESCRIPTION
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - Database used: opus3_test_200211
  - All Django tests pass: Y
- Were any JavaScript or CSS files modified? Y
  - JSHINT run on all affected files: Y
  - Tested on Chrome, Firefox, Safari, and iOS: Y
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): Y

Description of changes:
Fixed the issue that opus.selections gets updated when we type in any STRING input (opus.selections shouldn't get updated here). This was causing a page reload when user is typing something in a STRING input in the middle of a search.

Known problems:
None