### PR TITLE
Issue of triggering search when closing an empty widget

### DIFF
--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -859,11 +859,6 @@ var o_widgets = {
                 }
             }
 
-            // If the closing widget has empty values, don't perform a search.
-            // if (o_widgets.isRemovingEmptyWidget) {
-            //     opus.updateOPUSLastSelectionsWithOPUSSelections();
-            // }
-
             if (opus.areInputsValid()) {
                 // User may have changed input, so trigger search with delay
                 o_hash.updateURLFromCurrentHash(true, true);

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -817,15 +817,27 @@ var o_widgets = {
         o_menu.markMenuItem(selector, "unselect");
 
         let inputs = $(`#widget__${slugNoNum} input`);
-
+        // Reset the flag before checking all inputs
+        o_widgets.isRemovingEmptyWidget = true;
         // Check if the widget to be removed has empty values on all inputs.
         for (const input of inputs) {
-            if ($(input).val() && $(input).val().trim()) {
+            if ($(input).attr("type") === "text" && $(input).val() && $(input).val().trim()) {
+                o_widgets.isRemovingEmptyWidget = false;
+            } else if ($(input).is(":checked")) {
                 o_widgets.isRemovingEmptyWidget = false;
             }
         }
 
         o_widgets.removeInputsValidationInfo(inputs);
+
+        // If the closing widget has empty values, don't perform a normalize input api call & search.
+        if (o_widgets.isRemovingEmptyWidget) {
+            opus.updateOPUSLastSelectionsWithOPUSSelections();
+            if (opus.areInputsValid()) {
+                o_hash.updateURLFromCurrentHash();
+            }
+            return;
+        }
 
         o_search.allNormalizeInputApiCall().then(function(normalizedData) {
             if (normalizedData.reqno < o_search.lastSlugNormalizeRequestNo) {
@@ -848,9 +860,9 @@ var o_widgets = {
             }
 
             // If the closing widget has empty values, don't perform a search.
-            if (o_widgets.isRemovingEmptyWidget) {
-                opus.updateOPUSLastSelectionsWithOPUSSelections();
-            }
+            // if (o_widgets.isRemovingEmptyWidget) {
+            //     opus.updateOPUSLastSelectionsWithOPUSSelections();
+            // }
 
             if (opus.areInputsValid()) {
                 // User may have changed input, so trigger search with delay


### PR DESCRIPTION
- Fixes the issue of triggering search when closing an empty widget.
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - Database used: opus3_test_200517
  - All Django tests pass: Y
- Were any JavaScript or CSS files modified? Y
  - JSHINT run on all affected files: Y
  - Tested on Chrome, Firefox, Safari, and iOS: Y
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): Y

Description of changes:
- Properly reset/set the flag: o_widgets.isRemovingEmptyWidget in closeWidget so that if the closing widget has empty values, we don't perform a normalize input api call & search.

Known problems:
None