### PR TITLE
Remove interval timer

### DIFF
--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -83,7 +83,6 @@
                     <!-- selected widgets -->
                     <div class="col op-widget-col">
                         <div id="widget-container" class="op-widget-column">
-                            <!-- note to self:    this is where the widgets will be replace by cards; should no longer by ul/li -->
                             <ul id="op-search-widgets"></ul>
                         </div>
                     </div>

--- a/opus/application/apps/ui/templates/ui/widget.html
+++ b/opus/application/apps/ui/templates/ui/widget.html
@@ -19,7 +19,11 @@
                         {% endfor %}
                     <select>
                 {% endif %}
-                <span class="spinner">&nbsp;</span>
+                <span class="spinner"
+                    {% if form_type not in range_form_types and form_type not in mult_form_types %}
+                        style="display: none"
+                    {% endif %}
+                >&nbsp;</span>
             </div>
             <span class="float-right border-left border-dark">
                 <a href="#card__{{ slug }}" data-toggle="collapse" data-target="#card__{{ slug }}" aria-expanded="true">

--- a/opus/application/static_media/js/hash.js
+++ b/opus/application/static_media/js/hash.js
@@ -255,12 +255,15 @@ var o_hash = {
                 hashStrFromSelections + "&" + hashStrFromOPUSPrefs : hashStrFromOPUSPrefs);
     },
 
-    updateURLFromCurrentHash: function() {
+    updateURLFromCurrentHash: function(trigger_search=false, delay=false) {
         /**
          * Update URL with full hash string
          */
         let fullHashStr = o_hash.getFullHashStr();
         window.location.hash = '/' + fullHashStr;
+        if (trigger_search) {
+            opus.searchChanged(delay);
+        }
     },
 
     encodeSlugValue: function(slugValue) {
@@ -549,11 +552,12 @@ var o_hash = {
         }
     },
 
-    extrasWithoutUnusedQtypes: function(selections, extras) {
-        // If a qtype is present in extras but is not used in the search
-        // selections, then don't include it at all. This is so that when we
-        // compare selections and extras over time, a "lonely" qtype won't be
-        // taken into account and trigger a new backend search.
+    extrasWithoutUnusedQtypesUnits: function(selections, extras) {
+        // If a qtype or unit is present in extras but is not used in the search
+        // selections (either because it's not present as a slug, or because
+        // the search is entirely nulls), then don't include it at all. This is so
+        // that when we compare selections and extras over time, a "lonely" qtype
+        // or unit won't be taken into account and trigger a new backend search.
         let newExtras = {};
         $.each(extras, function(slug, value) {
             let slugInExtras = "";
@@ -562,10 +566,10 @@ var o_hash = {
             } else if (slug.startsWith("unit-")) {
                 slugInExtras = slug.slice(5);
             }
-            if (slugInExtras in selections ||
-                slugInExtras+'1' in selections ||
-                slugInExtras+'2' in selections) {
-                    newExtras[slug] = value;
+            if ((slugInExtras in selections && selections[slugInExtras].some(elem => elem !== null)) ||
+                (slugInExtras+'1' in selections && selections[slugInExtras+'1'].some(elem => elem !== null)) ||
+                (slugInExtras+'2' in selections && selections[slugInExtras+'2'].some(elem => elem !== null))) {
+                newExtras[slug] = value;
             }
         });
         return newExtras;

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -263,7 +263,12 @@ var opus = {
 
         // Start the spinners for the left side menu and each widget for hinting
         $("#sidebar .op-menu-spinner.spinner").addClass("op-show-spinner");
-        $("#op-search-widgets .spinner").fadeIn();
+        opus.widgetsDrawn.forEach(function(eachSlug) {
+            if ($(`.widget__${eachSlug}`).hasClass("range-widget") ||
+                $(`.widget__${eachSlug}`).hasClass("mult-widget")) {
+                $(`#widget__${eachSlug} .spinner`).fadeIn();
+            }
+        });
 
         // Mark the changes as complete. We have to do this before allNormalizeInputApiCall to
         // avoid a recursive api call

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -565,11 +565,14 @@ var opus = {
          * Handle the 'Reset Search' and 'Reset Search and Metadata' buttons.
          */
 
-        // Reset the search query and return to the Search tab
+        // Reset the search query
         opus.selections = {};
         opus.extras = {};
+        // Update the URL so getWidget below doesn't have old concepts of
+        // what mults were selected in the default widgets.
+        o_hash.updateURLFromCurrentHash(false);
+
         o_browse.clearObservationData();
-        opus.changeTab('search');
 
         // Enable or disable the 'Reset Search' and 'Reset Search and Metadata' buttons
         if (!o_utils.areObjectsEqual(opus.prefs.cols, opus.defaultColumns)) {

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -208,8 +208,8 @@ var opus = {
         // identical.
         let currentExtrasQ = o_hash.extrasWithoutUnusedQtypesUnits(selections, extras);
         let lastExtrasQ = o_hash.extrasWithoutUnusedQtypesUnits(opus.lastSelections, opus.lastExtras);
-        if (o_utils.areSelectionsExtrasEqual(selections, opus.lastSelections) &&
-            o_utils.areSelectionsExtrasEqual(currentExtrasQ, lastExtrasQ)) {
+        if (o_utils.areObjectsEqual(selections, opus.lastSelections) &&
+            o_utils.areObjectsEqual(currentExtrasQ, lastExtrasQ)) {
             if (!opus.force_load) {
                 return;
             }
@@ -221,8 +221,8 @@ var opus = {
             // so we have to reload the page. We can't just continue on normally
             // because we need to re-run the URL normalization process.
             let opusExtrasQ = o_hash.extrasWithoutUnusedQtypesUnits(opus.selections, opus.extras);
-            if (!o_utils.areSelectionsExtrasEqual(selections, opus.selections) ||
-                !o_utils.areSelectionsExtrasEqual(currentExtrasQ, opusExtrasQ)) {
+            if (!o_utils.areObjectsEqual(selections, opus.selections) ||
+                !o_utils.areObjectsEqual(currentExtrasQ, opusExtrasQ)) {
                 // Make sure page will not reload in these cases:
                 // 1) When it's in the middle of an input removal process. After normalize input API
                 // call returns at the end of an input removal, URL and opus.selections will get updated

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -38,7 +38,7 @@ var opus = {
     defaultColumns: DEFAULT_COLUMNS.split(","),
     defaultWidgets: DEFAULT_WIDGETS.split(","),
 
-    searchChangeDelay: 2000, // How long to wait after a search changes to do the new search
+    searchChangeDelay: 1000, // How long to wait after a search changes to do the new search
     spinnerDelay: 250, // The amount of time to wait before showing a spinner in case the API returns quickly
 
     // avoiding race conditions in ajax calls

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -208,8 +208,8 @@ var opus = {
         // identical.
         let currentExtrasQ = o_hash.extrasWithoutUnusedQtypesUnits(selections, extras);
         let lastExtrasQ = o_hash.extrasWithoutUnusedQtypesUnits(opus.lastSelections, opus.lastExtras);
-        if (o_utils.areObjectsEqual(selections, opus.lastSelections) &&
-            o_utils.areObjectsEqual(currentExtrasQ, lastExtrasQ)) {
+        if (o_utils.areSelectionsExtrasEqual(selections, opus.lastSelections) &&
+            o_utils.areSelectionsExtrasEqual(currentExtrasQ, lastExtrasQ)) {
             if (!opus.force_load) {
                 return;
             }
@@ -221,8 +221,8 @@ var opus = {
             // so we have to reload the page. We can't just continue on normally
             // because we need to re-run the URL normalization process.
             let opusExtrasQ = o_hash.extrasWithoutUnusedQtypesUnits(opus.selections, opus.extras);
-            if (!o_utils.areObjectsEqual(selections, opus.selections) ||
-                !o_utils.areObjectsEqual(currentExtrasQ, opusExtrasQ)) {
+            if (!o_utils.areSelectionsExtrasEqual(selections, opus.selections) ||
+                !o_utils.areSelectionsExtrasEqual(currentExtrasQ, opusExtrasQ)) {
                 // Make sure page will not reload in these cases:
                 // 1) When it's in the middle of an input removal process. After normalize input API
                 // call returns at the end of an input removal, URL and opus.selections will get updated
@@ -251,7 +251,6 @@ var opus = {
             // In this case we want to reset startobs and cart_startobs to 1
             leaveStartObs = false;
         }
-
         opus.force_load = false;
 
         // Start the result count spinner and do the yellow flash

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -239,7 +239,6 @@ var o_search = {
             Update URL (and search) if all inputs are valid
         */
         $("#search").on("change", "input.RANGE", function(e) {
-            console.log("search 242", opus.selections, opus.extras);
             let inputName = $(this).attr("name");
             let slugName = $(this).data("slugname");
             let slug = o_utils.getSlugOrDataWithoutCounter(inputName);
@@ -574,7 +573,6 @@ var o_search = {
             $(target).removeClass("input_currently_focused");
         }
 
-        console.log("search 576", opus.selections, opus.extras);
         o_search.parseFinalNormalizedInputDataAndUpdateURL(slugWithId, url);
     },
 
@@ -880,7 +878,6 @@ var o_search = {
          * Validate the return data from a normalize input API call, and update hash & URL
          * based on the selections for the same normalize input API.
          */
-        console.log("search 882", normalizedInputData, opus.selections, opus.extras);
         o_search.slugInputValidValueFromLastSearch = {};
         $.each(normalizedInputData, function(eachSlug, value) {
             if (eachSlug === "reqno") {
@@ -943,7 +940,6 @@ var o_search = {
             }
         });
 
-        console.log("search 945", opus.selections, opus.extras);
         // Update newly selected unit to currentUnitBySlug
         if (slug.startsWith("unit-") && unit) {
             let slugNoNum = slug.match(/unit-(.*)$/)[1];
@@ -991,9 +987,7 @@ var o_search = {
          * Parse the return data from a normalize input API call. validateInput
          * is called here.
          */
-        console.log("search 991", slug, url);
         $.getJSON(url, function(normalizedInputData) {
-            console.log("search 993", normalizedInputData);
             // Make sure data is from the final normalize input call before parsing
             // normalizedInputData
             if (normalizedInputData.reqno < o_search.slugNormalizeReqno[slug]) {

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -367,7 +367,8 @@ var o_search = {
                 opus.updateOPUSLastSelectionsWithOPUSSelections();
             }
 
-            o_hash.updateURLFromCurrentHash();
+            // User may have changed input, so trigger search with delay
+            o_hash.updateURLFromCurrentHash(true, true);
         });
 
         // range behaviors and string behaviors for search widgets - qtype and unit
@@ -521,7 +522,8 @@ var o_search = {
                 if (!opus.areInputsValid() || areInputSetsEmpty) {
                     opus.updateOPUSLastSelectionsWithOPUSSelections();
                 }
-                o_hash.updateURLFromCurrentHash();
+                // User may have changed input, so trigger search with delay
+                o_hash.updateURLFromCurrentHash(true, true);
             }
 
             // If no search is performed, we still update the hints for a unit change.
@@ -951,7 +953,8 @@ var o_search = {
             if (!opus.areInputsValid()) {
                 opus.updateOPUSLastSelectionsWithOPUSSelections();
             }
-            o_hash.updateURLFromCurrentHash();
+            // User may have changed input, so trigger search with delay
+            o_hash.updateURLFromCurrentHash(true, true);
         } else {
             $("#op-result-count").text("?");
             // set hinting info to ? when any range input has invalid value
@@ -1004,7 +1007,7 @@ var o_search = {
             }
 
             o_search.rangesNameTotalMatchedCounter[slug] = 0;
-            if (o_utils.areObjectsEqual(opus.selections, opus.lastSelections))  {
+            if (o_utils.areSelectionsExtrasEqual(opus.selections, opus.lastSelections))  {
                 // Put back normal hinting info
                 opus.widgetsDrawn.forEach(function(eachSlug) {
                     o_search.getHinting(eachSlug);

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -239,6 +239,7 @@ var o_search = {
             Update URL (and search) if all inputs are valid
         */
         $("#search").on("change", "input.RANGE", function(e) {
+            console.log("search 242", opus.selections, opus.extras);
             let inputName = $(this).attr("name");
             let slugName = $(this).data("slugname");
             let slug = o_utils.getSlugOrDataWithoutCounter(inputName);
@@ -573,6 +574,7 @@ var o_search = {
             $(target).removeClass("input_currently_focused");
         }
 
+        console.log("search 576", opus.selections, opus.extras);
         o_search.parseFinalNormalizedInputDataAndUpdateURL(slugWithId, url);
     },
 
@@ -878,6 +880,7 @@ var o_search = {
          * Validate the return data from a normalize input API call, and update hash & URL
          * based on the selections for the same normalize input API.
          */
+        console.log("search 882", normalizedInputData, opus.selections, opus.extras);
         o_search.slugInputValidValueFromLastSearch = {};
         $.each(normalizedInputData, function(eachSlug, value) {
             if (eachSlug === "reqno") {
@@ -940,6 +943,7 @@ var o_search = {
             }
         });
 
+        console.log("search 945", opus.selections, opus.extras);
         // Update newly selected unit to currentUnitBySlug
         if (slug.startsWith("unit-") && unit) {
             let slugNoNum = slug.match(/unit-(.*)$/)[1];
@@ -987,7 +991,9 @@ var o_search = {
          * Parse the return data from a normalize input API call. validateInput
          * is called here.
          */
+        console.log("search 991", slug, url);
         $.getJSON(url, function(normalizedInputData) {
+            console.log("search 993", normalizedInputData);
             // Make sure data is from the final normalize input call before parsing
             // normalizedInputData
             if (normalizedInputData.reqno < o_search.slugNormalizeReqno[slug]) {

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -204,6 +204,7 @@ var o_search = {
                 */
                 if (returnData === "") {
                     $(e.target).removeClass("search_input_valid search_input_invalid");
+                    $(e.target).removeClass("search_input_invalid_no_focus");
                     $(e.target).addClass("search_input_original");
                 } else if (returnData !== null) {
                     $(e.target).removeClass("search_input_original search_input_invalid");

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -185,19 +185,6 @@ var o_search = {
                 let currentUnitVal = $(`#widget__${slugName} .op-unit-${slugName}`).val();
                 newHash += `&${unitSlugWithId}=${currentUnitVal}`;
             }
-            /*
-            Do not perform normalized api call if:
-            1) Input field is empty OR
-            2) Input value didn't change from the last successful search
-            3) Input value didn't match any ranges names
-            */
-            if (currentValue === "" || currentValue === o_search.slugInputValidValueFromLastSearch[slugWithId] ||
-                !o_search.performInputValidation[slugWithId]) {
-                $(e.target).removeClass("search_input_valid search_input_invalid");
-                $(e.target).removeClass("search_input_invalid_no_focus");
-                $(e.target).addClass("search_input_original");
-                return;
-            }
 
             opus.normalizeInputForCharInProgress[slugWithId] = true;
             let url = "/opus/__api/normalizeinput.json?" + newHash + "&reqno=" + o_search.slugNormalizeReqno[slugWithId];
@@ -995,6 +982,9 @@ var o_search = {
                 return;
             }
 
+            // Save the old state which indicates if there are ? in the result count and hints
+            let inputsWereValid = opus.areInputsValid();
+
             // check each input, if it's not valid, change its background to red
             // and also remove spinner.
             o_search.validateInput(normalizedInputData, true, slug, unit);
@@ -1007,7 +997,8 @@ var o_search = {
             }
 
             o_search.rangesNameTotalMatchedCounter[slug] = 0;
-            if (o_utils.areObjectsEqual(opus.selections, opus.lastSelections))  {
+            if (!inputsWereValid &&
+                o_utils.areObjectsEqual(opus.selections, opus.lastSelections))  {
                 // Put back normal hinting info
                 opus.widgetsDrawn.forEach(function(eachSlug) {
                     o_search.getHinting(eachSlug);
@@ -1119,7 +1110,6 @@ var o_search = {
         if ($(".widget__" + slug).hasClass("range-widget")) {
             // this is a range field
             o_search.getRangeEndpoints(slug);
-
         } else if ($(".widget__" + slug).hasClass("mult-widget")) {
             // this is a mult field
             o_search.getValidMults(slug);
@@ -1178,7 +1168,7 @@ var o_search = {
                 }
 
                 let dataSlug = multdata.field_id;
-                $("#widget__" + dataSlug + " .spinner").fadeOut("");
+                $("#widget__" + dataSlug + " .spinner").fadeOut();
 
                 let widget = "widget__" + dataSlug;
                 let mults = multdata.mults;

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -1007,7 +1007,7 @@ var o_search = {
             }
 
             o_search.rangesNameTotalMatchedCounter[slug] = 0;
-            if (o_utils.areSelectionsExtrasEqual(opus.selections, opus.lastSelections))  {
+            if (o_utils.areObjectsEqual(opus.selections, opus.lastSelections))  {
                 // Put back normal hinting info
                 opus.widgetsDrawn.forEach(function(eachSlug) {
                     o_search.getHinting(eachSlug);

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -1007,7 +1007,7 @@ var o_search = {
             }
 
             o_search.rangesNameTotalMatchedCounter[slug] = 0;
-            if (o_utils.areObjectsEqual(opus.selections, opus.lastSelections))  {
+            if (o_utils.areSelectionsExtrasEqual(opus.selections, opus.lastSelections))  {
                 // Put back normal hinting info
                 opus.widgetsDrawn.forEach(function(eachSlug) {
                     o_search.getHinting(eachSlug);

--- a/opus/application/static_media/js/utils.js
+++ b/opus/application/static_media/js/utils.js
@@ -38,42 +38,6 @@ var o_utils = {
         return true;
     },
 
-    areSelectionsExtrasEqual: function(obj1, obj2) {
-        /**
-         * This is for comparing objects whose values are all arrays.
-         * However, we treat an array of "null" values as equivalent to
-         * a missing key.
-         * NOTE: We don't want to use JSON.stringify to directly compare
-         * two objects because the order of keys in the object will matter
-         * in that case.
-         **/
-        for (const key in obj1) {
-            if (!(key in obj2)) {
-                if (obj1[key].every(elem => elem == null)) {
-                    continue;
-                }
-                return false;
-            }
-            // expect the array (value) of the same key to be the same for both objects
-            if (JSON.stringify(obj1[key]) !== JSON.stringify(obj2[key])) {
-                return false;
-            }
-        }
-        for (const key in obj2) {
-            if (!(key in obj1)) {
-                if (obj2[key].every(elem => elem == null)) {
-                    continue;
-                }
-                return false;
-            }
-            // expect the array (value) of the same key to be the same for both objects
-            if (JSON.stringify(obj1[key]) !== JSON.stringify(obj2[key])) {
-                return false;
-            }
-        }
-        return true;
-    },
-
     // num is an int
     addCommas: function(num) {
           return num.toString().replace(/(\d)(?=(\d\d\d)+(?!\d))/g, "$1,");

--- a/opus/application/static_media/js/utils.js
+++ b/opus/application/static_media/js/utils.js
@@ -38,6 +38,42 @@ var o_utils = {
         return true;
     },
 
+    areSelectionsExtrasEqual: function(obj1, obj2) {
+        /**
+         * This is for comparing objects whose values are all arrays.
+         * However, in this case we treat a missing key as equivalent to a
+         * list that has nothing but nulls.
+         * NOTE: We don't want to use JSON.stringify to directly compare
+         * two objects because the order of keys in the object will matter
+         * in that case.
+         **/
+        for (const key in obj1) {
+            if (!(key in obj2)) {
+                if (obj1[key].some(elem => elem !== null)) {
+                    return false;
+                }
+                continue;
+            }
+            // expect the array (value) of the same key to be the same for both objects
+            if (JSON.stringify(obj1[key]) !== JSON.stringify(obj2[key])) {
+                return false;
+            }
+        }
+        for (const key in obj2) {
+            if (!(key in obj1)) {
+                if (obj2[key].some(elem => elem !== null)) {
+                    return false;
+                }
+                continue;
+            }
+            // expect the array (value) of the same key to be the same for both objects
+            if (JSON.stringify(obj1[key]) !== JSON.stringify(obj2[key])) {
+                return false;
+            }
+        }
+        return true;
+    },
+
     // num is an int
     addCommas: function(num) {
           return num.toString().replace(/(\d)(?=(\d\d\d)+(?!\d))/g, "$1,");

--- a/opus/application/static_media/js/utils.js
+++ b/opus/application/static_media/js/utils.js
@@ -17,8 +17,7 @@ var o_utils = {
      **/
     areObjectsEqual: function(obj1, obj2) {
         /**
-         * This is for comparing selections or lastSelections
-         * Expects objects whose values are all arrays.
+         * This is for comparing objects whose values are all arrays.
          * NOTE: We don't want to use JSON.stringify to directly compare
          * two objects because the order of keys in the object will matter
          * in that case.
@@ -34,6 +33,42 @@ var o_utils = {
                 if (JSON.stringify(obj1[key]) !== JSON.stringify(obj2[key])) {
                     return false;
                 }
+            }
+        }
+        return true;
+    },
+
+    areSelectionsExtrasEqual: function(obj1, obj2) {
+        /**
+         * This is for comparing objects whose values are all arrays.
+         * However, we treat an array of "null" values as equivalent to
+         * a missing key.
+         * NOTE: We don't want to use JSON.stringify to directly compare
+         * two objects because the order of keys in the object will matter
+         * in that case.
+         **/
+        for (const key in obj1) {
+            if (!(key in obj2)) {
+                if (obj1[key].every(elem => elem == null)) {
+                    continue;
+                }
+                return false;
+            }
+            // expect the array (value) of the same key to be the same for both objects
+            if (JSON.stringify(obj1[key]) !== JSON.stringify(obj2[key])) {
+                return false;
+            }
+        }
+        for (const key in obj2) {
+            if (!(key in obj1)) {
+                if (obj2[key].every(elem => elem == null)) {
+                    continue;
+                }
+                return false;
+            }
+            // expect the array (value) of the same key to be the same for both objects
+            if (JSON.stringify(obj1[key]) !== JSON.stringify(obj2[key])) {
+                return false;
             }
         }
         return true;

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -431,8 +431,8 @@ var o_widgets = {
 
             // Check if there is any selections change. This flag will be used to determine
             // if normalize input should be run when removing an empty input set.
-            let noSelectionsChange = (o_utils.areObjectsEqual(opus.selections, opus.lastSelections) &&
-                                      o_utils.areObjectsEqual(opus.extras, opus.lastExtras));
+            let noSelectionsChange = (o_utils.areSelectionsExtrasEqual(opus.selections, opus.lastSelections) &&
+                                      o_utils.areSelectionsExtrasEqual(opus.extras, opus.lastExtras));
 
             if (newlyAddedInput.hasClass("RANGE")) {
                 opus.selections[`${slug}1`] = opus.selections[`${slug}1`] || [];
@@ -506,8 +506,8 @@ var o_widgets = {
 
             // Check if there is any selections change. This flag will be used to determine
             // if normalize input should be run when removing an empty input set.
-            let noSelectionsChange = (o_utils.areObjectsEqual(opus.selections, opus.lastSelections) &&
-                                      o_utils.areObjectsEqual(opus.extras, opus.lastExtras));
+            let noSelectionsChange = (o_utils.areSelectionsExtrasEqual(opus.selections, opus.lastSelections) &&
+                                      o_utils.areSelectionsExtrasEqual(opus.extras, opus.lastExtras));
 
             if (inputElement.hasClass("RANGE")) {
                 let previousMinSelections = opus.selections[`${slug}1`];
@@ -610,7 +610,7 @@ var o_widgets = {
                         $("input.RANGE, input.STRING").addClass("search_input_original");
                         $("#sidebar").removeClass("search_overlay");
                         $("#op-result-count").text(o_utils.addCommas(o_browse.totalObsCount));
-                        if (o_utils.areObjectsEqual(opus.selections, opus.lastSelections))  {
+                        if (o_utils.areSelectionsExtrasEqual(opus.selections, opus.lastSelections))  {
                             // Put back normal hinting info
                             opus.widgetsDrawn.forEach(function(eachSlug) {
                                 o_search.getHinting(eachSlug);
@@ -819,7 +819,7 @@ var o_widgets = {
                 $("input.RANGE, input.STRING").addClass("search_input_original");
                 $("#sidebar").removeClass("search_overlay");
                 $("#op-result-count").text(o_utils.addCommas(o_browse.totalObsCount));
-                if (o_utils.areObjectsEqual(opus.selections, opus.lastSelections))  {
+                if (o_utils.areSelectionsExtrasEqual(opus.selections, opus.lastSelections))  {
                     // Put back normal hinting info
                     opus.widgetsDrawn.forEach(function(eachSlug) {
                         o_search.getHinting(eachSlug);

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -37,9 +37,6 @@ var o_widgets = {
 
     uniqueIdForInputs: 100,
     centerOrLabelDone: false,
-    // This flag is used to let opus.load know that a widget just opened and we don't
-    // want to perform a search when a widget has just opened.
-    isGetWidgetDone: false,
 
     // This flag is used to determine if we are closing any widget with empty input.
     // In a series of closing widget actions, if there is one input in a widget with a
@@ -434,8 +431,8 @@ var o_widgets = {
 
             // Check if there is any selections change. This flag will be used to determine
             // if normalize input should be run when removing an empty input set.
-            let noSelectionsChange = (o_utils.areObjectsEqual(opus.selections, opus.lastSelections) &&
-                                      o_utils.areObjectsEqual(opus.extras, opus.lastExtras));
+            let noSelectionsChange = (o_utils.areSelectionsExtrasEqual(opus.selections, opus.lastSelections) &&
+                                      o_utils.areSelectionsExtrasEqual(opus.extras, opus.lastExtras));
 
             if (newlyAddedInput.hasClass("RANGE")) {
                 opus.selections[`${slug}1`] = opus.selections[`${slug}1`] || [];
@@ -486,7 +483,8 @@ var o_widgets = {
                     opus.updateOPUSLastSelectionsWithOPUSSelections();
                 }
             }
-            o_hash.updateURLFromCurrentHash();
+            // User may have changed input, so trigger search with delay
+            o_hash.updateURLFromCurrentHash(true, true);
             o_widgets.isAddingInput = false;
         });
 
@@ -508,8 +506,8 @@ var o_widgets = {
 
             // Check if there is any selections change. This flag will be used to determine
             // if normalize input should be run when removing an empty input set.
-            let noSelectionsChange = (o_utils.areObjectsEqual(opus.selections, opus.lastSelections) &&
-                                      o_utils.areObjectsEqual(opus.extras, opus.lastExtras));
+            let noSelectionsChange = (o_utils.areSelectionsExtrasEqual(opus.selections, opus.lastSelections) &&
+                                      o_utils.areSelectionsExtrasEqual(opus.extras, opus.lastExtras));
 
             if (inputElement.hasClass("RANGE")) {
                 let previousMinSelections = opus.selections[`${slug}1`];
@@ -594,7 +592,8 @@ var o_widgets = {
                     // empty set is removed.
                     opus.updateOPUSLastSelectionsWithOPUSSelections();
                 }
-                o_hash.updateURLFromCurrentHash();
+                // User may have changed input, so trigger search with delay
+                o_hash.updateURLFromCurrentHash(true, true);
                 o_widgets.isRemovingInput = false;
             } else {
                 o_search.allNormalizeInputApiCall().then(function(normalizedData) {
@@ -611,7 +610,7 @@ var o_widgets = {
                         $("input.RANGE, input.STRING").addClass("search_input_original");
                         $("#sidebar").removeClass("search_overlay");
                         $("#op-result-count").text(o_utils.addCommas(o_browse.totalObsCount));
-                        if (o_utils.areObjectsEqual(opus.selections, opus.lastSelections))  {
+                        if (o_utils.areSelectionsExtrasEqual(opus.selections, opus.lastSelections))  {
                             // Put back normal hinting info
                             opus.widgetsDrawn.forEach(function(eachSlug) {
                                 o_search.getHinting(eachSlug);
@@ -620,7 +619,8 @@ var o_widgets = {
                     }
 
                     if (opus.areInputsValid()) {
-                        o_hash.updateURLFromCurrentHash();
+                        // User may have changed input, so trigger search with delay
+                        o_hash.updateURLFromCurrentHash(true, true);
                     }
 
                     delete opus.normalizeInputForAllFieldsInProgress[opus.allSlug];
@@ -819,7 +819,7 @@ var o_widgets = {
                 $("input.RANGE, input.STRING").addClass("search_input_original");
                 $("#sidebar").removeClass("search_overlay");
                 $("#op-result-count").text(o_utils.addCommas(o_browse.totalObsCount));
-                if (o_utils.areObjectsEqual(opus.selections, opus.lastSelections))  {
+                if (o_utils.areSelectionsExtrasEqual(opus.selections, opus.lastSelections))  {
                     // Put back normal hinting info
                     opus.widgetsDrawn.forEach(function(eachSlug) {
                         o_search.getHinting(eachSlug);
@@ -833,7 +833,8 @@ var o_widgets = {
             }
 
             if (opus.areInputsValid()) {
-                o_hash.updateURLFromCurrentHash();
+                // User may have changed input, so trigger search with delay
+                o_hash.updateURLFromCurrentHash(true, true);
             }
 
             delete opus.normalizeInputForAllFieldsInProgress[opus.allSlug];
@@ -841,7 +842,7 @@ var o_widgets = {
     },
 
     widgetDrop: function(obj) {
-            // if widget is moved to a different formscolumn,
+            // if widget is moved to a different location,
             // redefine the opus.prefs.widgets (preserves order)
             let widgets = $("#op-search-widgets").sortable("toArray");
             $.each(widgets, function(index, value) {
@@ -1189,6 +1190,7 @@ var o_widgets = {
                     o_hash.updateURLFromCurrentHash();
                 }
             }
+
             // Initialize popover, this for the (i) icon next to qtype
             $(".op-widget-main .op-range-qtype-helper a").popover({
                 html: true,
@@ -1231,7 +1233,7 @@ var o_widgets = {
                 });
             } catch(e) { } // these only apply to mult widgets
 
-            if ($.inArray(slug,opus.widgetsFetching) > -1) {
+            if ($.inArray(slug, opus.widgetsFetching) > -1) {
                 opus.widgetsFetching.splice(opus.widgetsFetching.indexOf(slug), 1);
             }
 
@@ -1337,7 +1339,6 @@ var o_widgets = {
             } else {
                 o_search.getHinting(slug);
             }
-            o_widgets.isGetWidgetDone = true;
         }); // end callback for .done()
     }, // end getWidget function
 

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -1238,7 +1238,7 @@ var o_widgets = {
             }
 
             if ($.isEmptyObject(opus.selections)) {
-                $('#widget__' + slug + ' .spinner').fadeOut('');
+                $('#widget__' + slug + ' .spinner').fadeOut();
             }
 
             let widgetInputs = $(`#widget__${slug} input`);
@@ -1343,6 +1343,9 @@ var o_widgets = {
             // inputs will also have null in opus.selections
             [opus.selections, opus.extras] = o_hash.alignDataInSelectionsAndExtras(opus.selections,
                                                                                    opus.extras);
+            if (!opus.isAnyNormalizeInputInProgress()) {
+                opus.updateOPUSLastSelectionsWithOPUSSelections();
+            }
         }); // end callback for .done()
     }, // end getWidget function
 

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -1339,6 +1339,10 @@ var o_widgets = {
             } else {
                 o_search.getHinting(slug);
             }
+            // Align data in opus.selections and opus.extras to make sure empty
+            // inputs will also have null in opus.selections
+            [opus.selections, opus.extras] = o_hash.alignDataInSelectionsAndExtras(opus.selections,
+                                                                                   opus.extras);
         }); // end callback for .done()
     }, // end getWidget function
 

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -431,8 +431,8 @@ var o_widgets = {
 
             // Check if there is any selections change. This flag will be used to determine
             // if normalize input should be run when removing an empty input set.
-            let noSelectionsChange = (o_utils.areSelectionsExtrasEqual(opus.selections, opus.lastSelections) &&
-                                      o_utils.areSelectionsExtrasEqual(opus.extras, opus.lastExtras));
+            let noSelectionsChange = (o_utils.areObjectsEqual(opus.selections, opus.lastSelections) &&
+                                      o_utils.areObjectsEqual(opus.extras, opus.lastExtras));
 
             if (newlyAddedInput.hasClass("RANGE")) {
                 opus.selections[`${slug}1`] = opus.selections[`${slug}1`] || [];
@@ -506,8 +506,8 @@ var o_widgets = {
 
             // Check if there is any selections change. This flag will be used to determine
             // if normalize input should be run when removing an empty input set.
-            let noSelectionsChange = (o_utils.areSelectionsExtrasEqual(opus.selections, opus.lastSelections) &&
-                                      o_utils.areSelectionsExtrasEqual(opus.extras, opus.lastExtras));
+            let noSelectionsChange = (o_utils.areObjectsEqual(opus.selections, opus.lastSelections) &&
+                                      o_utils.areObjectsEqual(opus.extras, opus.lastExtras));
 
             if (inputElement.hasClass("RANGE")) {
                 let previousMinSelections = opus.selections[`${slug}1`];
@@ -610,7 +610,7 @@ var o_widgets = {
                         $("input.RANGE, input.STRING").addClass("search_input_original");
                         $("#sidebar").removeClass("search_overlay");
                         $("#op-result-count").text(o_utils.addCommas(o_browse.totalObsCount));
-                        if (o_utils.areSelectionsExtrasEqual(opus.selections, opus.lastSelections))  {
+                        if (o_utils.areObjectsEqual(opus.selections, opus.lastSelections))  {
                             // Put back normal hinting info
                             opus.widgetsDrawn.forEach(function(eachSlug) {
                                 o_search.getHinting(eachSlug);
@@ -819,7 +819,7 @@ var o_widgets = {
                 $("input.RANGE, input.STRING").addClass("search_input_original");
                 $("#sidebar").removeClass("search_overlay");
                 $("#op-result-count").text(o_utils.addCommas(o_browse.totalObsCount));
-                if (o_utils.areSelectionsExtrasEqual(opus.selections, opus.lastSelections))  {
+                if (o_utils.areObjectsEqual(opus.selections, opus.lastSelections))  {
                     // Put back normal hinting info
                     opus.widgetsDrawn.forEach(function(eachSlug) {
                         o_search.getHinting(eachSlug);


### PR DESCRIPTION
- Fixes #980 
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - Database used: N/A
  - All Django tests pass: N/A
- Were any JavaScript or CSS files modified? Y
  - JSHINT run on all affected files: Y
  - Tested on Chrome, Firefox, Safari, and iOS: Y
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): Y

Description of changes:

Removed 1 second interval timer and replaced with a single-shot timer that is started every time the user changes something related to search.

Known problems:

None
