### PR TITLE
Select metadata cleanup 

### DIFF
--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -353,7 +353,7 @@
                             <i class="far fa-times-circle fa-lg text-light"></i>
                         </button>
                     </div>
-                    <div class="modal-body op-select-metadata-details" id="op-select-metadata-contents"></div>
+                    <div id="op-select-metadata-contents" class="modal-body"></div>
                     <div class="modal-footer">
                         <div class="left-container">
                             <button type="reset" class="btn btn-info">Reset to Default</button>

--- a/opus/application/apps/ui/templates/ui/select_metadata.html
+++ b/opus/application/apps/ui/templates/ui/select_metadata.html
@@ -24,7 +24,7 @@
     <div class='loader'></div>
 </div>
 
-<div class="row op-select-metadata-contents">
+<div class="row op-select-metadata-row-contents">
     <div class="col">
         <div class="op-all-metadata-column">
             {{ block.super }} {# renders ui/menu.html #}

--- a/opus/application/apps/ui/templates/ui/select_metadata.html
+++ b/opus/application/apps/ui/templates/ui/select_metadata.html
@@ -24,7 +24,7 @@
     <div class='loader'></div>
 </div>
 
-<div class="row">
+<div class="row op-select-metadata-contents">
     <div class="col">
         <div class="op-all-metadata-column">
             {{ block.super }} {# renders ui/menu.html #}

--- a/opus/application/apps/ui/templates/ui/select_metadata.html
+++ b/opus/application/apps/ui/templates/ui/select_metadata.html
@@ -20,6 +20,10 @@
     </div>
 </div>
 <hr class="op-select-metadata-headers-hr">
+<div class="op-select-metadata-load-status">
+    <div class='loader'></div>
+</div>
+
 <div class="row">
     <div class="col">
         <div class="op-all-metadata-column">

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2030,7 +2030,8 @@ even when screen is narrow */
 }
 
 /* large ellips spinner */
-.op-page-loading-status .loader {
+.op-page-loading-status .loader,
+.op-select-metadata-load-status .loader {
     display: none;
     /* top: 250px; */
 }
@@ -3182,7 +3183,7 @@ when wrapping into the 2nd line */
 @media (max-height: 400px) {
     /* Hide download csv button menu in select metadata menu when screen is short
     (browse tab) */
-    .op-select-metadata-details .op-download-csv {
+    #op-select-metadata-contents .op-download-csv {
         display: none !important;
     }
 

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -488,12 +488,6 @@ var opus = {
         // deselect any leftover selected text for clean slate
         document.getSelection().removeAllRanges();
 
-        // if the selectMetadata modal is in the process of rendering, disable
-        // the menu option on all tabs temporarily - will be enabled after render complete
-        if (!o_selectMetadata.rendered) {
-            o_selectMetadata.disableSelectMetadataButton();
-        }
-
         switch(opus.prefs.view) {
             case "search":
                 window.scrollTo(0,0);

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -488,6 +488,12 @@ var opus = {
         // deselect any leftover selected text for clean slate
         document.getSelection().removeAllRanges();
 
+        // if the selectMetadata modal is in the process of rendering, disable
+        // the menu option on all tabs temporarily - will be enabled after render complete
+        if (!o_selectMetadata.rendered) {
+            o_selectMetadata.disableSelectMetadataButton();
+        }
+
         switch(opus.prefs.view) {
             case "search":
                 window.scrollTo(0,0);
@@ -716,6 +722,7 @@ var opus = {
         o_cart.addCartBehaviors();
         o_search.addSearchBehaviors();
         o_sortMetadata.addBehaviours();
+        o_selectMetadata.addBehaviors();
     },
 
     addOpusBehaviors: function() {

--- a/opus/application/static_media/js/selectMetadata.js
+++ b/opus/application/static_media/js/selectMetadata.js
@@ -130,10 +130,9 @@ var o_selectMetadata = {
 
     showMenuLoaderSpinner: function() {
         o_selectMetadata.spinnerTimer = setTimeout(function() {
-            $("#op-select-metadata .op-menu-spinner.spinner").addClass("op-show-spinner");
             $(`.op-select-metadata-load-status > .loader`).show();
-            o_utils.disableUserInteraction();
             $("#op-select-metadata .op-select-metadata-contents").css("opacity", "0.1");
+            o_utils.disableUserInteraction();
         }, opus.spinnerDelay);
 
         if ($("#galleryView").hasClass("show")) {

--- a/opus/application/static_media/js/selectMetadata.js
+++ b/opus/application/static_media/js/selectMetadata.js
@@ -320,9 +320,7 @@ var o_selectMetadata = {
         o_menu.markMenuItem("#op-select-metadata .op-all-metadata-column a", "unselect");
         // remove all from selected column
         $("#op-select-metadata .op-selected-metadata-column li").remove();
-
-        opus.prefs.cols = [];
-        $.extend(opus.prefs.cols, o_selectMetadata.originalOpusPrefsCols);
+        opus.prefs.cols = o_selectMetadata.originalOpusPrefsCols.map((x) => x);
 
         // add them back in...
         $(opus.prefs.cols).each(function(index, slug) {

--- a/opus/application/static_media/js/selectMetadata.js
+++ b/opus/application/static_media/js/selectMetadata.js
@@ -15,7 +15,11 @@ const gapBetweenBottomEdgeAndMetadataModal = 55;
 /* jshint varstmt: false */
 var o_selectMetadata = {
 /* jshint varstmt: true */
-    selectMetadataDrawn: false,
+    // PS scrollbars - defining here; they will need to be set to NULL to release
+    // memory and enable garbage collection whenever a new render of the modal is requested
+    allMetadataScrollbar: null,
+    selectedMetadataScrollbar: null,
+
     // A flag to determine if the sortable item sorting is happening. This
     // will be used in mutation observer to determine if scrollbar location should
     // be set.
@@ -73,7 +77,7 @@ var o_selectMetadata = {
             o_browse.hidePageLoaderSpinner();
         });
 
-        $("#op-select-metadata .op-all-metadata-column").on("click", '.submenu li a', function() {
+        $("#op-select-metadata").on("click", ".op-all-metadata-column .submenu li a", function() {
             let slug = $(this).data('slug');
             if (!slug) { return; }
 
@@ -89,7 +93,7 @@ var o_selectMetadata = {
         });
 
         // removes chosen column
-        $("#op-select-metadata .op-selected-metadata-column").on("click", "li .op-selected-metadata-unselect", function() {
+        $("#op-select-metadata").on("click", ".op-selected-metadata-column li .op-selected-metadata-unselect", function() {
             let slug = $(this).parent().attr("id").split('__')[1];
             o_selectMetadata.removeColumn(slug);
             return false;
@@ -127,6 +131,8 @@ var o_selectMetadata = {
     showMenuLoaderSpinner: function() {
         o_selectMetadata.spinnerTimer = setTimeout(function() {
             $("#op-select-metadata .op-menu-spinner.spinner").addClass("op-show-spinner");
+            $(`.op-select-metadata-load-status > .loader`).show();
+            o_utils.disableUserInteraction();
         }, opus.spinnerDelay);
 
         if ($("#galleryView").hasClass("show")) {
@@ -135,7 +141,20 @@ var o_selectMetadata = {
     },
 
     hideMenuLoaderSpinner: function() {
-        clearTimeout(o_selectMetadata.spinnerTimer);
+        if (o_selectMetadata.spinnerTimer !== null) {
+            clearTimeout(o_selectMetadata.spinnerTimer);
+            $(`.op-select-metadata-load-status > .loader`).hide();
+            o_selectMetadata.spinnerTimer = null;
+        }
+        o_utils.enableUserInteraction();
+    },
+
+    disableSelectMetadataButton: function() {
+        $(`.op-metadata-modal.nav-link`).addClass("op-button-disabled");
+    },
+
+    enableSelectMetadataButton: function() {
+        $(`.op-metadata-modal.nav-link`).removeClass("op-button-disabled");
     },
 
     render: function() {
@@ -144,6 +163,7 @@ var o_selectMetadata = {
         let buttonTitle = (tab === "#cart" ? "Download CSV (in cart)" : "Download CSV (all results)");
 
         if (!o_selectMetadata.rendered) {
+            o_selectMetadata.disableSelectMetadataButton();
             o_selectMetadata.showMenuLoaderSpinner();
 
             // We use getFullHashStr instead of getHash because we want the updated
@@ -176,9 +196,13 @@ var o_selectMetadata = {
                 if (data.reqno < o_selectMetadata.lastMetadataMenuRequestNo) {
                     return;
                 }
-                $(".op-select-metadata-details").html(data.html);
+                // cleanup first
+                o_selectMetadata.allMetadataScrollbar = null;
+                o_selectMetadata.selectedMetadataScrollbar = null;
+                $("#op-select-metadata .op-selected-metadata-column > ul").sortable("destroy");
+
+                $("#op-select-metadata-contents").html(data.html);
                 $("#op-add-metadata-fields .op-select-list").html(data.add_field_html);
-                o_selectMetadata.rendered = true;  // bc this gets saved not redrawn
                 $("#op-select-metadata .op-reset-button").hide(); // we are not using this
 
                 // since we are rendering the left side of metadata selector w/the same code that builds the select menu,
@@ -205,15 +229,6 @@ var o_selectMetadata = {
                 o_browse.checkForEmptyMetadataList();
 
                 o_menu.wrapTriangleArrowAndLastWordOfMenuCategory("#op-select-metadata");
-
-                // Prevent the same event handlers from being attached to #op-select-metadata
-                // for multiple times. This will avoid o_selectMetadata.render() and
-                // /opus/__fake/__selectmetadatamodal.json being called for multiple times when
-                // the user clicks "Select Metadata" in browse tab.
-                $("#op-select-metadata").off("hide.bs.modal");
-                $("#op-select-metadata").off("show.bs.modal");
-
-                o_selectMetadata.addBehaviors();
 
                 o_selectMetadata.allMetadataScrollbar = new PerfectScrollbar("#op-select-metadata-contents .op-all-metadata-column", {
                     minScrollbarLength: opus.minimumPSLength
@@ -249,10 +264,11 @@ var o_selectMetadata = {
                 o_selectMetadata.lastSavedSelected = $("#op-select-metadata .op-selected-metadata-column > ul").find("li");
                 o_selectMetadata.saveOpusPrefsCols();
                 o_selectMetadata.adjustHeight();
-                o_selectMetadata.rendered = true;
                 o_selectMetadata.hideOrShowPS();
                 o_selectMetadata.hideOrShowMenuPS();
                 o_selectMetadata.hideMenuLoaderSpinner();
+                o_selectMetadata.enableSelectMetadataButton();
+                o_selectMetadata.rendered = true;
             });
         }
         $("#op-select-metadata a.op-download-csv").attr("title", downloadTitle);
@@ -265,8 +281,7 @@ var o_selectMetadata = {
     },
 
     saveOpusPrefsCols: function() {
-        o_selectMetadata.originalOpusPrefsCols = [];
-        $.extend(o_selectMetadata.originalOpusPrefsCols, opus.prefs.cols);
+        o_selectMetadata.originalOpusPrefsCols = opus.prefs.cols.map((x) => x);
     },
 
     addColumn: function(slug) {

--- a/opus/application/static_media/js/selectMetadata.js
+++ b/opus/application/static_media/js/selectMetadata.js
@@ -150,21 +150,12 @@ var o_selectMetadata = {
         o_utils.enableUserInteraction();
     },
 
-    disableSelectMetadataButton: function() {
-        $(`.op-metadata-modal.nav-link`).addClass("op-button-disabled");
-    },
-
-    enableSelectMetadataButton: function() {
-        $(`.op-metadata-modal.nav-link`).removeClass("op-button-disabled");
-    },
-
     render: function() {
         let tab = opus.getViewTab();
         let downloadTitle = (tab === "#cart" ? "Download a CSV of selected metadata for all observations in the cart" : "Download CSV of selected metadata for ALL observations in current results");
         let buttonTitle = (tab === "#cart" ? "Download CSV (in cart)" : "Download CSV (all results)");
 
         if (!o_selectMetadata.rendered) {
-            o_selectMetadata.disableSelectMetadataButton();
             o_selectMetadata.showMenuLoaderSpinner();
 
             // We use getFullHashStr instead of getHash because we want the updated
@@ -268,7 +259,6 @@ var o_selectMetadata = {
                 o_selectMetadata.hideOrShowPS();
                 o_selectMetadata.hideOrShowMenuPS();
                 o_selectMetadata.hideMenuLoaderSpinner();
-                o_selectMetadata.enableSelectMetadataButton();
                 o_selectMetadata.rendered = true;
             });
         }

--- a/opus/application/static_media/js/selectMetadata.js
+++ b/opus/application/static_media/js/selectMetadata.js
@@ -133,6 +133,7 @@ var o_selectMetadata = {
             $("#op-select-metadata .op-menu-spinner.spinner").addClass("op-show-spinner");
             $(`.op-select-metadata-load-status > .loader`).show();
             o_utils.disableUserInteraction();
+            $("#op-select-metadata .op-select-metadata-contents").css("opacity", "0.1");
         }, opus.spinnerDelay);
 
         if ($("#galleryView").hasClass("show")) {
@@ -144,6 +145,7 @@ var o_selectMetadata = {
         if (o_selectMetadata.spinnerTimer !== null) {
             clearTimeout(o_selectMetadata.spinnerTimer);
             $(`.op-select-metadata-load-status > .loader`).hide();
+            $("#op-select-metadata .op-select-metadata-contents").css("opacity", "1");
             o_selectMetadata.spinnerTimer = null;
         }
         o_utils.enableUserInteraction();

--- a/opus/application/static_media/js/selectMetadata.js
+++ b/opus/application/static_media/js/selectMetadata.js
@@ -130,8 +130,8 @@ var o_selectMetadata = {
 
     showMenuLoaderSpinner: function() {
         o_selectMetadata.spinnerTimer = setTimeout(function() {
-            $(`.op-select-metadata-load-status > .loader`).show();
-            $("#op-select-metadata .op-select-metadata-contents").css("opacity", "0.1");
+            $(".op-select-metadata-load-status > .loader").show();
+            $(".op-select-metadata-row-contents").css("opacity", "0.1");
             o_utils.disableUserInteraction();
         }, opus.spinnerDelay);
 
@@ -143,8 +143,8 @@ var o_selectMetadata = {
     hideMenuLoaderSpinner: function() {
         if (o_selectMetadata.spinnerTimer !== null) {
             clearTimeout(o_selectMetadata.spinnerTimer);
-            $(`.op-select-metadata-load-status > .loader`).hide();
-            $("#op-select-metadata .op-select-metadata-contents").css("opacity", "1");
+            $(".op-select-metadata-load-status > .loader").hide();
+            $(".op-select-metadata-row-contents").css("opacity", "1");
             o_selectMetadata.spinnerTimer = null;
         }
         o_utils.enableUserInteraction();


### PR DESCRIPTION
- Fixes #966
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - If YES:
    - Database used: XXX
    - All Django tests pass: Y/NA
    - FLAKE8 run on modified code: Y/NA
- Were any JavaScript or CSS files modified? Y
  - If YES:
    - JSHINT run on all affected files: Y
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): Y

Description of changes:
-Add a loader/spinner to the select metadata modal that is activated while the modal is rendered
-Set the contents of the modal to opacity .1 while loading the new data
-Initialize the PS globals to null; set them to null before a render to destroy any memory being used by them
-Destroy the sortable object before a new render
-update the event handlers and move the o_selectMetadata.addBehaviors from the render to opus.js where all the other addBehaviors live
-removed unused global selectMetadataDrawn


Known problems:
