### PR TITLE
Reorder download data buttons to Data Archive, URL Archive, Metadata CSV

### DIFF
--- a/opus/application/apps/cart/templates/cart/cart.html
+++ b/opus/application/apps/cart/templates/cart/cart.html
@@ -19,9 +19,6 @@
                     {% endif %}
                 ">
                 <li class="list-inline-item">
-                    <a href="#" class="op-download-csv btn btn-outline-primary" download title="Download a CSV of selected metadata for all observations in the cart"><i class="fas fa-file-csv"></i>&nbsp;Metadata CSV</a>
-                </li>
-                <li class="list-inline-item">
                     <div id="create_zip_data_file">
                         <a href="#" class="downloadData btn btn-outline-primary" title="Download a zipped data archive of all observations in the cart using the selected products"><i class="fas fa-download"></i>&nbsp;Data Archive</a>
                     </div>
@@ -30,6 +27,9 @@
                     <div id="create_zip_url_file">
                         <a href="#" class="downloadURL btn btn-outline-primary" title="Download a zipped URL archive of all observations in the cart using the selected products"><i class="fas fa-download"></i>&nbsp;URL Archive</a>
                     </div>
+                </li>
+                <li class="list-inline-item">
+                    <a href="#" class="op-download-csv btn btn-outline-primary" download title="Download a CSV of selected metadata for all observations in the cart"><i class="fas fa-file-csv"></i>&nbsp;Metadata CSV</a>
                 </li>
             </div>
             <h1 class="op-download-options-title">Download Options</h1>

--- a/opus/application/apps/help/templates/help/gettingstarted.html
+++ b/opus/application/apps/help/templates/help/gettingstarted.html
@@ -263,17 +263,6 @@ data OPUS has to offer.</p>
 <p>Three basic methods of download are provided:</p>
 
 <ol>
-    <li>A <b>Metadata CSV</b> is a comma-separated value (CSV) text file
-        containing one row per observation. The rows contain all of the
-        metadata fields selected using the <b>Select Metadata</b> option. On
-        the <b>Cart</b> tab, the <i class="fas fa-file-csv"></i> <b>Metadata
-        CSV</b> button will include all of the observations in the cart.
-        On the <b>Browse</b> tab, the
-        <i class="fas fa-download"></i> <b>Download CSV (all results)</b>
-        option will include <em>all</em> of the observations in the result set
-        (which may be a lot!).
-        The <i class="fas fa-bars fa-xs"></i> menu may also be used to create
-        a metadata CSV file for a single observation.</li>
     <li>A <b>Data Archive</b> includes all of the selected data products in
         a single zip file. Also included are a metadata CSV file (data.csv),
         a manifest file (manifest.csv) showing which files are included along
@@ -290,6 +279,17 @@ data OPUS has to offer.</p>
         products can then be retrieved using a command-line utility such as
         <b>wget</b>:
         <pre>    wget -i urls.txt</pre></li>
+    <li>A <b>Metadata CSV</b> is a comma-separated value (CSV) text file
+        containing one row per observation. The rows contain all of the
+        metadata fields selected using the <b>Select Metadata</b> option. On
+        the <b>Cart</b> tab, the <i class="fas fa-file-csv"></i> <b>Metadata
+        CSV</b> button will include all of the observations in the cart.
+        On the <b>Browse</b> tab, the
+        <i class="fas fa-download"></i> <b>Download CSV (all results)</b>
+        option will include <em>all</em> of the observations in the result set
+        (which may be a lot!).
+        The <i class="fas fa-bars fa-xs"></i> menu may also be used to create
+        a metadata CSV file for a single observation.</li>
 </ol>
 
 <h3>Observation Details</h3>


### PR DESCRIPTION
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - Database used: opus3_test_200517
  - All Django tests pass: Y
- Were any JavaScript or CSS files modified? N
  - JSHINT run on all affected files: NA
  - Tested on Chrome, Firefox, Safari, and iOS: Y
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:
In download data pane, the button order from left to right is: Data Archive, URL Archive, Metadata CSV
