### PR TITLE
Fixed the issue that browse view causes API calls past end of observations

### DIFF
--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -556,6 +556,19 @@ var o_browse = {
             "scrollbarOffset": 0
         });
 
+        // Properly set loadOnScroll. This will avoid loadOnScroll being false when the user
+        // drags the slider from the most right end to the middle.
+        if ($(`${tab} .op-gallery-view`).data("infiniteScroll") &&
+            $(`${tab} .op-data-table-view`).data("infiniteScroll")) {
+            if (value >  viewNamespace.totalObsCount) {
+                $(`${tab} .op-gallery-view`).infiniteScroll({"loadOnScroll": false});
+                $(`${tab} .op-data-table-view`).infiniteScroll({"loadOnScroll": false});
+            } else {
+                $(`${tab} .op-gallery-view`).infiniteScroll({"loadOnScroll": true});
+                $(`${tab} .op-data-table-view`).infiniteScroll({"loadOnScroll": true});
+            }
+        }
+
         opus.prefs[startObsLabel] = value;
 
         if (elem.length > 0) {
@@ -1626,14 +1639,20 @@ var o_browse = {
                         customizedLimitNum = 0;
                     }
 
-                    // if totalObsCount is not yet defined, we still need to init the infinite scroll...
-                    //if (viewNamespace.totalObsCount === undefined || obsNum <= viewNamespace.totalObsCount) {
-                        let path = o_browse.getDataURL(view, obsNum, customizedLimitNum);
-                        return path;
-                    //}
-                    // returning no value indicates end of infinite scroll... but apparently doesn't work at moment.
-                    // NOTE: leaving this commented out code in place with the hope that we will find a solution.
-                    //return null;
+                    let path = o_browse.getDataURL(view, obsNum, customizedLimitNum);
+                    let totalObs = viewNamespace.totalObsCount;
+                    // When it reaches to the end of the search data, disable loadOnScroll so that it
+                    // will not keep calling dataimages.json api with startObs larger the search results.
+                    if (infiniteScrollData) {
+                        if (obsNum > totalObs ) {
+                            $(`${tab} .op-gallery-view`).infiniteScroll({"loadOnScroll": false});
+                            $(`${tab} .op-data-table-view`).infiniteScroll({"loadOnScroll": false});
+                        } else {
+                            $(`${tab} .op-gallery-view`).infiniteScroll({"loadOnScroll": true});
+                            $(`${tab} .op-data-table-view`).infiniteScroll({"loadOnScroll": true});
+                        }
+                    }
+                    return path;
                 },
                 responseType: "text",
                 status: `${tab} .op-page-load-status`,
@@ -1646,6 +1665,7 @@ var o_browse = {
                 // store the most top left obsNum in gallery or the most top obsNum in table
                 obsNum: 1,
                 debug: false,
+                loadOnScroll: true,
             });
 
             $(selector).on("request.infiniteScroll", function(event, path) {


### PR DESCRIPTION
- Fixes #782
- Were any Django, import pipeline, table_schema, or dictionary files modified? Y
  - Database used: opus3_test_200517
  - All Django tests pass: Y
- Were any JavaScript or CSS files modified? Y
  - JSHINT run on all affected files: Y
  - Tested on Chrome, Firefox, Safari, and iOS: Y
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:
- In infiniteScroll path, when the data reaches to the end, disable infiniteScroll load data by setting loadOnScroll to false so it won't keep calling dataimages api with startObs larger the search results.

Known problems:
None