### PR TITLE
Fix the animated thumbnail box so it is in front of the thumbnail

### DIFF
--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2344,6 +2344,7 @@ ul.ui-autocomplete a.ui-state-active {
     opacity: 0.5;
     animation: hvr-ripple-in 1s infinite;
     -webkit-animation: hvr-ripple-in 1s infinite;
+    z-index: 9999;
 }
 
 /* Make sure ranges info div not splitting input min and max into two lines */


### PR DESCRIPTION
- Fixes #995 
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - Database used: opus3_test_200211
  - All Django tests pass: NA
- Were any JavaScript or CSS files modified? Y
  - JSHINT run on all affected files: NA
  - Tested on Chrome, Firefox, Safari, and iOS: Y
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:
changed the z-index so that the border is always on top

Known problems:
