### PR TITLE
Remove checksum file from zips and flesh out manifest file.

### DIFF
--- a/opus/application/apps/cart/templates/cart/cart.html
+++ b/opus/application/apps/cart/templates/cart/cart.html
@@ -99,8 +99,7 @@
                     <ul>
                         <li>The metadata CSV (data.csv)</li>
                         <li>The URLs of all data products (urls.txt)</li>
-                        <li>The checksums of all data products (checksum.txt)</li>
-                        <li>The manifest listing each OPUS ID and the files associated with it (manifest.txt)</li>
+                        <li>The manifest listing each OPUS ID along with the details of each associated file (manifest.csv)</li>
                     </ul>
                 </div>
             </div>

--- a/opus/application/apps/help/api_guide.md
+++ b/opus/application/apps/help/api_guide.md
@@ -635,9 +635,8 @@ C4360022_RESLOC.LBL
 C4360022_RESLOC.TAB
 C4360022_small.jpg
 C4360022_thumb.jpg
-checksum.txt
 data.csv
-manifest.txt
+manifest.csv
 urls.txt
 VGISS_6210_inventory.lbl
 VGISS_6210_inventory.tab
@@ -656,9 +655,8 @@ VGISS_6210_saturn_summary.tab
     Return value is a zip archive containing the files:
 
 %CODE%
-checksum.txt
 data.csv
-manifest.txt
+manifest.csv
 urls.txt
 %ENDCODE%
 
@@ -671,9 +669,8 @@ urls.txt
 %CODE%
 C0349632000R.IMG
 C0349632000R.LBL
-checksum.txt
 data.csv
-manifest.txt
+manifest.csv
 RLINEPRX.FMT
 RTLMTAB.FMT
 urls.txt

--- a/opus/application/apps/help/templates/help/gettingstarted.html
+++ b/opus/application/apps/help/templates/help/gettingstarted.html
@@ -275,15 +275,17 @@ data OPUS has to offer.</p>
         The <i class="fas fa-bars fa-xs"></i> menu may also be used to create
         a metadata CSV file for a single observation.</li>
     <li>A <b>Data Archive</b> includes all of the selected data products in
-        a single zip file. Also included are a metadata CSV file, a file of
-        product checksums, a manifest showing which files are included, and
-        a file containing the URLs for each data product. On the <b>Cart</b>
-        tab, the <i class="fas fa-download"></i> <b>Data Archive</b> button will
-        produce a zip file containing all observations in the cart. You may also
-        download a data archive of all relevant products for a single
-        observation using the <i class="fas fa-bars fa-xs"></i> menu.</li>
+        a single zip file. Also included are a metadata CSV file (data.csv),
+        a manifest file (manifest.csv) showing which files are included along
+        with their details (including checksums and sizes), and a file
+        containing the URLs for each data product (urls.txt). On the
+        <b>Cart</b> tab, the <i class="fas fa-download"></i>
+        <b>Data Archive</b> button will produce a zip file containing all
+        observations in the cart. You may also download a data archive of all
+        relevant products for a single observation using the
+        <i class="fas fa-bars fa-xs"></i> menu.</li>
     <li>A <b>URL Archive</b> is similar to a data archive, but includes only
-        the non-product files (metadata CSV, checksum, manifest, and URL) in a
+        the non-product files (metadata, manifest, and URLs) in a
         single zip file. This results in a very small download. The actual data
         products can then be retrieved using a command-line utility such as
         <b>wget</b>:

--- a/opus/application/apps/tools/file_utils.py
+++ b/opus/application/apps/tools/file_utils.py
@@ -74,7 +74,8 @@ def get_pds_products(opus_id_list,
     sql += q('obs_files')+'.'+q('category')+', '
     sql += q('obs_files')+'.'+q('sort_order')+', '
     sql += q('obs_files')+'.'+q('short_name')+', '
-    sql += q('obs_files')+'.'+q('full_name')
+    sql += q('obs_files')+'.'+q('full_name')+', '
+    sql += q('obs_files')+'.'+q('size')
     if loc_type == 'path' or loc_type == 'raw':
         sql += ', '+q('obs_files')+'.'+q('logical_path')
     if loc_type == 'url' or loc_type == 'raw':
@@ -109,13 +110,13 @@ def get_pds_products(opus_id_list,
         url = None
         if loc_type == 'path':
             (opus_id, version_name, category, sort_order, short_name,
-             full_name, path) = row
+             full_name, size, path) = row
         elif loc_type == 'url':
             (opus_id, version_name, category, sort_order, short_name,
-             full_name, url) = row
+             full_name, size, url) = row
         else:
             (opus_id, version_name, category, sort_order, short_name,
-             full_name, path, url, checksum) = row
+             full_name, size, path, url, checksum) = row
 
         # sort_order is the format CASISSxxx where xxx is the original numeric
         # sort order
@@ -139,7 +140,12 @@ def get_pds_products(opus_id_list,
         else:
             res = {'path': path,
                    'url': url,
-                   'checksum': checksum}
+                   'checksum': checksum,
+                   'category': category,
+                   'version_name': version_name,
+                   'full_name': full_name,
+                   'short_name': short_name,
+                   'size': size}
         if res not in results[opus_id][version_name][product_type]:
             results[opus_id][version_name][product_type].append(res)
 

--- a/opus_secrets_template.py
+++ b/opus_secrets_template.py
@@ -86,9 +86,10 @@ OPUS_STATIC_ROOT = '<OPUS_STATIC_ROOT>'
 # same server without causing memcached cache key conflicts.
 CACHE_SERVER_PREFIX = '<CACHE_SERVER_PREFIX>'
 
-# Where to put zipped cart files for downloading
+# Where to put zipped cart files for downloading and the manifest file
 # Needs a TRAILING SLASH
 TAR_FILE_PATH = '<TAR_FILE_PATH>/'
+MANIFEST_FILE_PATH = '<MANIFEST_FILE_PATH>/'
 
 # The root URL used to retrieve zipped collections files
 # Needs a TRAILING SLASH


### PR DESCRIPTION
- Fixes #N/A
- Were any Django, import pipeline, table_schema, or dictionary files modified? Y
  - Database used: opus3_test_200517
  - All Django tests pass: Y
- Were any JavaScript or CSS files modified? N
  - JSHINT run on all affected files: NA
  - Tested on Chrome, Firefox, Safari, and iOS: NA
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:

- Removed checksum file from download zips
- Changed manifest.txt to manifest.csv and added columns for various file attributes
- Reordered zip filenames so they could be sorted by date more easily

Known problems:

None

Note: There is a change to opus_secrets.py required. MANIFEST_FILE_PATH is the path to where the manifest files are stored. They aren't deleted after the zip file is made.
