### PR TITLE
Dummy pull with notes on upgrading to Django 3.x

### DIFF
--- a/opus/application/apps/metadata/views.py
+++ b/opus/application/apps/metadata/views.py
@@ -30,7 +30,7 @@ from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Max, Min, Count
 from django.http import Http404, HttpResponseServerError
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.views.decorators.cache import never_cache
 
 from cart.models import Cart
@@ -130,7 +130,7 @@ def api_get_result_count(request, fmt, internal=False):
     if fmt == 'json':
         ret = json_response({'data': [data]})
     elif fmt == 'html':
-        ret = render_to_response('metadata/result_count.html', {'data': data})
+        ret = render(None, 'metadata/result_count.html', {'data': data})
     elif fmt == 'csv':
         ret = csv_response('result_count', [['result count', count]])
     else: # pragma: no cover
@@ -321,7 +321,7 @@ def api_get_mult_counts(request, slug, fmt, internal=False):
     if fmt == 'json':
         ret = json_response(data)
     elif fmt == 'html':
-        ret = render_to_response('metadata/mults.html', data)
+        ret = render(None, 'metadata/mults.html', data)
     elif fmt == 'csv':
         ret = csv_response(slug, [list(mults.values())],
                            column_names=list(mults.keys()))
@@ -542,8 +542,8 @@ def api_get_range_endpoints(request, slug, fmt, internal=False):
     if fmt == 'json':
         ret = json_response(range_endpoints)
     elif fmt == 'html':
-        ret = render_to_response('metadata/endpoints.html',
-                                 {'data': range_endpoints})
+        ret = render(None, 'metadata/endpoints.html',
+                     {'data': range_endpoints})
     elif fmt == 'csv':
         ret = csv_response(slug, [[range_endpoints['min'],
                                    range_endpoints['max'],

--- a/requirements-python3-mac.txt
+++ b/requirements-python3-mac.txt
@@ -5,12 +5,12 @@ coverage==4.5.4
 # Use old version of Django here to avoid the issue about wrong version
 # of mysqlclient which is not used in mac. (Note: Upgrade mysqlclient to
 # the newer version will not solve the issue)
-Django==2.1.5
+Django==3.0.10
 django-annoying==0.10.5
 django-memcached==0.1.2
-django-nose==1.4.6
+django-nose==1.4.7
 django-storages==1.7.2
-djangorestframework==3.10.3
+djangorestframework==3.11.1
 docopt==0.6.2
 flake8==3.8.3
 hurry.filesize==0.9
@@ -21,6 +21,7 @@ MarkupSafe==1.1.1
 mccabe==0.6.1
 mistune==0.8.4
 mysql-connector-python==8.0.13
+mysqlclient==2.0.1
 nose==1.3.7
 numpy==1.17.3
 oyaml==0.9

--- a/requirements-python3.txt
+++ b/requirements-python3.txt
@@ -2,12 +2,12 @@ certifi==2019.9.11
 chardet==3.0.4
 colorclass==2.2.0
 coverage==4.5.4
-Django==2.2.6
+Django==3.0.10
 django-annoying==0.10.5
 django-memcached==0.1.2
-django-nose==1.4.6
+django-nose==1.4.7
 django-storages==1.7.2
-djangorestframework==3.10.3
+djangorestframework==3.11.1
 docopt==0.6.2
 flake8==3.8.3
 hurry.filesize==0.9
@@ -17,7 +17,7 @@ Jinja2==2.10.3
 MarkupSafe==1.1.1
 mccabe==0.6.1
 mistune==0.8.4
-mysqlclient==1.4.4
+mysqlclient==2.0.1
 nose==1.3.7
 numpy==1.17.3
 oyaml==0.9


### PR DESCRIPTION
- Addresses: #1084 
- Known problems of upgrading to either Django 3.1.2 or 3.0.10
    - Version 3.1.2: (Need to wait for update on sql_flush call in django_nose for python manage.py test to work)
        - python manage.py test can't be run. We need to wait for the update on sql_flush call in django_nose.
        - Reference: https://github.com/wemake-services/django-test-migrations/issues/117
    - Version 3.0.10: (Need to add a workaround to remove session from cache in base.py to make it work)
        - To have python manage.py runserver to work, we need to add a workaround to remove session from cahce under python site-packages "django/contrib/sessions/backends/base.py", we don't need this workaround in 3.1.x. After workaround runserver will work, and test will pass.
        - Reference: https://code.djangoproject.com/ticket/31592

- Requirement for Django version 3.x:
    - Change "render_to_response" to "render"
    - Reference: https://stackoverflow.com/questions/55911435/django-importerror-cannot-import-name-render-to-response-from-django-shortcu

- Note: mysqlclient==2.0.1 is required for runserver to work on mac.
