### PR TITLE
Manually trigger change event when user focused out an input if the d…

### DIFF
--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -998,6 +998,10 @@ var o_search = {
             if (!opus.areInputsValid()) {
                 delete opus.normalizeInputForAllFieldsInProgress[slug];
                 opus.navLinkRemembered = null;
+                // This is for the case when we change a valid search (result1) to an invalid
+                // search (result2), and later on change back to result1, there will be a search
+                // triggered again to put back the valid green hints instead of keeping "?".
+                opus.force_load = true;
                 return;
             }
 
@@ -1021,6 +1025,21 @@ var o_search = {
             $("#sidebar").removeClass("search_overlay");
             delete opus.normalizeInputForAllFieldsInProgress[slug];
             opus.changeTabToRemembered();
+
+            let slugNoCounter = o_utils.getSlugOrDataWithoutCounter(slug);
+            let uniqueid = o_utils.getSlugOrDataTrailingCounterStr(slug);
+            let targetInput = $(`input.RANGE[name^="${slugNoCounter}"][data-uniqueid="${uniqueid}"]`);
+            // Re-focus into the min input so that it will remember the current value (minVal) as
+            // the old value. That way, when user changes the input value (new value), this old value
+            // will be used for comparison to determine if a change event should fire. Note: if we
+            // don't re-focus into the min input, the old value will be the value when we first focused
+            // the input before selecting the preprogrammed item (not minVal).
+            if (o_widgets.isReFocusingBackToInput && targetInput.hasClass("op-range-input-min") &&
+                targetInput.hasClass("op-ranges-dropdown-menu")) {
+                targetInput.blur();
+                targetInput.focus();
+                o_widgets.isReFocusingBackToInput = false;
+            }
         });
     },
 

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -44,6 +44,10 @@ var o_widgets = {
     // inputs have values, we don't need to perform a search.
     isRemovingEmptyWidget: true,
 
+    // This flag is used to make sure dropdown is not open again when we re-focus into
+    // an input after a preprogrammed range item is selected.
+    isReFocusingBackToInput: false,
+
     addWidgetBehaviors: function() {
         $("#op-search-widgets").sortable({
             items: "> li",
@@ -228,6 +232,16 @@ var o_widgets = {
                 let uniqueid = minInput.attr("data-uniqueid");
                 let oppositeSuffixSlug = (slug.match(/(.*)1$/) ? `${slugName}2` : `${slugName}1`);
                 $(`#${widgetId} input.RANGE[name*="${oppositeSuffixSlug}"][data-uniqueid="${uniqueid}"]`).trigger("change");
+
+                // Re-focus into the min input so that it will remember the current value (minVal) as
+                // the old value. That way, when user changes the input value (new value), this old value
+                // will be used for comparison to determine if a change event should fire. Note: if we
+                // don't re-focus into the min input, the old value will be the value when we first focused
+                // the input before selecting the preprogrammed item (not minVal).
+                o_widgets.isReFocusingBackToInput = true;
+                $(`#${widgetId} input.RANGE[name="${minInputSlug}"]`).blur();
+                $(`#${widgetId} input.RANGE[name="${minInputSlug}"]`).focus();
+                o_widgets.isReFocusingBackToInput = false;
             }
         });
 

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -233,15 +233,7 @@ var o_widgets = {
                 let oppositeSuffixSlug = (slug.match(/(.*)1$/) ? `${slugName}2` : `${slugName}1`);
                 $(`#${widgetId} input.RANGE[name*="${oppositeSuffixSlug}"][data-uniqueid="${uniqueid}"]`).trigger("change");
 
-                // Re-focus into the min input so that it will remember the current value (minVal) as
-                // the old value. That way, when user changes the input value (new value), this old value
-                // will be used for comparison to determine if a change event should fire. Note: if we
-                // don't re-focus into the min input, the old value will be the value when we first focused
-                // the input before selecting the preprogrammed item (not minVal).
                 o_widgets.isReFocusingBackToInput = true;
-                $(`#${widgetId} input.RANGE[name="${minInputSlug}"]`).blur();
-                $(`#${widgetId} input.RANGE[name="${minInputSlug}"]`).focus();
-                o_widgets.isReFocusingBackToInput = false;
             }
         });
 


### PR DESCRIPTION
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - Database used: opus3_test_200517
  - All Django tests pass: Y
- Were any JavaScript or CSS files modified? Y
  - JSHINT run on all affected files: Y
  - Tested on Chrome, Firefox, Safari, and iOS: Y
    (Remember to test all browser sizes)
  - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:
When the user removed input value and focused out an input, sometimes the "change" event will not be fired. We manually fire the "change" event in the "focusout" event handler when this situation happened.

Known problems:
None