### PR TITLE
Fix the mismatched reqno comparison in updateSearchTabHinting in opus.js

### DIFF
--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -369,7 +369,7 @@ var opus = {
 
         // If there are more result counts in the queue, don't trigger
         // spurious hinting queries that we won't use anyway
-        if (resultCountData.data[0].reqno < opus.lastAllNormalizeRequestNo) {
+        if (resultCountData.data[0].reqno < opus.lastResultCountRequestNo) {
             return;
         }
 


### PR DESCRIPTION
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - Database used: opus3_test_200211
  - All Django tests pass: Y
- Were any JavaScript or CSS files modified? Y
  - JSHINT run on all affected files: Y
  - Tested on Chrome, Firefox, Safari, and iOS: Y
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): Y

Description of changes:
Compare the correct reqno (opus.lastResultCountRequestNo is the one used to call the api) in updateSearchTabHinting. If there are two consecutive searches (the 1st one is a slow search and the 2nd one is a fast search), this fix will make sure the result of the slow search is not falsely displayed after the correct result from the fast search is shown. 


