### PR TITLE
Responsive issues (Fixes #800)

### DIFF
--- a/opus/application/apps/paraminfo/models.py
+++ b/opus/application/apps/paraminfo/models.py
@@ -1,6 +1,8 @@
 from django.db import models
 from dictionary.views import get_def_for_tooltip
 
+import json
+
 from search.models import TableNames
 from tools.app_utils import parse_form_type
 

--- a/opus/application/apps/results/templates/results/detail_metadata_internal.html
+++ b/opus/application/apps/results/templates/results/detail_metadata_internal.html
@@ -16,13 +16,13 @@
                                 {{ param_info.label_results }}:&nbsp;
                             {% endif %}
                             <span class="op-detail-entry-values">{{ val }}
-                            {% if param_info.is_string_or_mult %}
-                                <a href="/opus/#/{{ param_info.slug }}={{ val|encode_value }}{% if param_info.is_string %}&qtype-{{ param_info.slug }}=matches{% endif %}{% if url_cols %}&cols={{ url_cols }}{% endif %}"
-                                        target="_blank">
-                                    <i class="fas fa-search"
-                                        title='Open a new browser tab containing OPUS that searches for "{{ param_info.label_results }}" equal to "{{ val }}"'></i>
-                                </a>
-                            {% endif %}
+                                {% if param_info.is_string_or_mult %}
+                                    <a href="/opus/#/{{ param_info.slug }}={{ val|encode_value }}{% if param_info.is_string %}&qtype-{{ param_info.slug }}=matches{% endif %}{% if url_cols %}&cols={{ url_cols }}{% endif %}"
+                                            target="_blank">
+                                        <i class="fas fa-search"
+                                            title='Open a new browser tab containing OPUS that searches for "{{ param_info.label_results }}" equal to "{{ val }}"'></i>
+                                    </a>
+                                {% endif %}
                             </span>
                         </div>
                     {% endif %}

--- a/opus/application/apps/results/templates/results/detail_metadata_internal.html
+++ b/opus/application/apps/results/templates/results/detail_metadata_internal.html
@@ -11,10 +11,11 @@
                         {% endif %}
                         <div>
                             {% if param_info.get_units %}
-                                {{ param_info.label_results }} {{ param_info.get_units }}: {{ val }}
+                                {{ param_info.label_results }} {{ param_info.get_units }}:&nbsp;
                             {% else %}
-                                {{ param_info.label_results }}: {{ val }}
+                                {{ param_info.label_results }}:&nbsp;
                             {% endif %}
+                            <span class="op-detail-entry-values">{{ val }}
                             {% if param_info.is_string_or_mult %}
                                 <a href="/opus/#/{{ param_info.slug }}={{ val|encode_value }}{% if param_info.is_string %}&qtype-{{ param_info.slug }}=matches{% endif %}{% if url_cols %}&cols={{ url_cols }}{% endif %}"
                                         target="_blank">
@@ -22,6 +23,7 @@
                                         title='Open a new browser tab containing OPUS that searches for "{{ param_info.label_results }}" equal to "{{ val }}"'></i>
                                 </a>
                             {% endif %}
+                            </span>
                         </div>
                     {% endif %}
                 {% endfor %}

--- a/opus/application/apps/results/templates/results/detail_metadata_slugs_internal.html
+++ b/opus/application/apps/results/templates/results/detail_metadata_slugs_internal.html
@@ -10,13 +10,13 @@
                 <div>
                     {{ param }}:&nbsp;
                     <span class="op-detail-entry-values">{{ values.0 }}
-                    {% if values.1.is_string_or_mult %}
-                        <a href="/opus/#/{{ values.1.slug }}={{ values.0|encode_value }}{% if values.1.is_string %}&qtype-{{ values.1.slug }}=matches{% endif %}{% if url_cols %}&cols={{ url_cols }}{% endif %}"
-                                target="_blank">
-                            <i class="fas fa-search"
-                                title='Open a new browser tab containing OPUS that searches for "{{ values.1.label_results }}" equal to "{{ values.0 }}"'></i>
-                        </a>
-                    {% endif %}
+                        {% if values.1.is_string_or_mult %}
+                            <a href="/opus/#/{{ values.1.slug }}={{ values.0|encode_value }}{% if values.1.is_string %}&qtype-{{ values.1.slug }}=matches{% endif %}{% if url_cols %}&cols={{ url_cols }}{% endif %}"
+                                    target="_blank">
+                                <i class="fas fa-search"
+                                    title='Open a new browser tab containing OPUS that searches for "{{ values.1.label_results }}" equal to "{{ values.0 }}"'></i>
+                            </a>
+                        {% endif %}
                     </span>
                 </div>
             {% endfor %}

--- a/opus/application/apps/results/templates/results/detail_metadata_slugs_internal.html
+++ b/opus/application/apps/results/templates/results/detail_metadata_slugs_internal.html
@@ -8,7 +8,8 @@
                         title="{{ values.1.get_tooltip_results|striptags }}"></i>&nbsp;
                 {% endif %}
                 <div>
-                    {{ param }}: {{ values.0 }}
+                    {{ param }}:&nbsp;
+                    <span class="op-detail-entry-values">{{ values.0 }}
                     {% if values.1.is_string_or_mult %}
                         <a href="/opus/#/{{ values.1.slug }}={{ values.0|encode_value }}{% if values.1.is_string %}&qtype-{{ values.1.slug }}=matches{% endif %}{% if url_cols %}&cols={{ url_cols }}{% endif %}"
                                 target="_blank">
@@ -16,6 +17,7 @@
                                 title='Open a new browser tab containing OPUS that searches for "{{ values.1.label_results }}" equal to "{{ values.0 }}"'></i>
                         </a>
                     {% endif %}
+                    </span>
                 </div>
             {% endfor %}
         </li>

--- a/opus/application/apps/ui/templates/ui/menu.html
+++ b/opus/application/apps/ui/templates/ui/menu.html
@@ -47,7 +47,7 @@
                                                             {{ p.body_qualified_label }}
                                                         {% endif %}
                                                       " data-slug="{{ p.slug }}" class="op-search-param" href="#">
-                                                        <span>
+                                                        <span class="op-menu-item">
                                                             <span class="op-search-param-checkmark">
                                                                 <i class="fa fa-check"></i>
                                                             </span>
@@ -55,12 +55,12 @@
                                                                 {% if p.get_tooltip_results %}
                                                                     <i class="fas fa-info-circle" title="{{ p.get_tooltip_results }}"></i>
                                                                 {% endif %}
-                                                                {{ p.label_results }}
+                                                                <span>{{ p.label_results }}</span>
                                                             {% else %}
                                                                 {% if p.get_tooltip %}
                                                                     <i class="fas fa-info-circle" title="{{ p.get_tooltip }}"></i>
                                                                 {% endif %}
-                                                                {{ p.label }}
+                                                                <span>{{ p.label }}</span>
                                                             {% endif %}
                                                         </span>
                                                     </a>
@@ -89,7 +89,7 @@
                                             {{ p.body_qualified_label }}
                                         {% endif %}
                                       " data-slug="{{ p.slug }}" class="op-search-param" href="#">
-                                        <span>
+                                        <span class="op-menu-item">
                                             <span class="op-search-param-checkmark">
                                                 <i class="fa fa-check"></i>
                                             </span>
@@ -98,15 +98,15 @@
                                                     <i class="fas fa-info-circle" title="{{ p.get_tooltip_results }}"></i>
                                                 {% endif %}
                                                 {% if div.table_name == 'search_fields' %}
-                                                    {{ p.body_qualified_label_results }}
+                                                    <span>{{ p.body_qualified_label_results }}</span>
                                                 {% else %}
-                                                    {{ p.label_results }}
+                                                    <span>{{ p.label_results }}</span>
                                                 {% endif %}
                                             {% else %}
                                                 {% if p.get_tooltip %}
                                                     <i class="fas fa-info-circle" title="{{ p.get_tooltip }}"></i>
                                                 {% endif %}
-                                                {{ p.label }}
+                                                <span>{{ p.label }}</span>
                                             {% endif %}
                                         </span>
                                     </a>

--- a/opus/application/apps/ui/templates/ui/menu.html
+++ b/opus/application/apps/ui/templates/ui/menu.html
@@ -6,7 +6,7 @@
                     <span class="op-menu-first-category">
                 {% endif %}
                         <a href="#{{ which }}-submenu-{{ div.table_name }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle py-2 op-submenu-category {{ div.collapsed }}" data-cat="{{ div.table_name }}">
-                            <span class="title">{{ div.label }}</span>
+                            <span class="title">{{ div.label }}&nbsp;<span class="op-menu-arrow"></span></span>
                         </a>
                 {% if div.first_category %}
                         <span class="op-menu-spinner spinner">&nbsp;</span>
@@ -28,7 +28,7 @@
                             {% for sub_head,params in info.data.items %}
                                 <li class="list-group-item py-0 pl-0">
                                     <a href="#{{ which }}-submenu-{{ div.table_name|slugify }}-{{ sub_head.0|slugify }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle op-submenu-category {{ sub_head.1 }}" data-cat="{{ div.table_name|slugify }}-{{ sub_head.0|slugify }}">
-                                        <span class="menu-text title">{{ sub_head.0 }}</span>
+                                        <span class="menu-text title">{{ sub_head.0 }}&nbsp;<span class="op-menu-arrow"></span></span>
                                     </a>
                                     <ul class="list-group list-group-flush submenu collapse {{ sub_head.2 }}" id="{{ which }}-submenu-{{ div.table_name|slugify }}-{{ sub_head.0|slugify }}">
                                         {% for p in params %}

--- a/opus/application/apps/ui/templates/ui/widget.html
+++ b/opus/application/apps/ui/templates/ui/widget.html
@@ -9,17 +9,19 @@
 <div class="card">
     <header class="card-header">
         <h6 class="card-title mt-0">
-            <div>
+            <div class="d-flex align-items-baseline">
                 <i class="fas fa-info-circle" title="{{ tooltip|safe }}"></i>
-                <span class="op-widget-title">{{ label }}&nbsp;</span>
-                {% if units %}
-                    <select class="op-unit-{{ slug }}" name="unit-{{ slug }}" tabindex="0">
-                        {% for unit, display_name in units.items %}
-                            <option value="{{ unit }}">{{ display_name }}</option>
-                        {% endfor %}
-                    <select>
-                {% endif %}
-                <span class="spinner">&nbsp;</span>
+                <div>
+                    <span class="op-widget-title">{{ label }}&nbsp;</span>
+                    {% if units %}
+                        <select class="op-unit-{{ slug }}" name="unit-{{ slug }}" tabindex="0">
+                            {% for unit, display_name in units.items %}
+                                <option value="{{ unit }}">{{ display_name }}</option>
+                            {% endfor %}
+                        <select>
+                    {% endif %}
+                    <span class="spinner">&nbsp;</span>
+                </div>
             </div>
             <span class="float-right border-left border-dark">
                 <a href="#card__{{ slug }}" data-toggle="collapse" data-target="#card__{{ slug }}" aria-expanded="true">

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -254,9 +254,30 @@ Not sure if this is the desired behavior
 /* As long as q-type shrink to the 2nd line, we set text input width
 to 100%, this will make the shrinking look smoother */
 @media (max-width: 970px) {
-    /* Make text input shrink proportionally when window is narrow */
-    #op-search-widgets input[type="text"] {
+    /* Make STRING input shrink proportionally when window is narrow */
+    #op-search-widgets input[class~="STRING"] {
         width: 100%;
+    }
+
+    /* The following styling are to group Min/Max with its corresponding input
+    when window is narrow */
+    #op-search-widgets input[class~="RANGE"] {
+        flex: 1 0 auto;
+    }
+
+    .op-range-input-min-list, .op-range-input-max-list {
+        white-space: nowrap;
+        display: inline-flex !important;
+        width: 100%;
+    }
+
+    /* Algin the Min/Max input tag when they are in different lines */
+    .op-range-input-min {
+        margin-left: 0.5rem;
+    }
+
+    .op-range-input-max {
+        margin-left: 0.3rem;
     }
 }
 

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -359,12 +359,16 @@ to 100%, this will make the shrinking look smoother */
 
 /* Css styling for triangle arrow pointing right */
 .op-menu-arrow {
+    display: inline-block;
     width: 0;
     height: 0;
-    border-left: 5px solid transparent;
-    border-right: 5px solid transparent;
-    border-top: 5px solid #000;
-    display: inline-block;
+    margin-left: 0.255em;
+    vertical-align: 0.255em;
+    content: "";
+    border-top: 0.3em solid;
+    border-right: 0.3em solid transparent;
+    border-bottom: 0;
+    border-left: 0.3em solid transparent;
 }
 
 /* Make sure triangle arrow is veritcally centered */

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -347,6 +347,37 @@ to 100%, this will make the shrinking look smoother */
     -webkit-transform: rotate(-90deg);
 }
 
+/* Rotate triangle arrows when menu category is clicked */
+.op-search-menu .dropdown-toggle .op-menu-arrow {
+    transition: all .3s;
+    -webkit-transition: all .3s;
+}
+.op-search-menu .dropdown-toggle.collapsed .op-menu-arrow {
+    transform: rotate(-90deg);
+    -webkit-transform: rotate(-90deg);
+}
+
+/* Css styling for triangle arrow pointing right */
+.op-menu-arrow {
+    width: 0;
+    height: 0;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 5px solid #000;
+    display: inline-block;
+}
+
+/* Make sure triangle arrow is veritcally centered */
+.op-menu-triangle-group {
+    display: inline-flex;
+    align-items: center;
+}
+
+/* Hide the default bootstrap dropdown triangle arrow */
+.op-search-menu .dropdown-toggle::after {
+    display: none !important;
+}
+
 .sidebar_wrapper {
     display: flex;
     margin: 0;

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2677,3 +2677,16 @@ at the right of -- OR -- label. */
 .op-hints-info {
     cursor: text;
 }
+
+/* Make sure text in the menu align with text in the 1st line instead of (i) icon
+when wrapping into the 2nd line. */
+.op-menu-item {
+    display: flex;
+    align-items: baseline;
+}
+
+/* Spacing between V, (i) icon, and text in the menu. */
+.op-menu-item i.fa-info-circle {
+    padding-left: 0.2rem;
+    padding-right: 0.2rem;
+}

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -765,6 +765,13 @@ button.op-mini-thumbnail-zoom {
     right: 1.25em;
 }
 
+/* Add spacing between each menu item in select metadata menu */
+#op-select-metadata .op-search-param {
+    margin-top: 1px;
+    margin-bottom: 1px;
+    display: flex;
+}
+
 /* Make sure first category search title text is vertically aligned with
    .op-menu-spinner */
 .op-menu-first-category {

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -215,7 +215,7 @@ so that both "Recent Announcements" and "Message" can be vertically aligned. */
     white-space: nowrap;
 }
 
-/* Group the magnifying glass and the value together in detail page. This will 
+/* Group the magnifying glass and the value together in detail page. This will
 make sure they always stay together when wrapping into a different line */
 #detail .op-detail-entry-values {
     display: inline-block;
@@ -277,7 +277,7 @@ to 100%, this will make the shrinking look smoother */
         width: 100%;
     }
 
-    /* Algin the Min/Max input tag when they are in different lines */
+    /* Align the Min/Max input tag when they are in different lines */
     .op-range-input-min {
         margin-left: 0.5rem;
     }
@@ -2710,7 +2710,7 @@ at the right of -- OR -- label. */
     }
 }
 
-/* Make sure label names & hints in wdigets have a caret cursor when users mouseover */
+/* Make sure label names & hints in widgets have a caret cursor when users mouseover */
 .op-choice-label-name,
 .op-hints-description,
 .op-hints-info {

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -373,8 +373,7 @@ to 100%, this will make the shrinking look smoother */
 
 /* Make sure triangle arrow is veritcally centered */
 .op-menu-triangle-group {
-    display: inline-flex;
-    align-items: center;
+    display: inline-block;
 }
 
 /* Hide the default bootstrap dropdown triangle arrow */

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -215,6 +215,12 @@ so that both "Recent Announcements" and "Message" can be vertically aligned. */
     white-space: nowrap;
 }
 
+/* Group the magnifying glass and the value together in detail page. This will 
+make sure they always stay together when wrapping into a different line */
+#detail .op-detail-entry-values {
+    display: inline-block;
+}
+
 #nav-sidebar {
     margin: 0;
     padding: 0;

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -168,6 +168,11 @@ so that both "Recent Announcements" and "Message" can be vertically aligned. */
     display: flex;
 }
 
+/* Spacing between (i) icon, and widget title text in search tab */
+#search .card-title i.fa-info-circle {
+    padding-right: 0.2rem;
+}
+
 #browse, #cart, #detail {
     padding: 0; margin:0;
     display: none;
@@ -2678,7 +2683,7 @@ at the right of -- OR -- label. */
     }
 }
 
-/* Make sure label names & hints in wdigets have a caret cursor when users mouseover. */
+/* Make sure label names & hints in wdigets have a caret cursor when users mouseover */
 .op-choice-label-name,
 .op-hints-description,
 .op-hints-info {
@@ -2686,13 +2691,13 @@ at the right of -- OR -- label. */
 }
 
 /* Make sure text in the menu align with text in the 1st line instead of (i) icon
-when wrapping into the 2nd line. */
+when wrapping into the 2nd line */
 .op-menu-item {
     display: flex;
     align-items: baseline;
 }
 
-/* Spacing between V, (i) icon, and text in the menu. */
+/* Spacing between V, (i) icon, and text in the menu */
 .op-menu-item i.fa-info-circle {
     padding-left: 0.2rem;
     padding-right: 0.2rem;

--- a/opus/application/static_media/js/menu.js
+++ b/opus/application/static_media/js/menu.js
@@ -69,6 +69,24 @@ var o_menu = {
             $("#sidebar").html(data.html);
             o_menu.markCurrentMenuItems();
             clearTimeout(spinnerTimer);
+
+            o_menu.wrapTriangleArrowAndLastWordOfMenuCategory("#search");
+        });
+    },
+
+    wrapTriangleArrowAndLastWordOfMenuCategory: function(tab) {
+        /**
+         * Wrap the last word of each menu category with triangle arrow. This is
+         * used to group the triangle arrow and the last word of category string,
+         * and make sure they will stay together when wrapped into a different
+         * line.
+         */
+        $.each($(`${tab} .op-submenu-category .title`), function(idx, category) {
+            let textArr = $(category).text().split(" ");
+            let lastWord = textArr.pop();
+            let lastWordWrappingGroup = `&nbsp;<span class="op-menu-triangle-group">${lastWord}` +
+                                        "<span class='op-menu-arrow'></span></span>";
+            $(category).html(textArr.join(" ") + lastWordWrappingGroup);
         });
     },
 

--- a/opus/application/static_media/js/menu.js
+++ b/opus/application/static_media/js/menu.js
@@ -84,7 +84,8 @@ var o_menu = {
         $.each($(`${tab} .op-submenu-category .title`), function(idx, category) {
             let textArr = $(category).text().split(" ");
             let lastWord = textArr.pop();
-            let lastWordWrappingGroup = `&nbsp;<span class="op-menu-triangle-group">${lastWord}` +
+            let spacing = textArr.length ? "&nbsp;" : "";
+            let lastWordWrappingGroup = `${spacing}<span class="op-menu-triangle-group">${lastWord}` +
                                         "<span class='op-menu-arrow'></span></span>";
             $(category).html(textArr.join(" ") + lastWordWrappingGroup);
         });

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -106,16 +106,22 @@ var o_search = {
         });
 
         // When clicking inside a widget body, if the clicked element is not input,
-        // select, hints, and text nodes, we will disable the default behavior of mousedown
-        // event. This will prevent input from focusing out when clicking on preprogrammed
-        // ranges dropdown, and also keep the ability to copy text & hints in mults
-        // and hints in ranges widgets.
+        // select, hints, text nodes, add input "+" icon, and remove input trash icon,
+        // we will disable the default behavior of mousedown event. This will prevent
+        // input from focusing out when clicking on preprogrammed ranges dropdown, and
+        // also keep the ability to copy text & hints in mults and hints in ranges
+        // widgets. This will also make sure input focus out to trigger a change event
+        // when clicking any add/remove input icon.
         $("#search").on("mousedown", ".widget .card-body", function(e) {
             if (!$(e.target).is("input") && !$(e.target).is("select") &&
                 !$(e.target).is("label") && !$(e.target).hasClass("hints") &&
                 !$(e.target).hasClass("op-hints-info") &&
                 !$(e.target).hasClass("op-hints-description") &&
-                !$(e.target).hasClass("op-choice-label-name")) {
+                !$(e.target).hasClass("op-choice-label-name") &&
+                !$(e.target).hasClass("op-remove-inputs-btn") &&
+                !$(e.target).hasClass("op-add-inputs-btn") &&
+                !$(e.target).parent(".op-remove-inputs-btn").length &&
+                !$(e.target).parent(".op-add-inputs-btn").length) {
                 e.preventDefault();
             }
         });

--- a/opus/application/static_media/js/selectMetadata.js
+++ b/opus/application/static_media/js/selectMetadata.js
@@ -163,6 +163,8 @@ var o_selectMetadata = {
                     o_menu.markMenuItem(`#op-select-metadata .op-all-metadata-column a[data-slug="${col}"]`);
                 });
 
+                o_menu.wrapTriangleArrowAndLastWordOfMenuCategory("#op-select-metadata");
+
                 // Prevent the same event handlers from being attached to #op-select-metadata
                 // for multiple times. This will avoid o_selectMetadata.render() and
                 // /opus/__fake/__selectmetadatamodal.json being called for multiple times when

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -326,7 +326,8 @@ var o_widgets = {
          * Make sure "+ (OR)" is attached to the right of last input set.
          * Display or hide the icon based on the number of input sets.
          */
-        $(`#widget__${slug} .op-search-inputs-set`).last().append(addInputIcon);
+        let lastInputSet = $(`#widget__${slug} .op-search-inputs-set`).last();
+        lastInputSet.find(".op-qtype-wrapping-group").append(addInputIcon);
         let numberOfInputSets = $(`#widget__${slug} .op-search-inputs-set`).length;
         if (numberOfInputSets === opus.maxAllowedInputSets) {
             $(`#widget__${slug} .op-add-inputs`).addClass("op-hide-element");
@@ -386,9 +387,9 @@ var o_widgets = {
             // to the first input set, and add remove icon to cloned input set, else we add "OR"
             // label to the last input set and remove "OR" label from cloned input set.
             if (firstExistingSetOfInputs.find(".op-remove-inputs").length === 0) {
-                firstExistingSetOfInputs.append(removeInputIcon);
+                firstExistingSetOfInputs.find(".op-qtype-wrapping-group").append(removeInputIcon);
                 firstExistingSetOfInputs.append(orLabel);
-                cloneInputs.append(removeInputIcon);
+                cloneInputs.find(".op-qtype-wrapping-group").append(removeInputIcon);
             } else {
                 lastExistingSetOfInputs.append(orLabel);
                 cloneInputs.find(".op-or-labels").remove();
@@ -1307,6 +1308,27 @@ var o_widgets = {
                     addInputIcon = $(`#widget__${slug} .op-add-inputs`).detach();
                 }
 
+                // Wrap (i) icon, qtype, and trash icon with a div. This will make sure these
+                // three elements stay together when browser gets narrow.
+                for (const eachInputSet of $(`#widget__${slug} .op-search-inputs-set`)) {
+                    let qtypeWrappingGroupClass = ".op-qtype-input, " +
+                                                  ".op-range-qtype-helper, " +
+                                                  ".op-remove-inputs, " +
+                                                  ".op-add-inputs";
+                    let qtypeWrappingGroup = $(eachInputSet).find(qtypeWrappingGroupClass);
+                    qtypeWrappingGroup.wrapAll("<li class='d-inline-block op-qtype-wrapping-group'/>");
+
+
+                    // Assign classes to the li of range min/max inputs. These classes will be used
+                    // to add the styling to group min/max with its corresponding input tag. This
+                    // will make sure min/max and its corresponding input stay together as a unit
+                    // when they move to a different line.
+                    let minInputList = $(eachInputSet).find(".op-range-input-min").parent();
+                    let maxInputList = $(eachInputSet).find(".op-range-input-max").parent();
+                    minInputList.addClass("op-range-input-min-list");
+                    maxInputList.addClass("op-range-input-max-list");
+                }
+
                 o_widgets.attachAddInputIcon(slug, addInputIcon);
 
                 let widgetInputSets = $(`#widget__${slug} .op-search-inputs-set`);
@@ -1327,26 +1349,6 @@ var o_widgets = {
                         return this.nodeType === 3;
                     }).wrap("<span class='op-choice-label-name'></span>");
                 }
-            }
-
-            // Wrap (i) icon, qtype, and trash icon with a div. This will make sure these
-            // three elements stay together when browser gets narrow.
-            for (const eachInputSet of $(`#widget__${slug} .op-search-inputs-set`)) {
-                let qtypeWrappingGroupClass = ".op-qtype-input, " +
-                                              ".op-range-qtype-helper, " +
-                                              ".op-remove-inputs";
-                let qtypeWrappingGroup = $(eachInputSet).find(qtypeWrappingGroupClass);
-                qtypeWrappingGroup.wrapAll("<li class='d-inline-block op-qtype-wrapping-group'/>");
-
-
-                // Assign classes to the li of range min/max inputs. These classes will be used
-                // to add the styling to group min/max with its corresponding input tag. This
-                // will make sure min/max and its corresponding input stay together as a unit
-                // when they move to a different line.
-                let minInputList = $(eachInputSet).find(".op-range-input-min").parent();
-                let maxInputList = $(eachInputSet).find(".op-range-input-max").parent();
-                minInputList.addClass("op-range-input-min-list");
-                maxInputList.addClass("op-range-input-max-list");
             }
 
             opus.widgetsDrawn.unshift(slug);

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -496,10 +496,10 @@ var o_widgets = {
 
             let slug = $(this).find(".op-remove-inputs-btn").data("slug");
             let addInputIcon = $(`#widget__${slug} .op-add-inputs`).detach();
-            let inputSetToBeDeleted = $(this).parent(".op-search-inputs-set");
+            let inputSetToBeDeleted = $(this).parents(".op-search-inputs-set");
 
-            let inputElement = $(this).parent(".op-search-inputs-set").find("input");
-            let qtypeElement = $(this).parent(".op-search-inputs-set").find("select");
+            let inputElement = $(this).parents(".op-search-inputs-set").find("input");
+            let qtypeElement = $(this).parents(".op-search-inputs-set").find("select");
             let slugNameFromInput = inputElement.attr("name");
             let trailingCounterString = o_utils.getSlugOrDataTrailingCounterStr(slugNameFromInput);
             let idx = trailingCounterString ? parseInt(trailingCounterString)-1 : 0;
@@ -1327,6 +1327,16 @@ var o_widgets = {
                         return this.nodeType === 3;
                     }).wrap("<span class='op-choice-label-name'></span>");
                 }
+            }
+
+            // Wrap (i) icon, qtype, and trash icon with a div. This will make sure these
+            // three elements stay together when browser gets narrow.
+            for (const eachInputSet of $(`#widget__${slug} .op-search-inputs-set`)) {
+                let qtypeWrappingGroupClass = ".op-qtype-input, " +
+                                              ".op-range-qtype-helper, " +
+                                              ".op-remove-inputs";
+                let qtypeWrappingGroup = $(eachInputSet).find(qtypeWrappingGroupClass);
+                qtypeWrappingGroup.wrapAll("<div class='d-inline-block op-qtype-wrapping-group'/>");
             }
 
             opus.widgetsDrawn.unshift(slug);

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -1336,7 +1336,17 @@ var o_widgets = {
                                               ".op-range-qtype-helper, " +
                                               ".op-remove-inputs";
                 let qtypeWrappingGroup = $(eachInputSet).find(qtypeWrappingGroupClass);
-                qtypeWrappingGroup.wrapAll("<div class='d-inline-block op-qtype-wrapping-group'/>");
+                qtypeWrappingGroup.wrapAll("<li class='d-inline-block op-qtype-wrapping-group'/>");
+
+
+                // Assign classes to the li of range min/max inputs. These classes will be used
+                // to add the styling to group min/max with its corresponding input tag. This
+                // will make sure min/max and its corresponding input stay together as a unit
+                // when they move to a different line.
+                let minInputList = $(eachInputSet).find(".op-range-input-min").parent();
+                let maxInputList = $(eachInputSet).find(".op-range-input-max").parent();
+                minInputList.addClass("op-range-input-min-list");
+                maxInputList.addClass("op-range-input-max-list");
             }
 
             opus.widgetsDrawn.unshift(slug);

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -327,7 +327,12 @@ var o_widgets = {
          * Display or hide the icon based on the number of input sets.
          */
         let lastInputSet = $(`#widget__${slug} .op-search-inputs-set`).last();
-        lastInputSet.find(".op-qtype-wrapping-group").append(addInputIcon);
+        if (lastInputSet.find(".op-qtype-wrapping-group").length > 0) {
+            lastInputSet.find(".op-qtype-wrapping-group").append(addInputIcon);
+        } else {
+            lastInputSet.append(addInputIcon);
+        }
+
         let numberOfInputSets = $(`#widget__${slug} .op-search-inputs-set`).length;
         if (numberOfInputSets === opus.maxAllowedInputSets) {
             $(`#widget__${slug} .op-add-inputs`).addClass("op-hide-element");
@@ -1308,27 +1313,6 @@ var o_widgets = {
                     addInputIcon = $(`#widget__${slug} .op-add-inputs`).detach();
                 }
 
-                // Wrap (i) icon, qtype, and trash icon with a div. This will make sure these
-                // three elements stay together when browser gets narrow.
-                for (const eachInputSet of $(`#widget__${slug} .op-search-inputs-set`)) {
-                    let qtypeWrappingGroupClass = ".op-qtype-input, " +
-                                                  ".op-range-qtype-helper, " +
-                                                  ".op-remove-inputs, " +
-                                                  ".op-add-inputs";
-                    let qtypeWrappingGroup = $(eachInputSet).find(qtypeWrappingGroupClass);
-                    qtypeWrappingGroup.wrapAll("<li class='d-inline-block op-qtype-wrapping-group'/>");
-
-
-                    // Assign classes to the li of range min/max inputs. These classes will be used
-                    // to add the styling to group min/max with its corresponding input tag. This
-                    // will make sure min/max and its corresponding input stay together as a unit
-                    // when they move to a different line.
-                    let minInputList = $(eachInputSet).find(".op-range-input-min").parent();
-                    let maxInputList = $(eachInputSet).find(".op-range-input-max").parent();
-                    minInputList.addClass("op-range-input-min-list");
-                    maxInputList.addClass("op-range-input-max-list");
-                }
-
                 o_widgets.attachAddInputIcon(slug, addInputIcon);
 
                 let widgetInputSets = $(`#widget__${slug} .op-search-inputs-set`);
@@ -1349,6 +1333,26 @@ var o_widgets = {
                         return this.nodeType === 3;
                     }).wrap("<span class='op-choice-label-name'></span>");
                 }
+            }
+
+            // Wrap (i) icon, qtype, and trash icon with a div. This will make sure these
+            // three elements stay together when browser gets narrow.
+            for (const eachInputSet of $(`#widget__${slug} .op-search-inputs-set`)) {
+                let qtypeWrappingGroupClass = ".op-qtype-input, " +
+                                              ".op-range-qtype-helper, " +
+                                              ".op-remove-inputs, " +
+                                              ".op-add-inputs";
+                let qtypeWrappingGroup = $(eachInputSet).find(qtypeWrappingGroupClass);
+                qtypeWrappingGroup.wrapAll("<li class='d-inline-block op-qtype-wrapping-group'/>");
+
+                // Assign classes to the li of range min/max inputs. These classes will be used
+                // to add the styling to group min/max with its corresponding input tag. This
+                // will make sure min/max and its corresponding input stay together as a unit
+                // when they move to a different line.
+                let minInputList = $(eachInputSet).find(".op-range-input-min").parent();
+                let maxInputList = $(eachInputSet).find(".op-range-input-max").parent();
+                minInputList.addClass("op-range-input-min-list");
+                maxInputList.addClass("op-range-input-max-list");
             }
 
             opus.widgetsDrawn.unshift(slug);

--- a/opus/application/test_api/test_results_api.py
+++ b/opus/application/test_api/test_results_api.py
@@ -325,7 +325,7 @@ class ApiResultsTests(TestCase, ApiTestHelper):
     def test__api_metadata2_vg_iss_2_s_c4360845_cols_opusid_html_private(self):
         "[test_results_api.py] /api/metadata_v2: vg-iss-2-s-c4360845 cols opusid html private"
         url = '/__api/metadata_v2/vg-iss-2-s-c4360845.html?cols=opusid'
-        expected = b'<ul class="op-detail-list">\n<li class="op-detail-entry">\n<i class="fas fa-info-circle op-detail-entry-icon" data-toggle="tooltip"\ntitle="A unique ID assigned to an observation by the Ring-Moon Systems Node of the PDS. The OPUS ID is useful for referencing specific observations in a mission-independent manner but should never be used outside of OPUS. To reference an observation outside of OPUS, use the Volume ID, Product ID, and/or Primary File Spec. Note: The format of the OPUS ID is not guaranteed to remain the same over time."></i>&nbsp;\n<div>\nOPUS ID: vg-iss-2-s-c4360845\n<a href="/opus/#/'
+        expected = b'<ul class="op-detail-list">\n<li class="op-detail-entry">\n<i class="fas fa-info-circle op-detail-entry-icon" data-toggle="tooltip"\ntitle="A unique ID assigned to an observation by the Ring-Moon Systems Node of the PDS. The OPUS ID is useful for referencing specific observations in a mission-independent manner but should never be used outside of OPUS. To reference an observation outside of OPUS, use the Volume ID, Product ID, and/or Primary File Spec. Note: The format of the OPUS ID is not guaranteed to remain the same over time."></i>&nbsp;\n<div>\nOPUS ID:&nbsp;\n<span class="op-detail-entry-values">vg-iss-2-s-c4360845\n<a href="/opus/#' 
         self._run_html_startswith(url, expected)
 
     def test__api_metadata_vg_iss_2_s_c4360845_cols_opusid_csv(self):


### PR DESCRIPTION
- Fixes #800 
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - Database used: opus3_test_200211
  - All Django tests pass: Y
- Were any JavaScript or CSS files modified? Y
  - JSHINT run on all affected files: Y
  - Tested on Chrome, Firefox, Safari, and iOS: Y
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:
- In search sidebar and metadata selector menu, when menu items start to wrap, make sure they are aligned with the text, not the (i) icon.
- In search tab, group qtype, (i) icon, and trash icon. They will move to a different line together when browser shrinks.
- In search widgets, group Min:/Max: and their corresponding input tags. Min:/Max: will stay together with their corresponding input tags when browser shrinks and they move to a different line.
- When search widget title starts to wrap, make sure it's aligned with the text instead of the (i) icon.
- In detail tab, group the value and the magnifying glass. They will move together to a different line when browser shrinks.
- Fixed the height of main nav bar when browser width changes.
  - Fixed in https://github.com/SETI/pds-opus/pull/970
- Help menu fit in the screen when browser height is small.
  - Fixed in #852 

Known problems:
- Note: In select metadata menu (different looks in UI):
  - To make the text aligned, we have to set .op-menu-item display to flex. Once this is done, the height of the span tag (.op-menu-item) will be a bit larger, and we have to add margin-top & bottom (1px for now) to create some spacing between each menu item. This will make the height of menu items larger than ones in production sites. 
  - In select metadata menu, when window is narrow, and if a menu item text is wrapped into the 2nd line, the highlighted background will cover the entire row for that menu item. (Match the behavior in search sidebar now) 