### PR TITLE
Sort pill ascending bug

### DIFF
--- a/opus/application/static_media/js/sortMetadata.js
+++ b/opus/application/static_media/js/sortMetadata.js
@@ -31,7 +31,8 @@ let o_sortMetadata = {
                 let newOrder = [];
                 $(this).find(".list-inline-item span.badge-pill").each(function(index, obj) {
                     let slug = $(obj).data("slug");
-                    newOrder.push(slug);
+                    let descending = ($(obj).data("descending") === true ? "-" : "");
+                    newOrder.push(`${descending}${slug}`);
                 });
                 // only bother if something actually changed...
                 if (!o_utils.areObjectsEqual(opus.prefs.order, newOrder)) {

--- a/opus/application/static_media/js/sortMetadata.js
+++ b/opus/application/static_media/js/sortMetadata.js
@@ -24,6 +24,7 @@ let o_sortMetadata = {
             items: "div.op-sort-only",
             cursor: "grab",
             containment: "parent",
+            helper: "clone",
             tolerance: "intersect",
             cancel: ".op-no-sort",
             stop: function(event, ui) {


### PR DESCRIPTION
- Fixes #<no issue logged>
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - Database used: opus3_test_200211
  - All Django tests pass: Y/N/NA
- Were any JavaScript or CSS files modified? Y
  - JSHINT run on all affected files: Y; issue at line 61 in sortMetadata unrelated to changes noted
  - Tested on Chrome, Firefox, Safari, and iOS: Y
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): Y/N/NA

Description of changes:
-update the object w/the ascend char for object comparison w/opus.prev.col
-add to sortable helper: clone to prevent event propagation on the sort pill for firefox

Known problems:
