### PR TITLE
Bug in Array.prototype.last.  

### DIFF
--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -2333,7 +2333,8 @@ var o_browse = {
         let left = targetPosition.left;
         let width = $(elem).outerWidth();
         // need to adjust for the PerfectScrollbar overlaying a bit on the last field
-        if (slug === opus.prefs.cols.last()) {
+        let lastSlug = opus.prefs.cols[opus.prefs.cols.length - 1];
+        if (slug === lastSlug) {
             width -= $(`.op-data-table-view .ps__thumb-y`).width();
         }
         let top = $(elem).offset().top +

--- a/opus/application/static_media/js/utils.js
+++ b/opus/application/static_media/js/utils.js
@@ -154,8 +154,3 @@ $.fn.isOnScreen = function(scope, slop) {
 
     return (elementTop + offset <= bottom) && (elementTop >= top);
 };
-
-// more convenient this way... 
-Array.prototype.last = function() {
-    return this[this.length-1];
-}


### PR DESCRIPTION
Odd behaviour in Array.prototype that caused the function to become part of the DOM

- Fixes #XXX
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - If YES:
    - Database used: XXX
    - All Django tests pass: Y/NA
    - FLAKE8 run on modified code: Y/NA
- Were any JavaScript or CSS files modified? Y
  - If YES:
    - JSHINT run on all affected files: Y/NA
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y/NA
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): Y/NA

Description of changes:

Known problems:
