### PR TITLE
Issue 1042 and 1037

### DIFF
--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -1366,14 +1366,18 @@ var o_widgets = {
                 o_search.getHinting(slug);
             }
 
-            // if a RANGE widget that has no qtype & unit inputs just got open, we need to
-            // update opus.selections to make sure input slugs exist.
-            if (widgetInputs.hasClass("RANGE") && !qtypeInputs.length && !unitInput.length) {
+            // if an input widget just got opened and input slugs are not in opus.selections, 
+            // we need to update opus.selections to make sure input slugs exist.
+            if (widgetInputs.hasClass("RANGE")) {
                 if (!opus.selections[`${slug}1`]) {
                     opus.selections[`${slug}1`] = [null];
                 }
                 if (!opus.selections[`${slug}2`]) {
                     opus.selections[`${slug}2`] = [null];
+                }
+            } else if (widgetInputs.hasClass("STRING")) {
+                if (!opus.selections[`${slug}`]) {
+                    opus.selections[`${slug}`] = [null];
                 }
             }
 

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -1365,6 +1365,18 @@ var o_widgets = {
             } else {
                 o_search.getHinting(slug);
             }
+
+            // if a RANGE widget that has no qtype & unit inputs just got open, we need to
+            // update opus.selections to make sure input slugs exist.
+            if (widgetInputs.hasClass("RANGE") && !qtypeInputs.length && !unitInput.length) {
+                if (!opus.selections[`${slug}1`]) {
+                    opus.selections[`${slug}1`] = [null];
+                }
+                if (!opus.selections[`${slug}2`]) {
+                    opus.selections[`${slug}2`] = [null];
+                }
+            }
+
             // Align data in opus.selections and opus.extras to make sure empty
             // inputs will also have null in opus.selections
             [opus.selections, opus.extras] = o_hash.alignDataInSelectionsAndExtras(opus.selections,

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -1582,9 +1582,9 @@ var o_widgets = {
                 o_search.slugStringSearchChoicesReqno[slugWithCounter] = o_widgets.lastStringSearchRequestNo;
 
                 let newHash = o_hash.getHashStrFromSelections();
-                // // Make sure the existing STRING input value is not passed to stringsearchchoices
-                // // API call. This will make sure each autocomplete dropdown results for individual
-                // // input will not be affected by others.
+                // Make sure the existing STRING input value is not passed to stringsearchchoices
+                // API call. This will make sure each autocomplete dropdown results for individual
+                // input will not be affected by others.
                 let hashArray = newHash.split("&");
                 let newHashArray = [];
                 for (const slugValuePair of hashArray) {
@@ -1594,7 +1594,9 @@ var o_widgets = {
                         newHashArray.push(slugValuePair);
                     }
                 }
-                newHashArray.push(`${slugWithCounter}=${currentValue}`);
+
+                let encodedValue = o_hash.encodeSlugValue(currentValue);
+                newHashArray.push(`${slugWithCounter}=${encodedValue}`);
                 newHash = newHashArray.join("&");
 
                 // Avoid calling api when some inputs are not valid

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -1366,7 +1366,7 @@ var o_widgets = {
                 o_search.getHinting(slug);
             }
 
-            // if an input widget just got opened and input slugs are not in opus.selections, 
+            // If an input widget just got opened and input slugs are not in opus.selections, 
             // we need to update opus.selections to make sure input slugs exist.
             if (widgetInputs.hasClass("RANGE")) {
                 if (!opus.selections[`${slug}1`]) {


### PR DESCRIPTION
- Fixes #1037, #1042 
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - Database used: opus3_test_200517
  - All Django tests pass: Y
- Were any JavaScript or CSS files modified? Y
  - JSHINT run on all affected files: Y (widgets.js)
  - Tested on Chrome, Firefox, Safari, and iOS: Y
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): Y

Description of changes:
- Fixed #1037 by encoding the input value before passing into stringsearchchoices API URL.
- Fixed #1042 by making sure when RANGE widgets (without qtype & unit inputs) just get open, the corresponding slugs are updated in opus.selections properly. Previously they are not in opus.selections. 

Known problems:
None