### PR TITLE
983 improve mobile support

### DIFF
--- a/opus/application/apps/cart/templates/cart/cart.html
+++ b/opus/application/apps/cart/templates/cart/cart.html
@@ -32,9 +32,9 @@
                     </div>
                 </li>
             </div>
-            <h1>Download Options</h1>
+            <h1 class="op-download-options-title">Download Options</h1>
             <p class="m-0 mb-1">Select which product types to include in downloads:</p>
-            <div class="mb-3">
+            <div class="op-product-types-select-btn-group mb-3">
                 <button class="op-cart-select-all-btn btn btn-sm btn-primary
                     {% if count < 1 and recycled_count < 1  %}
                         op-button-disabled

--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -241,7 +241,7 @@
                     </div>
                 </div>
                 <div id="op-cart-download-panel" class="card">
-                    <div class="card-header align-items-center h-auto pb-0 bg-secondary">
+                    <div class="card-header align-items-center h-auto bg-secondary">
                         <h3 class="op-header-text"></h3>
                         <a class="close" aria-label="Close"><i class="far fa-times-circle fa-lg"></i></a>
                      </div>

--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -186,25 +186,27 @@
                                 </span>&nbsp;
                                 <ul class="sort-contents list-inline"></ul>
                             </div>
-                            <div class="op-cart-actions">
-                                <li class="list-inline-item">
-                                    <a href="#" class="text-info mr-3" data-toggle="modal" data-target="#op-empty-cart-modal" title="Remove all observations from the cart"><i class="fas fa-trash-alt"></i>
-                                        &nbsp;Empty Cart</a>
-                                </li>
-                                <li class="list-inline-item">
-                                    <a href="#" class="text-info mr-3" data-toggle="modal" data-target="#op-empty-recycle-bin-modal" title="Remove all observations from the recycle bin"><i class="fas fa-recycle"></i>
-                                        &nbsp;Empty Recycle Bin</a>
-                                </li>
-                                <li class="list-inline-item">
-                                    <a href="#" class="text-info" data-toggle="modal" data-target="#op-restore-recycle-bin-modal" title="Restore all observations from the recycle bin to the cart"><i class="fas fa-undo"></i>
-                                        &nbsp;Restore Recycle Bin to Cart&nbsp;<span id="op-recycled-count" class="badge badge-primary">0</span></a>
-                                </li>
-                            </div>
-                            <div class="op-cart-toggle-download-panel">
-                                <button type="button" class="op-cart-slide-download-panel btn btn-secondary btn-sm nav-link text-dark font-weight-bold p-1" title="Slide over download data panel">
-                                   <i class="fas fa-arrow-left"></i>
-                                   <span>&nbsp;Download Data</span>
-                               </button>
+                            <div class="op-cart-actions-group">
+                                <div class="op-cart-actions">
+                                    <li class="list-inline-item">
+                                        <a href="#" class="text-info mr-3" data-toggle="modal" data-target="#op-empty-cart-modal" title="Remove all observations from the cart"><i class="fas fa-trash-alt"></i>
+                                            &nbsp;Empty Cart</a>
+                                    </li>
+                                    <li class="list-inline-item">
+                                        <a href="#" class="text-info mr-3" data-toggle="modal" data-target="#op-empty-recycle-bin-modal" title="Remove all observations from the recycle bin"><i class="fas fa-recycle"></i>
+                                            &nbsp;Empty Recycle Bin</a>
+                                    </li>
+                                    <li class="list-inline-item">
+                                        <a href="#" class="text-info" data-toggle="modal" data-target="#op-restore-recycle-bin-modal" title="Restore all observations from the recycle bin to the cart"><i class="fas fa-undo"></i>
+                                            &nbsp;Restore Recycle Bin to Cart&nbsp;<span id="op-recycled-count" class="badge badge-primary">0</span></a>
+                                    </li>
+                                </div>
+                                <div class="op-cart-toggle-download-panel">
+                                    <button type="button" class="op-cart-slide-download-panel btn btn-secondary btn-sm nav-link text-dark font-weight-bold p-1" title="Slide over download data panel">
+                                       <i class="fas fa-arrow-left"></i>
+                                       <span>&nbsp;Download Data</span>
+                                   </button>
+                                </div>
                             </div>
                         </nav>
                         <div class="panel-body gallery-contents flex-container">

--- a/opus/application/static_media/coreui/css/style.css
+++ b/opus/application/static_media/coreui/css/style.css
@@ -14169,4 +14169,3 @@ body {
   breakpoint-lg: 992px;
   breakpoint-xl: 1200px;
 }
-/*# sourceMappingURL=style.css.map */

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -155,6 +155,8 @@ so that both "Recent Announcements" and "Message" can be vertically aligned. */
     /* Make the whole search page shrink proportionally when window
     is narrower */
     width: 100%;
+    /* Make sure search tab will not scroll horizontally */
+    overflow-x: hidden;
 }
 
 #search .add_input {

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2783,18 +2783,18 @@ when wrapping into the 2nd line */
 
     /* Shrink the height of main nav */
     #op-main-nav {
-        padding-top: 3px;
-        padding-bottom: 3px;
+        padding-top: 0.3em;
+        padding-bottom: 0.3em;
     }
 
     /* Reduce the padding around selected tab on main nav */
     #op-main-nav .nav-link {
-        padding: 0.25rem;
+        padding: 0.4em;
     }
 
     /* Reduce the hamburger icon on main nav */
     #op-main-nav .navbar-toggler {
-        padding: 0.1rem 0.6rem;
+        padding: 0.1em 0.6em;
     }
 
     /* Remove the top margin to make reset buttons horizontally centered */
@@ -2805,16 +2805,16 @@ when wrapping into the 2nd line */
     /* Reduce the space around search sidebar & widgets when screen narrow
     (search tab) */
     #search {
-        padding-left: 0.25rem;
-        padding-right: 0.25rem;
-        padding-top: 0.25rem;
-        padding-bottom: 0.5rem;
+        padding-left: 0.25em;
+        padding-right: 0.25em;
+        padding-top: 0.25em;
+        padding-bottom: 0.5em;
     }
 
     /* Expand the width of widgets area when screen is narrow (search tab) */
     #search .op-widget-col {
-        padding-left: 5px;
-        padding-right: 5px;
+        padding-left: 0.3em;
+        padding-right: 0.3em;
     }
 
     /* Reduce widget title font-size to 75% */
@@ -2824,10 +2824,7 @@ when wrapping into the 2nd line */
 
     /* Reduce the padding around widget header */
     #widget-container .card-header {
-        padding-left: 0.75rem;
-        padding-right: 0.75rem;
-        padding-top: 0.25rem;
-        padding-bottom: 0.25rem;
+        padding: 0.25em 0.75em;
     }
 
     #widget-container .card-title {
@@ -2836,7 +2833,7 @@ when wrapping into the 2nd line */
 
     /* Reduce the spaces between each widget */
     #widget-container .card {
-        margin-bottom: 0.75rem;
+        margin-bottom: 0.75em;
     }
 
 }
@@ -2862,7 +2859,7 @@ when wrapping into the 2nd line */
     /* Shrink the modal header, modal body, and modal footer when screen is
     narrow or short (confirm modal) */
     .modal-header, .modal-body, .modal-footer {
-        padding: 0.25rem 0.5rem !important;
+        padding: 0.25em 0.5em !important;
     }
 
     /* Keep the spaces for detail metadata modal in browse & cart tab to have
@@ -2870,7 +2867,7 @@ when wrapping into the 2nd line */
     #galleryView .modal-header,
     #galleryView .modal-body,
     #galleryView .modal-footer {
-        padding: 1rem !important;
+        padding: 1.3em !important;
     }
 
     /* Reduce the size of font awesome icon in slide show */
@@ -2958,7 +2955,7 @@ when wrapping into the 2nd line */
     }
 
     .op-cart-actions a {
-        margin-right: 0.5rem !important;
+        margin-right: 0.5em !important;
     }
 }
 
@@ -2972,8 +2969,8 @@ when wrapping into the 2nd line */
     /* Reduce the spaces between each item in the hamburger menu when screen is
     short */
     #op-obs-menu .dropdown-item {
-        padding-top: 1px;
-        padding-bottom: 1px;
+        padding-top: 0.1em;
+        padding-bottom: 0.1em;
     }
 
     /* Reduce spaces between each item in the help menu when screen is short */
@@ -3062,7 +3059,7 @@ when screen is narrow (cart tab) */
     /* Make observation detail area shrinkable when screen is short & narrow
     (detail tab) */
     .op-detail-metadata {
-        padding-right: 1rem !important;
+        padding-right: 1em !important;
         min-width: 100%;
     }
 
@@ -3075,9 +3072,9 @@ when screen is narrow (cart tab) */
 
     /* Reduce the spaces around detail tab when screen is short & narrow */
     #detail {
-        padding-top: 1rem;
-        padding-bottom: 1rem;
-        padding-left: 1rem;
-        padding-right: 1rem;
+        padding-top: 1em;
+        padding-bottom: 1em;
+        padding-left: 1em;
+        padding-right: 1em;
     }
 }

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -1032,20 +1032,21 @@ when window sized is narrow */
 #galleryViewContents .op-metadata-details {
     overflow-y: auto;
     /* Make #galleryView modal right contents shrink vertically
-    95% for the metadata info, 5% for the bottom icons */
-    height: 95%;
+    93% for the metadata info, 5% for the bottom icons, 2% for the gap between
+    metadata and font awesome icons */
+    height: 90%;
     width: 100%;
     /* make ps stick to the right of the modal when screen is resizing */
     position: absolute;
     right: 0;
 }
 
-@media (max-height: 300px) {
+@media (max-height: 400px) {
     #galleryViewContents .op-metadata-details {
         height: 85%;
     }
     #galleryView .bottom {
-        height: 15%;
+        height: 5%;
     }
 }
 
@@ -1376,7 +1377,7 @@ to stay in one line */
 
     /* Move the last item in flexbox to the 2nd line */
     #browse .browse-nav-container .navbar-nav {
-        flex-wrap: wrap;
+        /* flex-wrap: wrap; */
         width: 100%;
     }
 
@@ -2789,7 +2790,7 @@ when wrapping into the 2nd line */
 
     /* Reduce the padding around selected tab on main nav */
     #op-main-nav .nav-link {
-        padding: 0.4em;
+        padding: 0.25rem;
     }
 
     /* Reduce the hamburger icon on main nav */
@@ -2805,10 +2806,10 @@ when wrapping into the 2nd line */
     /* Reduce the space around search sidebar & widgets when screen narrow
     (search tab) */
     #search {
-        padding-left: 0.25em;
-        padding-right: 0.25em;
-        padding-top: 0.25em;
-        padding-bottom: 0.5em;
+        padding-left: 0.5rem;
+        padding-right: 0.25rem;
+        padding-top: 0.25rem;
+        padding-bottom: 0.5rem;
     }
 
     /* Expand the width of widgets area when screen is narrow (search tab) */
@@ -2836,6 +2837,28 @@ when wrapping into the 2nd line */
         margin-bottom: 0.75em;
     }
 
+    /* Reduce the font-size of category headers to 75% */
+    /* Original font-size 2.1875rem */
+    .op-detail-metadata h1 {
+        font-size: 1.64rem;
+    }
+
+    /* Original font-size 1.75rem */
+    .op-detail-metadata h2 {
+        font-size: 1.3125rem;
+    }
+
+    /* Original font-size 1.53125rem */
+    .op-detail-metadata h3 {
+        font-size: 1.15rem;
+    }
+
+    /* Reduce the size of zoom-in mini-thumbnail on hover */
+    .op-mini-thumbnail img:hover {
+        -ms-transform: scale(2.5); /* IE 9 */
+        -webkit-transform: scale(2.5); /* Safari 3-8 */
+        transform: scale(2.5);
+    }
 }
 
 @media (max-width: 700px), (max-height: 630px) {
@@ -2915,6 +2938,15 @@ when wrapping into the 2nd line */
     /* Reduce the size of "Metadata CSV" button */
     .op-download-csv {
         padding: 0.175em 0.55em;
+    }
+}
+
+@media (max-width: 700px) {
+    /* Position "Download CSV (all results)" button right above the modal footer
+    when screen is narrow */
+    #op-select-metadata .op-download-csv {
+        margin-top: 0.1em;
+        bottom: auto;
     }
 }
 

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2010,13 +2010,6 @@ to the left pane when screen is getting too wide */
     max-width: 1800px;
 }
 
-@media (max-width: 768px) {
-    /* Move the detail image on top of the left pane */
-    .op-detail-content {
-        flex-wrap: wrap-reverse;
-    }
-}
-
 @media (max-width: 767px) {
     /* Set detail image size when it's above the left pane */
     .op-detail-img img {
@@ -2772,6 +2765,7 @@ when wrapping into the 2nd line */
     padding-right: 0.2rem;
 }
 
+/* The followings are for mobile support (width: 550px and height: 270px) */
 @media (max-width: 580px) {
     /* Need to use !important here so that the footer (inside a flex container)
     will not take up the space when hidden */
@@ -2798,7 +2792,8 @@ when wrapping into the 2nd line */
         padding-bottom: 3.5px;
     }
 
-    /* Reduce the space around search sidebar & widgets when screen narrow */
+    /* Reduce the space around search sidebar & widgets when screen narrow
+    (search tab) */
     #search {
         padding-left: 0.25rem;
         padding-right: 0.25rem;
@@ -2806,7 +2801,7 @@ when wrapping into the 2nd line */
         padding-bottom: 0.5rem;
     }
 
-    /* Expand the width of widgets area when screen is narrow */
+    /* Expand the width of widgets area when screen is narrow (search tab) */
     #search .op-widget-col {
         padding-left: 5px;
         padding-right: 5px;
@@ -2819,27 +2814,27 @@ when wrapping into the 2nd line */
         display: none !important;
     }
 
-    /* Hide download zip buttons in download data panel */
+    /* Hide download zip buttons in download data panel (cart tab) */
     #create_zip_url_file, #create_zip_data_file {
         display: none !important;
     }
 }
 
 @media (max-width: 580px), (max-height: 400px) {
-    /* Shrink the modal header when screen is narrow or short */
+    /* Shrink the modal header when screen is narrow or short (confirm modal) */
     .modal-header {
         padding: 0.25rem !important;
     }
 
-    /* Reduce the space between "Download Options" download panel when screen is
-    narrow or short */
-    .op-download-options-header > h1 {
+    /* Reduce the top & bottom spaces around "Download Options" in download panel
+    when screen is narrow or short (cart tab) */
+    .op-download-options-title {
         margin-top: 0;
         margin-bottom: 0;
     }
 
-    /* Reduce the space around data in download panel when screen is narrow or
-    short */
+    /* Reduce the space around card body in download panel when screen is narrow
+    or short (cart tab) */
     #op-cart-download-panel .card-body {
         padding-top: 0.5rem;
         padding-left: 0.5rem;
@@ -2847,7 +2842,7 @@ when wrapping into the 2nd line */
     }
 
     /* Reduce the space around "Download Data" in download panel when screen is
-    narrow or short */
+    narrow or short (cart tab) */
     #op-cart-download-panel .card-header {
         padding-top: 0.25rem;
         padding-bottom: 0.25rem;
@@ -2855,29 +2850,77 @@ when wrapping into the 2nd line */
         padding-right: 0.75rem;
     }
 }
+@media (max-width: 580px) and (max-height: 400px) {
+    /* Shrink the table header font size to have a better table display when
+    screen is narrow & short (browse/cart tab) */
+    .op-data-table-view thead {
+        font-size: 75%;
+    }
+}
 
 @media (max-height: 400px) {
-    /* Hide download csv button menu in select metadata menu when screen is short */
+    /* Hide download csv button menu in select metadata menu when screen is short
+    (browse tab) */
     .op-select-metadata-details .op-download-csv {
         display: none !important;
     }
 
-    /* Hide product type select/deselect buttons when screen is short */
+    /* Hide product type select/deselect buttons when screen is short (cart tab) */
     .op-product-types-select-btn-group {
         display: none !important;
     }
 
-    /* Hide "Download Options" when screen is short */
+    /* Hide "Download Options" in download panel when screen is short (cart tab) */
     .op-download-options-title {
         display: none !important;
     }
+
+
 }
 
 /* Bypass .col-sm-1 breakpoint to have pretty table display in download panel
-when screen is narrow */
+when screen is narrow (cart tab) */
 @media (max-width: 576px) {
     .op-product-type-table-body .row .col-sm-1 {
         flex: 0 0 8.333333% !important;
         max-width: 8.333333% !important;
+    }
+}
+
+@media (max-width: 768px) {
+    /* Move the detail image on top of the left pane */
+    .op-detail-content {
+        flex-wrap: wrap-reverse;
+    }
+}
+
+@media (max-height: 400px) {
+    /* Keep detail image stay at the right of the page when screen is narrow
+    (detail tab) */
+    .op-detail-content {
+        flex-wrap: nowrap;
+    }
+}
+
+@media (max-width: 768px) and (max-height: 400px) {
+    /* Make observation detail area shrinkable when screen is short & narrow
+    (detail tab) */
+    .op-detail-metadata {
+        padding-right: 1rem !important;
+        min-width: 100%;
+    }
+
+    /* Make observation detail area take up 70% of width and image take up 30%
+    when screen is short & narrow (detail tab) */
+    .op-detail-metadata-container {
+        flex: 1 0 70%;
+    }
+
+    /* Reduce the spaces around detail tab when screen is short & narrow */
+    #detail {
+        padding-top: 1rem;
+        padding-bottom: 1rem;
+        padding-left: 1rem;
+        padding-right: 1rem;
     }
 }

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -1054,7 +1054,9 @@ when window sized is narrow */
 #galleryView {
     overflow-y: hidden;
     pointer-events: none;
-    z-index: 999;
+    /* Make sure metadata modal will not be covered by the main nav when screen
+    is short & narrow */
+    z-index: 1031;
 }
 
 #galleryView button.close {
@@ -2766,7 +2768,7 @@ when wrapping into the 2nd line */
 }
 
 /* The followings are for mobile support (width: 550px and height: 270px) */
-@media (max-width: 580px) {
+@media (max-width: 580px), (max-height: 400px){
     /* Need to use !important here so that the footer (inside a flex container)
     will not take up the space when hidden */
     .app-footer {
@@ -2850,6 +2852,7 @@ when wrapping into the 2nd line */
         padding-right: 0.75rem;
     }
 }
+
 @media (max-width: 580px) and (max-height: 400px) {
     /* Shrink the table header font size to have a better table display when
     screen is narrow & short (browse/cart tab) */
@@ -2900,6 +2903,11 @@ when screen is narrow (cart tab) */
     .op-detail-content {
         flex-wrap: nowrap;
     }
+}
+
+/* Make sure image always stays at the left in metadata modal */
+#galleryViewContents .row {
+    flex-wrap: nowrap !important;
 }
 
 @media (max-width: 768px) and (max-height: 400px) {

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2774,11 +2774,36 @@ when wrapping into the 2nd line */
     }
 
     body {
-        font-size: 80% !important;
+        font-size: 75% !important;
     }
 
     .op-reset-search, .op-reset-search-metadata {
         font-size: 90% !important;
+    }
+
+    /*  Make sure main nav tabs are displayed horizontally when screen is narrow */
+    .op-tab {
+        flex-direction: row !important;
+    }
+
+    /* Shrink the height of main nav */
+    #op-main-nav {
+        padding-top: 3.5px;
+        padding-bottom: 3.5px;
+    }
+
+    /* Reduce the space around search sidebar & widgets when screen narrow */
+    #search {
+        padding-left: 0.25rem;
+        padding-right: 0.25rem;
+        padding-top: 0.25rem;
+        padding-bottom: 0.5rem;
+    }
+
+    /* Expand the width of widgets area when screen is narrow */
+    #search .op-widget-col {
+        padding-left: 0;
+        padding-right: 0;
     }
 }
 
@@ -2789,25 +2814,6 @@ when wrapping into the 2nd line */
     }
 }
 
-@media (max-width: 575px) {
-    /*  Make sure main nav tabs are displayed horizontally when screen is narrow */
-    .op-tab {
-        flex-direction: row !important;
-    }
-}
-
 @media (min-width: 576px){
 
-}
-
-.op-main-nav-tabs-toggler {
-    /* color: rgba(255, 255, 255, 0.5);
-    border-color: rgba(255, 255, 255, 0.1)
-    padding: 0.25rem 0.75rem;
-    font-size: 1.09375rem;
-    line-height: 1;
-    background-color: transparent;
-    border: 1px solid transparent;
-    border-radius: 0.25rem;
-    cursor: pointer; */
 }

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -1,7 +1,6 @@
 /* opus-specific values live here... */
 :root {
     --op-cart-panel-width-break: 1100px;
-    --op-cart-panel-height-break: 460px;
 }
 
 body {
@@ -1534,13 +1533,6 @@ to stay in one line */
     }
 }
 
-@media (max-height: 460px) {
-    /* Hide download data pane when the screen is too short */
-    .cart_details {
-        display: none;
-    }
-}
-
 @media (max-width: 1100px) {
     /* Hide download data pane when the screen is too narrow */
     .cart_details {
@@ -1573,7 +1565,8 @@ to stay in one line */
 
 /* Remove the nav-link for opening up download data panel when screen
 is wide enough */
-@media (min-width: 1101px) and (min-height: 461px) {
+/* @media (min-width: 1101px) and (min-height: 461px) { */
+@media (min-width: 1101px) {
     .op-cart-toggle-download-panel {
         display: none !important;
     }
@@ -2854,6 +2847,11 @@ when wrapping into the 2nd line */
         display: none !important;
     }
 
+    /* Hide contact us when screen is narrow or short */
+    .op-help-item[data-action="contact"] {
+        display: none !important;
+    }
+
     /* Hide download zip buttons in download data panel (cart tab) */
     #create_zip_url_file, #create_zip_data_file {
         display: none !important;
@@ -2900,18 +2898,26 @@ when wrapping into the 2nd line */
     /* Reduce the space around card body in download panel when screen is narrow
     or short (cart tab) */
     #op-cart-download-panel .card-body {
-        padding-top: 0.5rem;
-        padding-left: 0.5rem;
-        padding-bottom: 0.5rem;
+        padding-top: 0.5em;
+        padding-left: 0.5em;
+        padding-bottom: 0.5em;
     }
 
     /* Reduce the space around "Download Data" in download panel when screen is
     narrow or short (cart tab) */
     #op-cart-download-panel .card-header {
-        padding-top: 0.25rem;
-        padding-bottom: 0.25rem;
-        padding-left: 0.75rem;
-        padding-right: 0.75rem;
+        padding-top: 0.25em 0.75em;
+    }
+
+    /* Reduce the space around "Download Data" in download pane */
+    .op-download-panel-title h1 {
+        margin-top: 0.25em;
+        margin-bottom: 0.25em;
+    }
+
+    /* Reduce the size of "Metadata CSV" button */
+    .op-download-csv {
+        padding: 0.175em 0.55em;
     }
 }
 

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -1604,6 +1604,12 @@ panel are properly separated */
     justify-content: space-between;
 }
 
+/* Center "Download Data" in download panel in cart tab */
+#op-cart-download-panel .card-header h3,
+#op-cart-download-panel .card-header h2 {
+    margin-bottom: 0;
+}
+
 .op-sort-order-container {
     display: inline-flex;
     padding-left: 0.5em;
@@ -2766,7 +2772,7 @@ when wrapping into the 2nd line */
     padding-right: 0.2rem;
 }
 
-@media (max-width: 575px) {
+@media (max-width: 580px) {
     /* Need to use !important here so that the footer (inside a flex container)
     will not take up the space when hidden */
     .app-footer {
@@ -2807,23 +2813,71 @@ when wrapping into the 2nd line */
     }
 }
 
-@media (max-width: 575px), (max-height: 630px) {
+@media (max-width: 580px), (max-height: 630px) {
     /* Hide the feedback button when screen is narrow or short */
     .feedbackTab {
         display: none !important;
     }
+
+    /* Hide download zip buttons in download data panel */
+    #create_zip_url_file, #create_zip_data_file {
+        display: none !important;
+    }
 }
 
-@media (max-width: 575px), (max-height: 400px) {
+@media (max-width: 580px), (max-height: 400px) {
     /* Shrink the modal header when screen is narrow or short */
     .modal-header {
         padding: 0.25rem !important;
     }
+
+    /* Reduce the space between "Download Options" download panel when screen is
+    narrow or short */
+    .op-download-options-header > h1 {
+        margin-top: 0;
+        margin-bottom: 0;
+    }
+
+    /* Reduce the space around data in download panel when screen is narrow or
+    short */
+    #op-cart-download-panel .card-body {
+        padding-top: 0.5rem;
+        padding-left: 0.5rem;
+        padding-bottom: 0.5rem;
+    }
+
+    /* Reduce the space around "Download Data" in download panel when screen is
+    narrow or short */
+    #op-cart-download-panel .card-header {
+        padding-top: 0.25rem;
+        padding-bottom: 0.25rem;
+        padding-left: 0.75rem;
+        padding-right: 0.75rem;
+    }
 }
 
-@media (max-height: 400px){
+@media (max-height: 400px) {
     /* Hide download csv button menu in select metadata menu when screen is short */
     .op-select-metadata-details .op-download-csv {
         display: none !important;
+    }
+
+    /* Hide product type select/deselect buttons when screen is short */
+    .op-product-types-select-btn-group {
+        display: none !important;
+    }
+
+    /* Hide "Download Options" when screen is short */
+    .op-download-options-title {
+        display: none !important;
+    }
+}
+
+/* Bypass .col-sm-1 breakpoint to have pretty table display in download panel
+when screen is narrow */
+@media (max-width: 576px) {
+    .op-product-type-table-body .row .col-sm-1 {
+        flex: 0 0 8.333333% !important;
+        max-width: 8.333333% !important;
     }
 }

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2939,14 +2939,14 @@ when wrapping into the 2nd line */
     in help panel when screen is narrow or short */
     #op-cart-download-panel .card-header,
     #op-help-panel .card-header {
-        padding: 0.35em 0.75em;
+        padding: 0.5em 0.75em;
     }
 
     /* Shrink the font size of "Download Data" in download panel & the header text
-    in help panel to 90% when screen is narrow or short */
+    in help panel to 75% when screen is narrow or short */
     #op-cart-download-panel .op-header-text h2,
     #op-help-panel .op-header-text h2  {
-        font-size: 90%;
+        font-size: 75%;
     }
 
     /* Shrink "x" icon in download & help panel when screen is narrow or short */

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2766,7 +2766,7 @@ when wrapping into the 2nd line */
 }
 
 /* The followings are for mobile support (width: 550px and height: 270px) */
-@media (max-width: 580px), (max-height: 400px){
+@media (max-width: 700px), (max-height: 400px){
     /* Need to use !important here so that the footer (inside a flex container)
     will not take up the space when hidden */
     .app-footer {
@@ -2804,6 +2804,11 @@ when wrapping into the 2nd line */
         padding: 0.1rem 0.6rem;
     }
 
+    /* Remove the top margin to make reset buttons horizontally centered */
+    .op-reset-button button {
+        margin-top: 0;
+    }
+
     /* Reduce the space around search sidebar & widgets when screen narrow
     (search tab) */
     #search {
@@ -2817,6 +2822,11 @@ when wrapping into the 2nd line */
     #search .op-widget-col {
         padding-left: 5px;
         padding-right: 5px;
+    }
+
+    /* Reduce widget title font-size to 75% */
+    .op-widget-title {
+        font-size: 75%;
     }
 
     /* Reduce the padding around widget header */
@@ -2838,7 +2848,7 @@ when wrapping into the 2nd line */
 
 }
 
-@media (max-width: 580px), (max-height: 630px) {
+@media (max-width: 700px), (max-height: 630px) {
     /* Hide the feedback button when screen is narrow or short */
     .feedbackTab {
         display: none !important;
@@ -2850,7 +2860,7 @@ when wrapping into the 2nd line */
     }
 }
 
-@media (max-width: 580px), (max-height: 400px) {
+@media (max-width: 700px), (max-height: 400px) {
     /* Shrink the modal header, modal body, and modal footer when screen is
     narrow or short (confirm modal) */
     .modal-header, .modal-body, .modal-footer {
@@ -2910,7 +2920,7 @@ when wrapping into the 2nd line */
     align-items: center !important;
 }
 
-@media (max-width: 580px) and (max-height: 400px) {
+@media (max-width: 700px) and (max-height: 400px) {
     /* Shrink the table header font size to have a better table display when
     screen is narrow & short (browse/cart tab) */
     .op-data-table-view thead {

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -261,7 +261,6 @@ Not sure if this is the desired behavior
 /* As long as q-type shrink to the 2nd line, we set text input width
 to 100%, this will make the shrinking look smoother */
 @media (max-width: 940px) {
-/* @media (max-width: 970px) { */
     /* Make STRING input shrink proportionally when window is narrow */
     #op-search-widgets input[class~="STRING"] {
         width: 100%;
@@ -1373,7 +1372,6 @@ to stay in one line */
 
     /* Move the last item in flexbox to the 2nd line */
     #browse .browse-nav-container .navbar-nav {
-        /* flex-wrap: wrap; */
         width: 100%;
     }
 
@@ -1562,7 +1560,6 @@ to stay in one line */
 
 /* Remove the nav-link for opening up download data panel when screen
 is wide enough */
-/* @media (min-width: 1101px) and (min-height: 461px) { */
 @media (min-width: 1101px) {
     .op-cart-toggle-download-panel {
         display: none !important;
@@ -2381,7 +2378,8 @@ ul.ui-autocomplete a.ui-state-active {
     -webkit-transform: perspective(1px) translateZ(0);
     transform: perspective(1px) translateZ(0);
     position: relative;
-    z-index: 20;
+    /* Avoid overlapping with table header (z-index: 10) */
+    z-index: 9;
 }
 
 .hvr-ripple-in::before {
@@ -2759,15 +2757,21 @@ when wrapping into the 2nd line */
 }
 
 /* The followings are for mobile support (width: 550px and height: 270px) */
-@media (max-width: 700px), (max-height: 400px){
+@media (max-width: 700px), (max-height: 400px) {
+    body {
+        font-size: 75% !important;
+    }
+
     /* Need to use !important here so that the footer (inside a flex container)
     will not take up the space when hidden */
     .app-footer {
         display: none !important;
     }
 
-    body {
-        font-size: 75% !important;
+    /* When footer is gone, make sure range select info box at the lower left
+    corner has the proper height */
+    .op-range-select-info-box.op-range-select {
+        height: 1.6em;
     }
 
     /* Reduce the thumbnail container from 100x100 to 90x90 (10% off) when font

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2765,3 +2765,33 @@ when wrapping into the 2nd line */
     padding-left: 0.2rem;
     padding-right: 0.2rem;
 }
+
+@media (max-width: 600px) {
+    /* Need to use !important here so that the footer (inside a flex container)
+    will not take up the space when hidden */
+    .app-footer {
+        display: none !important;
+    }
+}
+
+@media (max-width: 575px) {
+    .op-tab {
+        flex-direction: row !important;
+    }
+}
+
+@media (min-width: 576px){
+
+}
+
+.op-main-nav-tabs-toggler {
+    /* color: rgba(255, 255, 255, 0.5);
+    border-color: rgba(255, 255, 255, 0.1)
+    padding: 0.25rem 0.75rem;
+    font-size: 1.09375rem;
+    line-height: 1;
+    background-color: transparent;
+    border: 1px solid transparent;
+    border-radius: 0.25rem;
+    cursor: pointer; */
+}

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -1047,20 +1047,11 @@ when window sized is narrow */
     /* Make #galleryView modal right contents shrink vertically
     93% for the metadata info, 5% for the bottom icons, 2% for the gap between
     metadata and font awesome icons */
-    height: 90%;
+    height: 93%;
     width: 100%;
     /* make ps stick to the right of the modal when screen is resizing */
     position: absolute;
     right: 0;
-}
-
-@media (max-height: 400px) {
-    #galleryViewContents .op-metadata-details {
-        height: 85%;
-    }
-    #galleryView .bottom {
-        height: 5%;
-    }
 }
 
 /* prevent weird browser y-scrollbar */
@@ -2884,7 +2875,7 @@ when wrapping into the 2nd line */
     }
 }
 
-@media (max-width: 700px), (max-height: 630px) {
+@media (max-width: 560px), (max-height: 630px) {
     /* Hide the feedback button when screen is narrow or short */
     .feedbackTab {
         display: none !important;
@@ -2892,11 +2883,6 @@ when wrapping into the 2nd line */
 
     /* Hide contact us when screen is narrow or short */
     .op-help-item[data-action="contact"] {
-        display: none !important;
-    }
-
-    /* Hide download zip buttons in download data panel (cart tab) */
-    #create_zip_url_file, #create_zip_data_file {
         display: none !important;
     }
 }
@@ -2958,8 +2944,11 @@ when wrapping into the 2nd line */
         margin-bottom: 0.25em;
     }
 
-    /* Reduce the size of "Metadata CSV" button */
-    .op-download-csv {
+    /* Reduce the size of "Metadata CSV", "Data Archive", and "URL Archive"
+    buttons */
+    .op-download-csv,
+    #create_zip_url_file a,
+    #create_zip_data_file a {
         padding: 0.175em 0.55em;
     }
 }
@@ -3108,6 +3097,12 @@ when screen is narrow (cart tab) */
 /* Make sure image always stays at the left in metadata modal */
 #galleryViewContents .row {
     flex-wrap: nowrap !important;
+}
+
+/* Make sure bottom icons will be vertically centered in metadata modal in
+different browsers */
+#galleryViewContents .bottom {
+    align-items: stretch;
 }
 
 @media (max-width: 768px) and (max-height: 400px) {

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2935,10 +2935,24 @@ when wrapping into the 2nd line */
         padding-bottom: 0.5em;
     }
 
-    /* Reduce the space around "Download Data" in download panel when screen is
-    narrow or short (cart tab) */
-    #op-cart-download-panel .card-header {
-        padding: 0.25em 0.75em;
+    /* Reduce the space around "Download Data" in download panel & the header text
+    in help panel when screen is narrow or short */
+    #op-cart-download-panel .card-header,
+    #op-help-panel .card-header {
+        padding: 0.35em 0.75em;
+    }
+
+    /* Shrink the font size of "Download Data" in download panel & the header text
+    in help panel to 90% when screen is narrow or short */
+    #op-cart-download-panel .op-header-text h2,
+    #op-help-panel .op-header-text h2  {
+        font-size: 90%;
+    }
+
+    /* Shrink "x" icon in download & help panel when screen is narrow or short */
+    #op-cart-download-panel .close i,
+    #op-help-panel .close i {
+        font-size: 1.1em;
     }
 
     /* Reduce the space around "Download Data" in download pane */

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -454,6 +454,7 @@ ul.op-search-menu {
     float: left;
     position: relative;
     margin: 1px;
+    /* Extra 2px margin + 98px (content + padding + border) = 100px */
     min-width: 98px;  /* This gives us a 100x100 thumbnail including margin */
     min-height: 98px;
     border: medium solid transparent;
@@ -2782,6 +2783,7 @@ when wrapping into the 2nd line */
     /* Reduce the thumbnail container from 100x100 to 90x90 (10% off) when font
     size is changed */
     .op-thumbnail-container {
+        /* Extra 2px margin + 88px (content + padding + border) = 90px */
         min-width: 88px;
         min-height: 88px;
     }

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2614,6 +2614,13 @@ wiggling when mouse over autocomplete menu items */
     background: transparent !important;
 }
 
+/* Make "+ (OR)" sans-serif */
+.op-add-inputs-btn i {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+                 "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji",
+                 "Segoe UI Emoji", "Segoe UI Symbol", "Font Awesome 5 Free";
+}
+
 /* Styling for the text between each set of inputs in a widget */
 .op-or-labels {
     text-align: center;

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -293,14 +293,6 @@ to 100%, this will make the shrinking look smoother */
     }
 }
 
-/* Make sure input tags shrink more when screen get narrower before qtype groups
-are wrapped into a different line */
-@media (max-width: 1100px) {
-    input.RANGE {
-        width: 20% !important;
-    }
-}
-
 @media (max-width: 860px) {
     /* Make search menu shrink proportionally when screen width is narrower */
     .sidebar-area {

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -1558,14 +1558,6 @@ to stay in one line */
         padding-top: 0.5em;
     }
 
-    @media (max-height: 460px) {
-        /* Remove the nav-link for opening up download data panel when screen
-        is too small to see download data options */
-        .op-cart-toggle-download-panel {
-            display: none !important;
-        }
-    }
-
     /* Make sure gallery-contents not cut off by the right edge of the
     screen */
     #cart .gallery-contents {
@@ -1581,7 +1573,7 @@ to stay in one line */
 
 /* Remove the nav-link for opening up download data panel when screen
 is wide enough */
-@media (min-width: 1101px) {
+@media (min-width: 1101px) and (min-height: 461px) {
     .op-cart-toggle-download-panel {
         display: none !important;
     }
@@ -1996,13 +1988,6 @@ make ctrl + F search scroll to work with perfect scrollbar in FF. */
     /* Reduce the top space above the detail image when screen is short */
     .op-detail-img {
         padding-top: 1% !important;
-    }
-
-}
-
-@media (max-height: 370px) and (min-width: 768px) and (max-width: 905px) {
-    .op-detail-img p {
-        font-size: 0.5rem;
     }
 }
 
@@ -2838,7 +2823,17 @@ when wrapping into the 2nd line */
 @media (max-width: 580px), (max-height: 400px) {
     /* Shrink the modal header when screen is narrow or short (confirm modal) */
     .modal-header {
-        padding: 0.25rem !important;
+        padding: 0.25rem 0.5rem !important;
+    }
+
+    /* Shrink the modal body when screen is narrow or short (confirm modal) */
+    .modal-body {
+        padding: 0.25rem 0.5rem !important;
+    }
+
+    /* Shrink the modal footer when screen is narrow or short (confirm modal) */
+    .modal-footer {
+        padding: 0.25rem 0.5rem !important;
     }
 
     /* Reduce the top & bottom spaces around "Download Options" in download panel
@@ -2866,11 +2861,44 @@ when wrapping into the 2nd line */
     }
 }
 
+/* Make sure confirm modal header is vertically centered */
+.modal-header {
+    align-items: center !important;
+}
+
 @media (max-width: 580px) and (max-height: 400px) {
     /* Shrink the table header font size to have a better table display when
     screen is narrow & short (browse/cart tab) */
     .op-data-table-view thead {
         font-size: 75%;
+    }
+
+    /* The followings are to make hide "Download CSV (all results)" and move the
+    slider a line above */
+    #browse .browse-nav-container {
+        flex-wrap: nowrap;
+    }
+
+    #browse .browse-nav-container .navbar-nav {
+        width: auto;
+    }
+
+    #browse .browse-nav-container .op-download-csv {
+        display: none !important;
+    }
+
+    #browse .op-sort-order-container {
+        margin-top: 0;
+    }
+
+    /* Reduce spaces to make sure cart actions buttons are wrapped into the next
+    line when screen is narrow & short */
+    .op-cart-actions > li {
+        margin-right: 0 !important;
+    }
+
+    .op-cart-actions a {
+        margin-right: 0.5rem !important;
     }
 }
 
@@ -2881,6 +2909,22 @@ when wrapping into the 2nd line */
         display: none !important;
     }
 
+    /* Reduce the spaces between each item in the hamburger menu when screen is
+    short */
+    #op-obs-menu .dropdown-item {
+        padding-top: 1px;
+        padding-bottom: 1px;
+    }
+
+    /* Reduce spaces between each item in the help menu when screen is short */
+    .op-help-item {
+        padding-top: 0.1em !important;
+        padding-bottom: 0.1em !important;
+        font-size: 90%;
+    }
+}
+
+@media (max-height: 500px) {
     /* Hide product type select/deselect buttons when screen is short (cart tab) */
     .op-product-types-select-btn-group {
         display: none !important;
@@ -2890,8 +2934,6 @@ when wrapping into the 2nd line */
     .op-download-options-title {
         display: none !important;
     }
-
-
 }
 
 /* Bypass .col-sm-1 breakpoint to have pretty table display in download panel
@@ -2910,11 +2952,33 @@ when screen is narrow (cart tab) */
     }
 }
 
+/* Group cart actions nav buttons & download panel button together */
+.op-cart-actions-group {
+    display: flex;
+    flex-direction: column
+}
+
 @media (max-height: 400px) {
     /* Keep detail image stay at the right of the page when screen is narrow
     (detail tab) */
     .op-detail-content {
         flex-wrap: nowrap;
+    }
+
+    /* The followings are to move "Download Data" button to the same line as
+    cart actions nav buttons  (cart tab) */
+    .op-cart-actions-group {
+        flex-direction: row;
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .op-cart-slide-download-panel i {
+        display: none !important;
+    }
+
+    .op-cart-toggle-download-panel {
+        padding: 0;
     }
 }
 
@@ -2935,6 +2999,7 @@ when screen is narrow (cart tab) */
     when screen is short & narrow (detail tab) */
     .op-detail-metadata-container {
         flex: 1 0 70%;
+        display: grid;
     }
 
     /* Reduce the spaces around detail tab when screen is short & narrow */

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2756,7 +2756,12 @@ when wrapping into the 2nd line */
     padding-right: 0.2rem;
 }
 
-/* The followings are for mobile support (width: 550px and height: 270px) */
+/* ************************************************************************** */
+/* The followings are for mobile support (width: 550px and height: 270px)     */
+/* NOTE: Current breakpoints are width: 700px & height: 400px, these have to  */
+/* match the constant browserThresholdWidth & browserThresholdHeight in       */
+/* opus.js.                                                                   */
+/* ************************************************************************** */
 @media (max-width: 700px), (max-height: 400px) {
     body {
         font-size: 75% !important;

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2802,8 +2802,8 @@ when wrapping into the 2nd line */
 
     /* Expand the width of widgets area when screen is narrow */
     #search .op-widget-col {
-        padding-left: 0;
-        padding-right: 0;
+        padding-left: 5px;
+        padding-right: 5px;
     }
 }
 
@@ -2814,6 +2814,16 @@ when wrapping into the 2nd line */
     }
 }
 
-@media (min-width: 576px){
+@media (max-width: 575px), (max-height: 400px) {
+    /* Shrink the modal header when screen is narrow or short */
+    .modal-header {
+        padding: 0.25rem !important;
+    }
+}
 
+@media (max-height: 400px){
+    /* Hide download csv button menu in select metadata menu when screen is short */
+    .op-select-metadata-details .op-download-csv {
+        display: none !important;
+    }
 }

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2766,15 +2766,31 @@ when wrapping into the 2nd line */
     padding-right: 0.2rem;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 575px) {
     /* Need to use !important here so that the footer (inside a flex container)
     will not take up the space when hidden */
     .app-footer {
         display: none !important;
     }
+
+    body {
+        font-size: 80% !important;
+    }
+
+    .op-reset-search, .op-reset-search-metadata {
+        font-size: 90% !important;
+    }
+}
+
+@media (max-width: 575px), (max-height: 630px) {
+    /* Hide the feedback button when screen is narrow or short */
+    .feedbackTab {
+        display: none !important;
+    }
 }
 
 @media (max-width: 575px) {
+    /*  Make sure main nav tabs are displayed horizontally when screen is narrow */
     .op-tab {
         flex-direction: row !important;
     }

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2671,6 +2671,11 @@ at the right of -- OR -- label. */
     padding-bottom: 5px;
 }
 
+/* Make sure hamburger menu will not be covered by metadata modal */
+#op-obs-menu {
+    z-index: 1032;
+}
+
 /* Styling for the first column of table header in browse tab */
 .op-table-first-col div {
     /* hamburger width 13px + 2px gap to align with checkboxes in other rows */

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -260,7 +260,8 @@ Not sure if this is the desired behavior
 
 /* As long as q-type shrink to the 2nd line, we set text input width
 to 100%, this will make the shrinking look smoother */
-@media (max-width: 970px) {
+@media (max-width: 940px) {
+/* @media (max-width: 970px) { */
     /* Make STRING input shrink proportionally when window is narrow */
     #op-search-widgets input[class~="STRING"] {
         width: 100%;
@@ -285,6 +286,18 @@ to 100%, this will make the shrinking look smoother */
 
     .op-range-input-max {
         margin-left: 0.3rem;
+    }
+
+    .op-or-labels {
+        width: auto !important;
+    }
+}
+
+/* Make sure input tags shrink more when screen get narrower before qtype groups
+are wrapped into a different line */
+@media (max-width: 1100px) {
+    input.RANGE {
+        width: 20% !important;
     }
 }
 
@@ -2558,9 +2571,17 @@ expanded/collapsed */
     display: none !important;
 }
 
-/* Make palceholder hints visible when browser width is large enough */
+/* Set the width of input.STRING to make sure it can be shrunk more when screen
+is shrinking (before reaching to the breakpoint at 940px)*/
+input.STRING {
+    width: 55%;
+}
+
+/* Make palceholder hints visible when browser width is large enough, and also
+make sure it can be shrunk more when screen is shrinking (before reaching to
+the breakpoint at 940px) */
 input.RANGE {
-    min-width: 25%;
+    width: 25%;
 }
 
 /* Style placeholder to have "..." when text is overflow */
@@ -2605,6 +2626,7 @@ wiggling when mouse over autocomplete menu items */
     text-align: center;
     font-style: italic;
     font-weight: bold;
+    width: 75%;
 }
 
 /* Styling for horizontal divider between OR label when there are multiple
@@ -2627,12 +2649,6 @@ searches */
     pointer-events: none;
 }
 
-/* Styling to make each input set takes up the width that will fit its contents */
-.op-search-inputs-set {
-    width: fit-content;
-    width: -moz-fit-content;
-}
-
 /* Hide the element but still keep its space. This is used for dummy items placed
 at the right of -- OR -- label. */
 .op-visibility-hidden {
@@ -2644,7 +2660,7 @@ at the right of -- OR -- label. */
     display: inline-block;
 }
 
-@media (max-width: 1000px) {
+@media (max-width: 940px) {
     .op-dummy-item1, .op-dummy-item2 {
         display: none !important;
     }
@@ -2769,6 +2785,13 @@ when wrapping into the 2nd line */
 
     body {
         font-size: 75% !important;
+    }
+
+    /* Reduce the thumbnail container from 100x100 to 90x90 (10% off) when font
+    size is changed */
+    .op-thumbnail-container {
+        min-width: 88px;
+        min-height: 88px;
     }
 
     .op-reset-search,

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2865,6 +2865,15 @@ when wrapping into the 2nd line */
         padding: 1rem !important;
     }
 
+    /* Reduce the size of font awesome icon in slide show */
+    #galleryView .close i {
+        font-size: 1.1em;
+    }
+
+    #galleryView .bottom i {
+        font-size: 1.8em;
+    }
+
     /* Reduce the modal buttons size when screen is narrow or short (confirm
     modal) */
     .modal-footer button {

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2938,7 +2938,7 @@ when wrapping into the 2nd line */
     /* Reduce the space around "Download Data" in download panel when screen is
     narrow or short (cart tab) */
     #op-cart-download-panel .card-header {
-        padding-top: 0.25em 0.75em;
+        padding: 0.25em 0.75em;
     }
 
     /* Reduce the space around "Download Data" in download pane */

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2777,7 +2777,9 @@ when wrapping into the 2nd line */
         font-size: 75% !important;
     }
 
-    .op-reset-search, .op-reset-search-metadata {
+    .op-reset-search,
+    .op-reset-search-metadata,
+    .op-slider-pointer {
         font-size: 90% !important;
     }
 
@@ -2788,8 +2790,18 @@ when wrapping into the 2nd line */
 
     /* Shrink the height of main nav */
     #op-main-nav {
-        padding-top: 3.5px;
-        padding-bottom: 3.5px;
+        padding-top: 3px;
+        padding-bottom: 3px;
+    }
+
+    /* Reduce the padding around selected tab on main nav */
+    #op-main-nav .nav-link {
+        padding: 0.25rem;
+    }
+
+    /* Reduce the hamburger icon on main nav */
+    #op-main-nav .navbar-toggler {
+        padding: 0.1rem 0.6rem;
     }
 
     /* Reduce the space around search sidebar & widgets when screen narrow
@@ -2806,6 +2818,24 @@ when wrapping into the 2nd line */
         padding-left: 5px;
         padding-right: 5px;
     }
+
+    /* Reduce the padding around widget header */
+    #widget-container .card-header {
+        padding-left: 0.75rem;
+        padding-right: 0.75rem;
+        padding-top: 0.25rem;
+        padding-bottom: 0.25rem;
+    }
+
+    #widget-container .card-title {
+        margin-bottom: 0;
+    }
+
+    /* Reduce the spaces between each widget */
+    #widget-container .card {
+        margin-bottom: 0.75rem;
+    }
+
 }
 
 @media (max-width: 580px), (max-height: 630px) {
@@ -2821,19 +2851,24 @@ when wrapping into the 2nd line */
 }
 
 @media (max-width: 580px), (max-height: 400px) {
-    /* Shrink the modal header when screen is narrow or short (confirm modal) */
-    .modal-header {
+    /* Shrink the modal header, modal body, and modal footer when screen is
+    narrow or short (confirm modal) */
+    .modal-header, .modal-body, .modal-footer {
         padding: 0.25rem 0.5rem !important;
     }
 
-    /* Shrink the modal body when screen is narrow or short (confirm modal) */
-    .modal-body {
-        padding: 0.25rem 0.5rem !important;
+    /* Keep the spaces for detail metadata modal in browse & cart tab to have
+    the pretty display when screen is narrow or short */
+    #galleryView .modal-header,
+    #galleryView .modal-body,
+    #galleryView .modal-footer {
+        padding: 1rem !important;
     }
 
-    /* Shrink the modal footer when screen is narrow or short (confirm modal) */
-    .modal-footer {
-        padding: 0.25rem 0.5rem !important;
+    /* Reduce the modal buttons size when screen is narrow or short (confirm
+    modal) */
+    .modal-footer button {
+        padding: 0.175rem 0.55rem;
     }
 
     /* Reduce the top & bottom spaces around "Download Options" in download panel
@@ -2963,6 +2998,17 @@ when screen is narrow (cart tab) */
     (detail tab) */
     .op-detail-content {
         flex-wrap: nowrap;
+    }
+
+    /* Reduce the spaces around "Observation Detail" (detail tab) */
+    .op-detail-metadata h1 {
+        margin-top: 0.2em;
+        margin-bottom: 0.2em;
+    }
+
+    /* Reduce the spaces around "OPUS ID" in detail tab */
+    .op-detail-metadata p {
+        margin-bottom: 0.2em;
     }
 
     /* The followings are to move "Download Data" button to the same line as

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -2084,9 +2084,27 @@ var o_browse = {
         return width;
     },
 
+    updateImageSize: function() {
+        /**
+         * Update the thumbnail image size based on the browser size.
+         * The default value & updated value need to match min-height & min-width
+         * values assigned to .op-thumbnail-container in opus.css.
+         */
+        if ($(window).width() <= opus.browserThresholdWidth ||
+            $(window).height() <= opus.browserThresholdHeight) {
+            // udpated thumbnail size: 90x90
+            o_browse.imageSize = 90;
+        } else {
+            // default thumbnail size: 100x100
+            o_browse.imageSize = 100;
+        }
+    },
+
     adjustBrowseHeight: function(browserResized=false, isDOMChanged=false) {
         let tab = opus.getViewTab();
         let view = opus.prefs.view;
+        // Check screen size and update o_browse.imageSize
+        o_browse.updateImageSize();
         let containerHeight = o_browse.calculateGalleryHeight();
         $(`${tab} .gallery-contents`).height(containerHeight);
         $(`${tab} .gallery-contents .op-gallery-view`).height(containerHeight);

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1175,6 +1175,13 @@ var o_browse = {
         let top = ($(tab).innerHeight() - e.pageY > menu.height) ? e.pageY-5 : e.pageY-menu.height;
         let left = ($(tab).innerWidth() - e.pageX > menu.width)  ? e.pageX-5 : e.pageX-menu.width;
 
+        // Make sure hamburger won't go off the screen
+        if (top < 0) {
+            top = 0;
+        } else if ((top + menu.height) > $(window).height()) {
+            top -= (top + menu.height - $(window).height());
+        }
+
         $("#op-obs-menu").css({
             display: "block",
             top: top,

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -2052,6 +2052,9 @@ var o_browse = {
         let footerHeight = $(".app-footer").outerHeight();
         let mainNavHeight = $("#op-main-nav").outerHeight();
         let navbarHeight = $(`${tab} .panel-heading`).outerHeight();
+        // The main navbar (#op-main-nav) and the 2nd navbar (.panel-heading) have an overlapping
+        // area, need to take this overlapped height into consideration when doing the calculation.
+        // This will make sure there is no gap between the end of .gallery-contents and .app-footer.
         let navOverlappedHeight = $("#op-main-nav").offset().top + mainNavHeight -
                                   $(`${tab} .panel-heading`).offset().top;
         let totalNonGalleryHeight = footerHeight + mainNavHeight + navbarHeight - navOverlappedHeight;

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -2052,7 +2052,10 @@ var o_browse = {
         let footerHeight = $(".app-footer").outerHeight();
         let mainNavHeight = $("#op-main-nav").outerHeight();
         let navbarHeight = $(`${tab} .panel-heading`).outerHeight();
-        let totalNonGalleryHeight = footerHeight + mainNavHeight + navbarHeight;
+        let navOverlappedHeight = $("#op-main-nav").offset().top + mainNavHeight -
+                                  $(`${tab} .panel-heading`).offset().top;
+        let totalNonGalleryHeight = footerHeight + mainNavHeight + navbarHeight - navOverlappedHeight;
+
         return $(window).height()-totalNonGalleryHeight;
     },
 

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1522,9 +1522,10 @@ var o_browse = {
         // check all box
         // let addallIcon = "<button type='button' data-toggle='modal' data-target='#op-addall-to-cart-modal' " +
         let addallIcon = "<button type='button'" +
-                         "class='op-table-header-addall btn btn-link'>" +
-                         "<i class='fas fa-cart-plus' data-action='addall'" +
-                         " title='Add All Results to Cart'></i></button>";
+                         "class='op-table-header-addall btn btn-link'" +
+                         " title='Add All Results to Cart'>" +
+                         "<i class='fas fa-cart-plus' data-action='addall'></i></button>";
+
         let tableHeaderFirstCol = `<th scope='col' class='sticky-header op-table-first-col'><div>${addallIcon}</div></th>`;
         // note: this column header will be empty
         let tableHeaderThumbnailCol = `<th scope='col' class='sticky-header op-table-first-col'></th>`;

--- a/opus/application/static_media/js/cart.js
+++ b/opus/application/static_media/js/cart.js
@@ -298,7 +298,8 @@ var o_cart = {
          */
         // We use detach here to keep the event handlers attached to elements
         let html = $("#op-download-options-container").detach();
-        if ($(window).width() <= cartLeftPaneThreshold) {
+        if ($(window).width() <= cartLeftPaneThreshold ||
+            $(window).height() <= cartLeftPaneMinHeight) {
             $("#op-cart-download-panel .op-header-text").html("<h2>Download Data</h2>");
             $("#op-cart-download-panel .op-card-contents").html(html);
             $(".op-download-panel-title").hide();

--- a/opus/application/static_media/js/cart.js
+++ b/opus/application/static_media/js/cart.js
@@ -298,8 +298,7 @@ var o_cart = {
          */
         // We use detach here to keep the event handlers attached to elements
         let html = $("#op-download-options-container").detach();
-        if ($(window).width() <= cartLeftPaneThreshold ||
-            $(window).height() <= cartLeftPaneMinHeight) {
+        if ($(window).width() <= cartLeftPaneThreshold) {
             $("#op-cart-download-panel .op-header-text").html("<h2>Download Data</h2>");
             $("#op-cart-download-panel .op-card-contents").html(html);
             $(".op-download-panel-title").hide();
@@ -418,13 +417,19 @@ var o_cart = {
     adjustProductInfoHeight: function() {
         let containerHeight = o_browse.calculateGalleryHeight();
         let footerHeight = $(".app-footer").outerHeight();
-        let mainNavHeight = $("#op-main-nav").outerHeight();
+        let mainNavHeight = $(".op-reset-opus").outerHeight() +
+                            $("#op-main-nav").innerHeight() - $("#op-main-nav").height();
         let downloadOptionsHeight = $(window).height() - (footerHeight + mainNavHeight);
         let cardHeaderHeight = $("#op-cart-download-panel .card-header").outerHeight();
         let downloadOptionsHeaderHeight = $(".op-download-options-header").outerHeight();
         let productTypesTableHeader = $(".op-product-type-table-header").outerHeight();
+        let downloadContainerTopPadding = 0;
+        if ( $("#cart-sidebar").length && $("#op-download-options-container").length) {
+            downloadContainerTopPadding = $("#cart-sidebar").offset().top -
+                                          $("#op-download-options-container").offset().top;
+        }
         let downloadOptionsScrollableHeight = (downloadOptionsHeight - downloadOptionsHeaderHeight -
-                                          footerHeight - productTypesTableHeader);
+                                               productTypesTableHeader - downloadContainerTopPadding);
 
         $("#cart .gallery-contents").height(containerHeight);
         if ($(window).width() < cartLeftPaneThreshold) {
@@ -434,7 +439,6 @@ var o_cart = {
         }
 
         $("#cart .sidebar_wrapper").height(downloadOptionsHeight);
-        // $(".op-download-options-product-types").height(downloadOptionsScrollableHeight);
         $(".op-product-type-table-body").height(downloadOptionsScrollableHeight);
 
         if (o_cart.downloadOptionsScrollbar) {

--- a/opus/application/static_media/js/detail.js
+++ b/opus/application/static_media/js/detail.js
@@ -127,8 +127,11 @@ var o_detail = {
         let detailTabPaddingTop = ($("#detail").outerHeight() - $("#detail").height())/2;
         // When detail image is moved to the top of detail left pane, we have to
         // account for the height of detail image as well when calculating the containerHeight
-        let detailImgHeight = ($(".op-detail-img").offset().top !== $(".op-detail-metadata").offset().top ?
+        let detailImgHeight = 0;
+        if ($(".op-detail-img").length && $(".op-detail-metadata").length) {
+            detailImgHeight = ($(".op-detail-img").offset().top !== $(".op-detail-metadata").offset().top ?
                                $(".op-detail-img").outerHeight() : 0);
+        }
         let containerHeight = ($(window).height() - footerHeight - mainNavHeight -
                                detailTabPaddingTop - detailImgHeight);
 

--- a/opus/application/static_media/js/detail.js
+++ b/opus/application/static_media/js/detail.js
@@ -7,10 +7,6 @@
 /* globals $, _, PerfectScrollbar */
 /* globals o_hash, opus */
 
-// The detail image will stay on top of detail left pane when screen width
-// is equal to or less than the threshold point.
-const detailImageThreshold = 767;
-
 /* jshint varstmt: false */
 var o_detail = {
 /* jshint varstmt: true */

--- a/opus/application/static_media/js/detail.js
+++ b/opus/application/static_media/js/detail.js
@@ -127,7 +127,7 @@ var o_detail = {
         let detailTabPaddingTop = ($("#detail").outerHeight() - $("#detail").height())/2;
         // When detail image is moved to the top of detail left pane, we have to
         // account for the height of detail image as well when calculating the containerHeight
-        let detailImgHeight = ($(window).width() <= detailImageThreshold ?
+        let detailImgHeight = ($(".op-detail-img").offset().top !== $(".op-detail-metadata").offset().top ?
                                $(".op-detail-img").outerHeight() : 0);
         let containerHeight = ($(window).height() - footerHeight - mainNavHeight -
                                detailTabPaddingTop - detailImgHeight);

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -1292,8 +1292,7 @@ var opus = {
              opus.browserSizeActionInProgress = false;
              modal.off("hidden.bs.modal", hideCompleted);
          }
-        console.log(`Current window height: ${$(window).height()}`);
-        console.log(`Current window height: ${$(window).width()}`);
+
         if ($(window).width() < opus.browserSupport.width ||
             $(window).height() < opus.browserSupport.height) {
             if (!$("#op-browser-size-msg-modal").hasClass("show")) {

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -1301,7 +1301,8 @@ var opus = {
                 $("#op-browser-size-msg-modal .modal-body").html(modalMsg);
                 opus.browserSizeActionInProgress = true;
                 modal.on("shown.bs.modal", showCompleted);
-                modal.modal("show");
+                // TODO: Uncomment this later
+                // modal.modal("show");
             }
         } else {
             if ($("#op-browser-size-msg-modal").hasClass("show")) {

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -1272,9 +1272,10 @@ var opus = {
         if ($(window).width() < opus.browserSupport.width ||
             $(window).height() < opus.browserSupport.height) {
             if (!$("#op-browser-size-msg-modal").hasClass("show")) {
-                let modalMsg = (`Please resize your browser. OPUS requires a browser
-                                size of at least ${opus.browserSupport.width} pixels by
-                                ${opus.browserSupport.height} pixels.`);
+                let modalMsg = (`Please resize your browser or rotate your mobile
+                                device to landscape mode. OPUS requires a browser
+                                size of at least ${opus.browserSupport.width} pixels
+                                by ${opus.browserSupport.height} pixels. `);
                 $("#op-browser-size-msg-modal .modal-body").html(modalMsg);
                 opus.browserSizeActionInProgress = true;
                 modal.on("shown.bs.modal", showCompleted);

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -119,8 +119,10 @@ var opus = {
         "opera": 42,
         "safari": 10.1,
         "based on applewebkit": 537, // Based on Chrome 56
-        "width": 600,
-        "height": 350
+        "width": 550,
+        "height": 300
+        // "width": 600,
+        // "height": 350
     },
 
     // current splash page version for storing in the visited cookie
@@ -1290,7 +1292,8 @@ var opus = {
              opus.browserSizeActionInProgress = false;
              modal.off("hidden.bs.modal", hideCompleted);
          }
-
+        console.log(`Current window height: ${$(window).height()}`);
+        console.log(`Current window height: ${$(window).width()}`);
         if ($(window).width() < opus.browserSupport.width ||
             $(window).height() < opus.browserSupport.height) {
             if (!$("#op-browser-size-msg-modal").hasClass("show")) {
@@ -1302,7 +1305,7 @@ var opus = {
                 opus.browserSizeActionInProgress = true;
                 modal.on("shown.bs.modal", showCompleted);
                 // TODO: Uncomment this later
-                // modal.modal("show");
+                modal.modal("show");
             }
         } else {
             if ($("#op-browser-size-msg-modal").hasClass("show")) {

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -718,7 +718,6 @@ var opus = {
 
         // When the browser is resized, we need to recalculate the scrollbars
         // for all tabs.
-        let searchHeightChangedDB = _.debounce(o_search.searchHeightChanged, 200);
         let adjustBrowseHeightDB = function() {o_browse.adjustBrowseHeight(true);};
         let adjustTableSizeDB = _.debounce(o_browse.adjustTableSize, 200);
         let adjustProductInfoHeightDB = _.debounce(o_cart.adjustProductInfoHeight, 200);
@@ -730,7 +729,7 @@ var opus = {
         let displayCartLeftPaneDB = _.debounce(o_cart.displayCartLeftPane, 200);
 
         $(window).on("resize", function() {
-            searchHeightChangedDB();
+            o_search.searchHeightChanged();
             adjustBrowseHeightDB();
             adjustTableSizeDB();
             adjustProductInfoHeightDB();

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -120,7 +120,7 @@ var opus = {
         "safari": 10.1,
         "based on applewebkit": 537, // Based on Chrome 56
         "width": 550,
-        "height": 300
+        "height": 270
         // "width": 600,
         // "height": 350
     },
@@ -1300,7 +1300,7 @@ var opus = {
                 let modalMsg = (`Please resize your browser or rotate your mobile
                                 device to landscape mode. OPUS requires a browser
                                 size of at least ${opus.browserSupport.width} pixels
-                                by ${opus.browserSupport.height} pixels. `);
+                                by ${opus.browserSupport.height} pixels. Current size ${$(window).width()} x ${$(window).height()}`);
                 $("#op-browser-size-msg-modal .modal-body").html(modalMsg);
                 opus.browserSizeActionInProgress = true;
                 modal.on("shown.bs.modal", showCompleted);

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -121,8 +121,6 @@ var opus = {
         "based on applewebkit": 537, // Based on Chrome 56
         "width": 550,
         "height": 270
-        // "width": 600,
-        // "height": 350
     },
 
     // current splash page version for storing in the visited cookie
@@ -1299,11 +1297,10 @@ var opus = {
                 let modalMsg = (`Please resize your browser or rotate your mobile
                                 device to landscape mode. OPUS requires a browser
                                 size of at least ${opus.browserSupport.width} pixels
-                                by ${opus.browserSupport.height} pixels. Current size ${$(window).width()} x ${$(window).height()}`);
+                                by ${opus.browserSupport.height} pixels.`);
                 $("#op-browser-size-msg-modal .modal-body").html(modalMsg);
                 opus.browserSizeActionInProgress = true;
                 modal.on("shown.bs.modal", showCompleted);
-                // TODO: Uncomment this later
                 modal.modal("show");
             }
         } else {

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -134,6 +134,11 @@ var opus = {
     // Max number of input sets per (RANGE or STRING) widget
     maxAllowedInputSets: 10,
 
+    // The browser threshold width & height that font & thumbnail size start to shirnk.
+    // NTOE: These two variables have to match the breakpoints in mobile support section in opus.css.
+    browserThresholdWidth: 700,
+    browserThresholdHeight: 400,
+
     //------------------------------------------------------------------------------------
     // Debugging support
     //------------------------------------------------------------------------------------

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -1034,7 +1034,8 @@ var o_search = {
     },
 
     searchBarContainerHeight: function() {
-        let mainNavHeight = $("#op-main-nav").outerHeight();
+        let mainNavHeight = $(".op-reset-opus").outerHeight() +
+                            $("#op-main-nav").innerHeight() - $("#op-main-nav").height();
         let footerHeight = $(".app-footer").outerHeight();
         let resetButtonHeight = $(".op-reset-button").outerHeight();
         let dividerHeight = $(".shadow-divider").outerHeight();
@@ -1065,7 +1066,8 @@ var o_search = {
 
     searchWidgetHeightChanged: function() {
         let footerHeight = $(".app-footer").outerHeight();
-        let mainNavHeight = $("#op-main-nav").outerHeight();
+        let mainNavHeight = $(".op-reset-opus").outerHeight() +
+                            $("#op-main-nav").innerHeight() - $("#op-main-nav").height();
         let totalNonSearchAreaHeight = footerHeight + mainNavHeight;
         let containerHeight = $("#search").height() - totalNonSearchAreaHeight;
         let searchWidgetHeight = $("#op-search-widgets").height();

--- a/opus/application/static_media/js/selectMetadata.js
+++ b/opus/application/static_media/js/selectMetadata.js
@@ -9,6 +9,9 @@
 /******************************************/
 /********* SELECT METADATA DIALOG *********/
 /******************************************/
+const metadataModalHeightBreakPoint = 400;
+const gapBetweenBottomEdgeAndMetadataModal = 55;
+
 /* jshint varstmt: false */
 var o_selectMetadata = {
 /* jshint varstmt: true */
@@ -314,7 +317,8 @@ var o_selectMetadata = {
         $(".op-select-metadata-headers").show(); // Show now so computations are accurate
         $(".op-select-metadata-headers-hr").show();
         let footerHeight = $(".app-footer").outerHeight();
-        let mainNavHeight = $("#op-main-nav").outerHeight();
+        let mainNavHeight = $(".op-reset-opus").outerHeight() +
+                            $("#op-main-nav").innerHeight() - $("#op-main-nav").height();
         let modalHeaderHeight = $("#op-select-metadata .modal-header").outerHeight();
         let modalFooterHeight = $("#op-select-metadata .modal-footer").outerHeight();
         let selectMetadataHeadersHeight = $(".op-select-metadata-headers").outerHeight()+30;
@@ -340,7 +344,9 @@ var o_selectMetadata = {
            130 is the minimum size required to display four metadata fields.
            Anything less than that makes the dialog useless. In that case we hide the
            header text to give us more room. */
-        let height = Math.max($(window).height()-totalNonScrollableHeight-55);
+        let height = (($(window).height() > metadataModalHeightBreakPoint) ?
+                      $(window).height()-totalNonScrollableHeight-gapBetweenBottomEdgeAndMetadataModal : $(window).height()-totalNonScrollableHeight);
+
         if (height < 130) {
             $(".op-select-metadata-headers").hide();
             $(".op-select-metadata-headers-hr").hide();


### PR DESCRIPTION
- Fixes #983 
- Fixes #1005 
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - Database used: opus3_test_200211
  - All Django tests pass: Y
- Were any JavaScript or CSS files modified? Y
  - JSHINT run on all affected files: Y 
  - Tested on Chrome, Firefox, Safari, and iOS: Y
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:
General: 
- Change supported browser size to 550px width & 270px height
- When browser width is less than 580px OR height is shorter than 400px:
    - Shrink the modal header 
    - Hide the footer
    - Set body font-size to be 75%
    - Set reset buttons font-size to be 90% (in search tab)
    - Shrink the height of main nav
- When browser width is less than 580px AND height is shorter than 400px:
    - Set the table header font size to 75% to have a better table display

Search:
- Recalculate mainNavHeight in searchBarContainerHeight & searchWidgetHeightChanged to have the correct height of search menu sidebar and widgets area.
- When browser width is less than 580px OR height is shorter than 630px:
    - Hide the feedback button
- When browser width is less than 580px OR height is shorter than 400px:
    - Reduce the padding around the whole search tab
    - Expand the width of widgets area

Browse:
- When browser height is shorter than 400px:
    - Hide download csv button in select metadata menu
- Update the logic in calculateGalleryHeight, take overlapped nav into consideration. This will remove the little gap between the end of gallery contents and the footer.

Cart:
- When browser height is shorter than 400px:
    - Hide product type select/deselect buttons in download panel
    - Hide "Download Options" in download panel
- When browser width is less than 580px OR height is shorter than 630px:
    - Hide download zip buttons in download panel
- When browser width is less than 580px OR height is shorter than 400px:
    - Reduce the top & bottom spaces around "Download Options" 
    - Reduce the space around data in download panel card body
    - Reduce the space around "Download Data" in download panel 

Detail:
- When browser height is less than 400px:
    - Keep the detail image stay at the right of the page
- When browser width is less than 768px AND height is shorter than 400px:
    - Make observation detail area shrinkable
    - Make observation detail area take up 70% of width and image take up 30%
    - Reduce the spaces around detail tab

Metadata modal for each observation:
- Make sure image always stays at the left in metadata modal
- Make sure metadata modal is not covered by main nav 
- Make sure hamburger menu is not covered by the modal

Known problems:
Mobile touch over-scrolling:
- In Pixel with Chrome (Firefox doesn't have this issue), in browse tab, there will be a huge gap at the end of gallery contents and footer.
- In iOS or Android devices with smaller screen (like iphone 8 or iphone se), in browse/cart tab, the 2nd navbar & gallery area can be over-scrolled. (The issue is not happened on iphone pro max). 