### PR TITLE
Small changes to API guide and images API

### DIFF
--- a/opus/application/apps/help/api_guide.md
+++ b/opus/application/apps/help/api_guide.md
@@ -386,7 +386,7 @@ Supported return formats: `json`, `html`, `csv`
 
 | Parameter | Description | Default |
 |---|---|---|
-| `cols=<field list>` | Metadata fields to return | [Default columns](#retrievingmetadata) |
+| `cols=<field list>` | Metadata fields to return | All columns |
 | `cats=<categories>` | If supplied, only returns data for these categories; if `cols` is supplied, `cats` is ignored | All categories |
 
 `categories` is a list of category names separated by commas. Category names can either be full names ending in "Constraints" (e.g. `PDS Constraints` or `Cassini ISS Constraints`) or abbreviated names representing internal database tables (`obs_pds`, `obs_mission_cassini`, or `obs_instrument_coiss`). Full category names must replace spaces with `+` or another appropriate encoding. The list of categories available for an `opusid` can be retrieved with [`api/categories/[opusid].json`](#categoriesopusidfmt).
@@ -691,7 +691,6 @@ Supported return formats: `json`.
 | Parameter | Description | Default |
 |---|---|---|
 | `<searchid>=<value>` | Search parameters (including sort order) | All observations in database |
-| `cols=<fieldid_list>` | Metadata fields to return | [Default columns](#retrievingmetadata) |
 | `startobs=<N>` | The (1-based) observation number to start with | 1 |
 | `limit=<N>` | The maximum number of observations to return | 100 |
 | `types=<types>` | List of product types to return | All product types |
@@ -947,7 +946,7 @@ Get the URLs of images of all sizes (or a given size) based on search criteria a
 
 If specified, `[size]` must be one of `full`, `med`, `small`, or `thumb`.
 
-Supported return formats: `json`, `csv`, `html` is also supported when a specified size is requested.
+Supported return formats: `json`, `csv`. `html` is also supported when a specified size is requested.
 
 #### Parameters
 
@@ -985,7 +984,7 @@ When all sizes are requested, `data` is an object containing a series of entries
 | `<size>_size_bytes` | Size of the image file in bytes |
 | `<size>_width` | Width of the image in pixels |
 | `<size>_height` | Height of the image in pixels |
-| `<size>_url` | Relative path to the image |
+| `<size>_url` | Full URL path to the image |
 
 When one size is requested, `data` an object containing a single entry with these fields:
 
@@ -996,7 +995,7 @@ When one size is requested, `data` an object containing a single entry with thes
 | `size_bytes` | Size of the image file in bytes |
 | `width` | Width of the image in pixels |
 | `height` | Height of the image in pixels |
-| `url` | Relative path to the image |
+| `url` | Full URL path to the image |
 
 Examples:
 

--- a/opus/application/apps/help/templates/help/apiguide.html
+++ b/opus/application/apps/help/templates/help/apiguide.html
@@ -9,7 +9,7 @@
                 <tr>
                     <th>Category<br/>&nbsp;</th>
                     <th>Label<br/>Units</th>
-                    <th>Slug<br/>&nbsp;</th>
+                    <th>Field ID<br/>&nbsp;</th>
                 </tr>
             </thead>
             <tbody>

--- a/opus/application/apps/help/templates/help/apiguide_print.html
+++ b/opus/application/apps/help/templates/help/apiguide_print.html
@@ -8,7 +8,7 @@
             <tr>
                 <th>Category<br/>&nbsp;</th>
                 <th>Label<br/>Units</th>
-                <th>Slug<br/>&nbsp;</th>
+                <th>Field ID<br/>&nbsp;</th>
             </tr>
         </thead>
         <tbody>

--- a/opus/application/apps/tools/file_utils.py
+++ b/opus/application/apps/tools/file_utils.py
@@ -152,7 +152,8 @@ def get_pds_products(opus_id_list,
     return results
 
 
-def get_pds_preview_images(opus_id_list, preview_jsons, sizes=None):
+def get_pds_preview_images(opus_id_list, preview_jsons, sizes=None,
+                           ignore_missing=False):
     """Given a list of opus_ids, return a list of image info for a size.
 
         opus_id_list can be a string or a list.
@@ -214,6 +215,8 @@ def get_pds_preview_images(opus_id_list, preview_jsons, sizes=None):
             if not preview_json or not viewset:
                 # log.error('No preview image size "%s" found for '
                 #           +'opus_id "%s"', size, opus_id)
+                if ignore_missing:
+                    continue
                 url = settings.THUMBNAIL_NOT_FOUND
                 alt_text = 'Not found'
                 byte_size = 0


### PR DESCRIPTION
Fix typos in api guide. Make missing image files show up as blank fields in images api.

- Fixes #N/A
- Were any Django, import pipeline, table_schema, or dictionary files modified? Y
  - Database used: opus3_test_200517
  - All Django tests pass: Y
- Were any JavaScript or CSS files modified? N
  - JSHINT run on all affected files: NA
  - Tested on Chrome, Firefox, Safari, and iOS: NA
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:

Known problems:
