### PR TITLE
Issue of widget ps when mult group is expanded

### DIFF
--- a/opus/application/static_media/js/mutationObserver.js
+++ b/opus/application/static_media/js/mutationObserver.js
@@ -137,19 +137,18 @@ var o_mutationObserver = {
         let searchWidgetMultGroupObserver = new MutationObserver(function(mutationsList) {
             let lastMutationIdx = mutationsList.length - 1;
             mutationsList.forEach((mutation, idx) => {
-                if (mutation.type === "attributes" && idx === lastMutationIdx) {
-                    if (mutation.target.classList.value.match(/mult_group/)) {
-                        // If new mult_group is open inside widgets, we update ps
-                        let multGroupContentsHeight = mutation.target.clientHeight;
-                        let widgetContainerBottomPosition = $("#search #widget-container").offset().top +
-                                                            $("#search #widget-container").height();
-                        let targetBottomPosition = $(mutation.target).offset().top + multGroupContentsHeight;
-                        // If the clicked mult group contents is covered, scroll the scrollbar so that all
-                        // contents can be displayed.
-                        let offset = (targetBottomPosition > widgetContainerBottomPosition) ?
-                                     multGroupContentsHeight : 0;
-                        searchWidgetHeightChanged(offset);
-                    }
+                if (mutation.type === "attributes" && idx === lastMutationIdx &&
+                    mutation.target.classList.value.match(/mult_group/)) {
+                    // If new mult_group is open inside widgets, we update ps
+                    let multGroupContentsHeight = mutation.target.clientHeight;
+                    let widgetContainerBottomPosition = $("#search #widget-container").offset().top +
+                                                        $("#search #widget-container").height();
+                    let targetBottomPosition = $(mutation.target).offset().top + multGroupContentsHeight;
+                    // If the clicked mult group contents is covered, scroll the scrollbar so that all
+                    // contents can be displayed.
+                    let offset = (targetBottomPosition > widgetContainerBottomPosition) ?
+                                 multGroupContentsHeight : 0;
+                    searchWidgetHeightChanged(offset);
                 }
             });
         });

--- a/opus/application/static_media/js/mutationObserver.js
+++ b/opus/application/static_media/js/mutationObserver.js
@@ -147,7 +147,7 @@ var o_mutationObserver = {
                     // If the clicked mult group contents is covered, scroll the scrollbar so that all
                     // contents can be displayed.
                     let offset = (targetBottomPosition > widgetContainerBottomPosition) ?
-                                 multGroupContentsHeight : 0;
+                                 (targetBottomPosition - widgetContainerBottomPosition) : 0;
                     searchWidgetHeightChanged(offset);
                 }
             });

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -1064,7 +1064,7 @@ var o_search = {
         o_search.searchScrollbar.update();
     },
 
-    searchWidgetHeightChanged: function() {
+    searchWidgetHeightChanged: function(offset=0) {
         let footerHeight = $(".app-footer").outerHeight();
         let mainNavHeight = $(".op-reset-opus").outerHeight() +
                             $("#op-main-nav").innerHeight() - $("#op-main-nav").height();
@@ -1082,6 +1082,13 @@ var o_search = {
         }
 
         o_search.widgetScrollbar.update();
+        // If offset is not 0, properly scroll the scrollabr so that all the expanded mult
+        // group contents can be displayed on the screen.
+        if (offset) {
+            let currentScrollbarPosition = $("#search #widget-container").scrollTop();
+            let newScrollbarPosition = currentScrollbarPosition + offset;
+            $("#search #widget-container").scrollTop(newScrollbarPosition);
+        }
     },
 
     activateSearchTab: function() {

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -1082,7 +1082,7 @@ var o_search = {
         }
 
         o_search.widgetScrollbar.update();
-        // If offset is not 0, properly scroll the scrollabr so that all the expanded mult
+        // If offset is not 0, properly scroll the scrollbar so that all the expanded mult
         // group contents can be displayed on the screen.
         if (offset) {
             let currentScrollbarPosition = $("#search #widget-container").scrollTop();

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -97,19 +97,13 @@ var o_widgets = {
             $(this).find(".indicator").toggleClass("fa-plus");
             $(this).find(".indicator").toggleClass("fa-minus");
             let multGroupContents = $(this).next();
+            let currentExpandedStatus = $(this).find(".indicator").hasClass("fa-plus") ?
+                                        "expanded" : "collapsed";
             multGroupContents.slideToggle("fast", function() {
-                let widgetContainerBottomPosition = $("#search #widget-container").offset().top +
-                                                    $("#search #widget-container").height();
-                let targetBottomPosition = $(this).offset().top + $(this).height();
-                // When mult group contents are expanded and covered by the bottom of the window
-                // (footer), scroll the scrollbar so that all checkboxes in the group are visible.
-                if (targetBottomPosition > widgetContainerBottomPosition) {
-                    let offset = $(this).is(":visible") ? $(this).outerHeight() : -$(this).outerHeight();
-                    let currentScrollbarPosition = $("#search #widget-container").scrollTop();
-                    let newScrollbarPosition = currentScrollbarPosition + offset;
-                    $("#search #widget-container").scrollTop(newScrollbarPosition);
-                }
-
+                // Toggle the data-status after the animation is done. MutationObserver is set
+                // to detect the change of data-status, so we can always make sure ps gets
+                // updated and scrolled after the animation is done.
+                $(this).attr("data-status", currentExpandedStatus);
             });
         });
 


### PR DESCRIPTION
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - Database used: opus3_test_200517
  - All Django tests pass: Y
- Were any JavaScript or CSS files modified? Y
  - JSHINT run on all affected files: Y
  - Tested on Chrome, Firefox, Safari, and iOS: Y
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:
- When the user clicks a mult group, after the expanding/collapsing animation, toggle the data-status attribute in the target element (container of mult group contents). 
-  Create a mutation observer to detect the change of data-status, so we can always make sure ps gets updated and scrolled after the animation is done.

Known problems:
None