### PR TITLE
Fix issue 804: scrollbar doesn't scroll to the top of widget container when a new widget is open

### DIFF
--- a/opus/application/static_media/js/menu.js
+++ b/opus/application/static_media/js/menu.js
@@ -28,7 +28,7 @@ var o_menu = {
                 // widget is already showing do not fetch another
                 try {
                     // scroll to widget and highlight it
-                    o_widgets.scrollToWidget(`widget__#{slug}`);
+                    o_widgets.scrollToWidget(`widget__${slug}`);
                 } catch(e) {
                     return false;
                 }

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -93,10 +93,24 @@ var o_widgets = {
         });
 
         // open/close mult groupings in widgets
-        $('#search').on('click', '.mult_group_label_container', function() {
-            $(this).find('.indicator').toggleClass('fa-plus');
-            $(this).find('.indicator').toggleClass('fa-minus');
-            $(this).next().slideToggle("fast");
+        $("#search").on("click", ".mult_group_label_container", function() {
+            $(this).find(".indicator").toggleClass("fa-plus");
+            $(this).find(".indicator").toggleClass("fa-minus");
+            let multGroupContents = $(this).next();
+            multGroupContents.slideToggle("fast", function() {
+                let widgetContainerBottomPosition = $("#search #widget-container").offset().top +
+                                                    $("#search #widget-container").height();
+                let targetBottomPosition = $(this).offset().top + $(this).height();
+                // When mult group contents are expanded and covered by the bottom of the window
+                // (footer), scroll the scrollbar so that all checkboxes in the group are visible.
+                if (targetBottomPosition > widgetContainerBottomPosition) {
+                    let offset = $(this).is(":visible") ? $(this).outerHeight() : -$(this).outerHeight();
+                    let currentScrollbarPosition = $("#search #widget-container").scrollTop();
+                    let newScrollbarPosition = currentScrollbarPosition + offset;
+                    $("#search #widget-container").scrollTop(newScrollbarPosition);
+                }
+
+            });
         });
 
         // close a card
@@ -1359,14 +1373,19 @@ var o_widgets = {
 
             opus.widgetsDrawn.unshift(slug);
             o_widgets.customWidgetBehaviors(slug);
-            o_widgets.scrollToWidget(widget);
+
+            // Make sure when a new widget is open at the top, scrollbar always scrolls to the top.
+            $("#search #widget-container").animate({
+                scrollTop: 0
+            }, 500);
+
             if (slug === "surfacegeometrytargetname" && !o_search.areAllSURFACEGEOSelectionsEmpty()) {
                 o_search.getValidMults(slug, true);
             } else {
                 o_search.getHinting(slug);
             }
 
-            // If an input widget just got opened and input slugs are not in opus.selections, 
+            // If an input widget just got opened and input slugs are not in opus.selections,
             // we need to update opus.selections to make sure input slugs exist.
             if (widgetInputs.hasClass("RANGE")) {
                 if (!opus.selections[`${slug}1`]) {
@@ -1535,12 +1554,19 @@ var o_widgets = {
     },
 
     scrollToWidget: function(widget) {
-        // scrolls window to a widget
-        // widget is like: "widget__" + slug
-        //  scroll the widget panel to top
-        $('#search').animate({
-            scrollTop: $("#"+ widget).offset().top
-        }, 1000);
+        /**
+         * Scroll to the target widget when users click on an opened widget slug
+         * name in the search sidebar.
+         */
+        let widgetTargetTopPosition = $(`#${widget}`).offset().top;
+        let widgetContainerTopPosition = $("#search #widget-container").offset().top;
+        let widgetScrollbarPosition = $("#search #widget-container").scrollTop();
+
+        let widgetTargetFinalPosition = (widgetTargetTopPosition - widgetContainerTopPosition +
+                                        widgetScrollbarPosition);
+        $("#search #widget-container").animate({
+            scrollTop: widgetTargetFinalPosition
+        }, 500);
     },
 
     attachStringDropdownToInput: function() {


### PR DESCRIPTION
- Fixes #804 
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - Database used: opus3_test_200517
  - All Django tests pass: Y
- Were any JavaScript or CSS files modified? Y
  - JSHINT run on all affected files: Y
  - Tested on Chrome, Firefox, Safari, and iOS: Y
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:
- Always scroll the scrollbar to the top of widget container when a new widget is open at the top.
- When users click on an opened widget slug name in the search sidebar, scrollbar will scroll to the corresponding widget.
- When mult group contents are expanded and covered by the bottom of the window, scrollbar will scroll so that all checkboxes in the group are visible.

Known problems:
None