### PR TITLE
Discard changes can corrupt select metadata

### DIFF
--- a/opus/application/static_media/js/selectMetadata.js
+++ b/opus/application/static_media/js/selectMetadata.js
@@ -51,7 +51,7 @@ var o_selectMetadata = {
             // update the data table w/the new columns
             let currentCols = [];
             $("#op-select-metadata .op-selected-metadata-column > ul").find("li").each(function(index, obj) {
-                currentCols.push(obj.id.slice(9));
+                currentCols.push(obj.id.replace("cchoose__", ""));
             });
             if (!o_utils.areObjectsEqual(opus.prefs.cols, currentCols)) {
                 // only pop up the confirm modal if the user clicked the 'X' in the corner
@@ -233,9 +233,7 @@ var o_selectMetadata = {
 
     removeColumn: function(slug) {
         let menuSelector = `#op-select-metadata .op-all-metadata-column a[data-slug=${slug}]`;
-        if ($(`#op-select-metadata .op-all-metadata-column a[data-slug=${slug}]`).length > 0) {
-            o_menu.markMenuItem(menuSelector, "unselected");
-        }
+        o_menu.markMenuItem(menuSelector, "unselected");
 
         $(`#cchoose__${slug}`).fadeOut(200, function() {
             $(this).remove();
@@ -252,9 +250,7 @@ var o_selectMetadata = {
         // add them back in...
         $(opus.prefs.cols).each(function(index, slug) {
             let menuSelector = `#op-select-metadata .op-all-metadata-column a[data-slug=${slug}]`;
-            if ($(menuSelector).length > 0) {
-                o_menu.markMenuItem(menuSelector);
-            }
+            o_menu.markMenuItem(menuSelector);
         });
         $(o_selectMetadata.lastSavedSelected).each(function(index, selected) {
             $("#op-select-metadata .op-selected-metadata-column > ul").append(selected);
@@ -280,7 +276,7 @@ var o_selectMetadata = {
     updatePrefsCols: function() {
         opus.prefs.cols = [];
         $(o_selectMetadata.lastSavedSelected).each(function(index, obj) {
-            opus.prefs.cols.push(obj.id.slice(9));
+            opus.prefs.cols.push(obj.id.replace("cchoose__", ""));
         });
     },
 

--- a/opus/application/static_media/js/selectMetadata.js
+++ b/opus/application/static_media/js/selectMetadata.js
@@ -49,10 +49,10 @@ var o_selectMetadata = {
 
         $("#op-select-metadata").on("hide.bs.modal", function(e) {
             // update the data table w/the new columns
-            let currentCols = []
+            let currentCols = [];
             $("#op-select-metadata .op-selected-metadata-column > ul").find("li").each(function(index, obj) {
                 currentCols.push(obj.id.slice(9));
-            })
+            });
             if (!o_utils.areObjectsEqual(opus.prefs.cols, currentCols)) {
                 // only pop up the confirm modal if the user clicked the 'X' in the corner
                 if (clickedX) {
@@ -287,7 +287,7 @@ var o_selectMetadata = {
         opus.prefs.cols = [];
         $(o_selectMetadata.lastSavedSelected).each(function(index, obj) {
             opus.prefs.cols.push(obj.id.slice(9));
-        })
+        });
     },
 
     saveChanges: function() {

--- a/opus/application/static_media/js/selectMetadata.js
+++ b/opus/application/static_media/js/selectMetadata.js
@@ -159,6 +159,8 @@ var o_selectMetadata = {
                     o_menu.markMenuItem(`#op-select-metadata .op-all-metadata-column a[data-slug="${col}"]`);
                 });
 
+                o_menu.wrapTriangleArrowAndLastWordOfMenuCategory("#op-select-metadata");
+
                 // Prevent the same event handlers from being attached to #op-select-metadata
                 // for multiple times. This will avoid o_selectMetadata.render() and
                 // /opus/__fake/__selectmetadatamodal.json being called for multiple times when

--- a/opus/application/static_media/js/selectMetadata.js
+++ b/opus/application/static_media/js/selectMetadata.js
@@ -185,7 +185,6 @@ var o_selectMetadata = {
                     containment: "parent",
                     tolerance: "pointer",
                     stop: function(event, ui) {
-                        o_selectMetadata.metadataDragged(this);
                         o_selectMetadata.isSortingHappening = false;
                     },
                     start: function(event, ui) {
@@ -241,13 +240,6 @@ var o_selectMetadata = {
             if ($(".op-selected-metadata-column li").length <= 1) {
                 $(".op-selected-metadata-column .op-selected-metadata-unselect").hide();
             }
-        });
-    },
-
-    // columns can be reordered wrt each other in 'metadata selector' by dragging them
-    metadataDragged: function(element) {
-        let cols = $.map($(element).sortable("toArray"), function(item) {
-            return item.split("__")[1];
         });
     },
 

--- a/opus/application/static_media/js/selectMetadata.js
+++ b/opus/application/static_media/js/selectMetadata.js
@@ -19,7 +19,7 @@ var o_selectMetadata = {
     isSortingHappening: false,
 
     // save the original copy in case we need to discard
-    opusPrefsCols: opus.prefs.cols,
+    originalOpusPrefsCols: [],
 
     lastSavedSelected: [],
     lastMetadataMenuRequestNo: 0,
@@ -34,6 +34,7 @@ var o_selectMetadata = {
         $("#op-select-metadata").on("show.bs.modal", function(e) {
             // this is to make sure modal is back to it original position when open again
             $("#op-select-metadata .modal-dialog").css({top: 0, left: 0});
+            o_selectMetadata.saveOpusPrefsCols();
             o_selectMetadata.adjustHeight();
             o_browse.hideMenu();
             o_selectMetadata.render();
@@ -52,7 +53,7 @@ var o_selectMetadata = {
 
         $("#op-select-metadata").on("hide.bs.modal", function(e) {
             // update the data table w/the new columns
-            if (!o_utils.areObjectsEqual(opus.prefs.cols, o_selectMetadata.opusPrefsCols)) {
+            if (!o_utils.areObjectsEqual(opus.prefs.cols, o_selectMetadata.originalOpusPrefsCols)) {
                 // only pop up the confirm modal if the user clicked the 'X' in the corner
                 if (clickedX) {
                     clickedX = false;
@@ -202,8 +203,7 @@ var o_selectMetadata = {
                 }
                 // save the current selected metadata
                 o_selectMetadata.lastSavedSelected = $("#op-select-metadata .op-selected-metadata-column > ul").find("li");
-                o_selectMetadata.opusPrefsCols = [];
-                $.extend(o_selectMetadata.opusPrefsCols, opus.prefs.cols);
+                o_selectMetadata.saveOpusPrefsCols();
                 o_selectMetadata.adjustHeight();
                 o_selectMetadata.rendered = true;
                 o_selectMetadata.hideOrShowPS();
@@ -218,6 +218,11 @@ var o_selectMetadata = {
     reRender: function() {
         o_selectMetadata.rendered = false;
         o_selectMetadata.render();
+    },
+
+    saveOpusPrefsCols: function() {
+        o_selectMetadata.originalOpusPrefsCols = [];
+        $.extend(o_selectMetadata.originalOpusPrefsCols, opus.prefs.cols);
     },
 
     addColumn: function(slug) {
@@ -267,7 +272,7 @@ var o_selectMetadata = {
         $("#op-select-metadata .op-selected-metadata-column li").remove();
 
         opus.prefs.cols = [];
-        $.extend(opus.prefs.cols, o_selectMetadata.opusPrefsCols);
+        $.extend(opus.prefs.cols, o_selectMetadata.originalOpusPrefsCols);
 
         // add them back in...
         $(opus.prefs.cols).each(function(index, slug) {
@@ -278,7 +283,7 @@ var o_selectMetadata = {
             $("#op-select-metadata .op-selected-metadata-column > ul").append(selected);
         });
         $("#op-select-metadata .op-selected-metadata-column").find("li").show();
-        $("#op-select-metadata").modal('hide');
+        $("#op-select-metadata").modal("hide");
     },
 
     resetMetadata: function() {


### PR DESCRIPTION
- Fixes #967
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - Database used: opus3_test_200211
  - All Django tests pass: NA
- Were any JavaScript or CSS files modified? Y
  - JSHINT run on all affected files: Y
  - Tested on Chrome, Firefox, Safari, and iOS: Y
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:
-Only update opus.prefs.cols on user option for save;
-Save the selected list as array of 'li' html 
-On discard, replace the list of 'selected' li w/the saved/original list of li

Known problems:
