### PR TITLE
Add intro for primary_file_spec

### DIFF
--- a/opus/import/table_schemas/obs_pds.json
+++ b/opus/import/table_schemas/obs_pds.json
@@ -177,7 +177,7 @@
         "pi_display": 1,
         "pi_display_results": 1,
         "pi_form_type": "STRING",
-        "pi_intro": "The Primary File SpecX has different filename extensions for each mission and instrument and in many cases specifies the label file instead of the data file. Thus we suggest that you eliminate the extension from your search and use the \"contains\" query type to guarantee the best match.",
+        "pi_intro": "The Primary File Spec uses different filename extensions depending on the mission and instrument, and in many cases specifies the label file instead of the data file. Thus we suggest that you do not include the extension in your search and that you use the \"contains\" query type to guarantee the best match.",
         "pi_label": "Primary File Spec",
         "pi_label_results": "Primary File Spec",
         "pi_slug": "primaryfilespec",

--- a/opus/import/table_schemas/obs_pds.json
+++ b/opus/import/table_schemas/obs_pds.json
@@ -177,7 +177,7 @@
         "pi_display": 1,
         "pi_display_results": 1,
         "pi_form_type": "STRING",
-        "pi_intro": null,
+        "pi_intro": "The Primary File SpecX has different filename extensions for each mission and instrument and in many cases specifies the label file instead of the data file. Thus we suggest that you eliminate the extension from your search and use the \"contains\" query type to guarantee the best match.",
         "pi_label": "Primary File Spec",
         "pi_label_results": "Primary File Spec",
         "pi_slug": "primaryfilespec",


### PR DESCRIPTION
- Were any Django, import pipeline, table_schema, or dictionary files modified? Y
  - Database used: opus3_test_200304
  - All Django tests pass: Y
- Were any JavaScript or CSS files modified? N
  - JSHINT run on all affected files: NA
  - Tested on Chrome, Firefox, Safari, and iOS: N
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:

Added intro paragraph to the primary file spec search widget explaining how to search without using file extensions.

Known problems:

None.
