### PR TITLE
-implement the up/down keys for the gallery view/slide modal

### DIFF
--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -333,7 +333,6 @@
                                 </div>
                                 <div class="op-metadata-details">
                                     <div class="contents mr-2"></div>
-                                    <div class="loader"></div>
                                 </div>
                                 <div class="row bottom"></div>
                             </div>

--- a/opus/application/static_media/css/loader.css
+++ b/opus/application/static_media/css/loader.css
@@ -19,7 +19,7 @@
     -webkit-animation: spin 2s linear infinite;
     animation: spin 2s linear infinite;
     /* this is to display the spinner over the modal */
-    z-index: 1000;
+    z-index: 3000;
 }
 .loader:before {
     content: "";

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -2027,7 +2027,6 @@ var o_browse = {
             o_browse.renderGalleryAndTable(data, this.url, view);
 
             if (opus.metadataDetailOpusId !== "") {
-                let obsNum =  o_browse.getGalleryElement(opus.metadataDetailOpusId).data("obs");
                 o_browse.metadataboxHtml(opus.metadataDetailOpusId, view);
             }
             o_sortMetadata.updateSortOrder(data);
@@ -2568,7 +2567,7 @@ var o_browse = {
             let buttonInfo = o_browse.cartButtonInfo(action);
 
             // prev/next buttons - put this in galleryView html...
-            html = `<div class="col"><a href="#" class="op-cart-toggle" data-id="${opusId}" title="${buttonInfo[tab].title} (spacebar)"><i class="${buttonInfo[tab].icon} fa-2x float-left"></i></a></div>`;
+            let html = `<div class="col"><a href="#" class="op-cart-toggle" data-id="${opusId}" title="${buttonInfo[tab].title} (spacebar)"><i class="${buttonInfo[tab].icon} fa-2x float-left"></i></a></div>`;
             html += `<div class="col text-center op-obs-direction">`;
             let opPrevDisabled = (nextPrevHandles.prev == "" ? "op-button-disabled" : "");
             let opNextDisabled = (nextPrevHandles.next == "" ? "op-button-disabled" : "");

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -553,7 +553,6 @@ var o_browse = {
                         }
                         break;
                     case 38:  // up
-                        // note that if there is no where to go in the up direction, nothing will change ... it could go to the very first, tho
                         offset = (o_browse.isGalleryView() ? viewNamespace.galleryBoundingRect.x : 1);
                         if (obsNum > offset) {
                             obsNum -= offset;
@@ -567,7 +566,6 @@ var o_browse = {
                         }
                         return false;
                     case 40:  // down
-                        // note that if there are not enough left to go down, nothing will change ... it could go to the very last tho
                         offset = (o_browse.isGalleryView() ? viewNamespace.galleryBoundingRect.x : 1);
                         if (obsNum + offset <= viewNamespace.totalObsCount) {
                             obsNum += offset;

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -526,18 +526,19 @@ var o_browse = {
                 let detailOpusId;
                 let offset = 0;
                 let obsNum = $("#galleryViewContents .op-obs-direction a").data("obs");
+                let lastCachedObsNum = $(`${tab} .op-thumbnail-container`).last().data("obs");
                 // the || is for cross-browser support; firefox does not support keyCode
                 switch (e.which || e.keyCode) {
                     case 32:  // spacebar
-                        if ((opus.metadataDetailOpusId !== "" && opus.metadataDetailOpusId !== undefined) && !$("#galleryViewContents").hasClass("op-disabled")) {
+                        if (opus.metadataDetailOpusId !== "" && opus.metadataDetailOpusId !== undefined && !$("#galleryViewContents").hasClass("op-disabled")) {
                             o_browse.undoRangeSelect();
                             o_cart.toggleInCart(opus.metadataDetailOpusId);
                         }
                         break;
                     case 39:  // next
                         obsNum++;
-                        // if this new observation is in the last row of screen, don't allow the user to arrow there
-                        if (!o_browse.isLastRowOfObservations(tab, viewNamespace, obsNum)) {
+                        // if this new observation is in the last row of cached observations, don't allow the user to arrow there
+                        if (lastCachedObsNum === viewNamespace.totalObsCount || obsNum + viewNamespace.galleryBoundingRect.x <= lastCachedObsNum) {
                             detailOpusId = $("#galleryView").find(".op-next").data("id");
                             o_browse.removeEditMetadataDetails();
                             o_browse.loadPageIfNeeded("next", detailOpusId);
@@ -564,8 +565,8 @@ var o_browse = {
                         offset = (o_browse.isGalleryView() ? viewNamespace.galleryBoundingRect.x : 1);
                         if (obsNum + offset <= viewNamespace.totalObsCount) {
                             obsNum += offset;
-                            // if this new observation is in the last row of screen, don't allow the user to arrow there
-                            if (!o_browse.isLastRowOfObservations(tab, viewNamespace, obsNum)) {
+                            // if this new observation is in the last row of cached observations, don't allow the user to arrow there
+                            if (lastCachedObsNum === viewNamespace.totalObsCount || obsNum + viewNamespace.galleryBoundingRect.x <= lastCachedObsNum) {
                                 detailOpusId = (o_browse.isGalleryView() ? $(tab).find(`.op-thumbnail-container[data-obs='${obsNum}']`).data("id") : $(tab).find(`tr[data-obs='${obsNum}']`).data("id"));
                                 o_browse.removeEditMetadataDetails();
                                 o_browse.loadPageIfNeeded("next", detailOpusId);
@@ -584,18 +585,9 @@ var o_browse = {
         });
     }, // end browse behaviors
 
-    isLastRowOfObservations: function(tab, viewNamespace, obsNum) {
-        let firstObsOnScreen = $(`${tab} .op-observation-slider`).slider("option", "value");
-        let obsPerRow = viewNamespace.galleryBoundingRect.x;
-        let totalObsOnScreen = obsPerRow * viewNamespace.galleryBoundingRect.yFloor;
-        let beginningOfLastRow = firstObsOnScreen + (totalObsOnScreen - obsPerRow);
-        let lastObs = $(`${tab} .op-thumbnail-container`).last().data("obs");
-        return (lastObs - firstObsOnScreen < o_browse.getLimit() && obsNum >= beginningOfLastRow);
-    },
-
     onGalleryOrRowClick: function(obj, e) {
-        // make sure selected modal thumb is unhighlighted, as clicking on this closes the modal
-        // but is not caught in time before hidden.bs to get correct opusId
+        // make sure selected slide show modal thumb is unhighlighted, as clicking on this closes
+        // the slide show modal but is not caught in time before hidden.bs to get correct opusId
         e.preventDefault();
         o_browse.hideMenus();
 

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -539,12 +539,18 @@ var o_browse = {
                         obsNum++;
                         o_browse.removeEditMetadataDetails();
                         o_browse.loadPageIfNeeded("next", detailOpusId);
+                        if (!$("#galleryViewContents").hasClass("op-disabled")) {
+                            o_browse.updateGalleryView(detailOpusId, obsNum);
+                        }
                         break;
                     case 37:  // prev
                         detailOpusId = $("#galleryView").find(".op-prev").data("id");
                         obsNum--;
                         o_browse.removeEditMetadataDetails();
                         o_browse.loadPageIfNeeded("prev", detailOpusId);
+                        if (!$("#galleryViewContents").hasClass("op-disabled")) {
+                            o_browse.updateGalleryView(detailOpusId, obsNum);
+                        }
                         break;
                     case 38:  // up
                         // note that if there is no where to go in the up direction, nothing will change ... it could go to the very first, tho
@@ -554,8 +560,12 @@ var o_browse = {
                             detailOpusId = (o_browse.isGalleryView() ? $(tab).find(`.op-thumbnail-container[data-obs='${obsNum}']`).data("id") : $(tab).find(`tr[data-obs='${obsNum}']`).data("id"));
                             o_browse.removeEditMetadataDetails();
                             o_browse.loadPageIfNeeded("prev", detailOpusId);
+                            // note: need to check for detailOpusId because if the next window is loading, it could still be undefined at this point
+                            if (detailOpusId && !$("#galleryViewContents").hasClass("op-disabled")) {
+                                o_browse.updateGalleryView(detailOpusId, obsNum);
+                            }
                         }
-                        break;
+                        return false;
                     case 40:  // down
                         // note that if there are not enough left to go down, nothing will change ... it could go to the very last tho
                         offset = (o_browse.isGalleryView() ? viewNamespace.galleryBoundingRect.x : 1);
@@ -564,11 +574,12 @@ var o_browse = {
                             detailOpusId = (o_browse.isGalleryView() ? $(tab).find(`.op-thumbnail-container[data-obs='${obsNum}']`).data("id") : $(tab).find(`tr[data-obs='${obsNum}']`).data("id"));
                             o_browse.removeEditMetadataDetails();
                             o_browse.loadPageIfNeeded("next", detailOpusId);
+                            // note: need to check for detailOpusId because if the next window is loading, it could still be undefined at this point
+                            if (detailOpusId && !$("#galleryViewContents").hasClass("op-disabled")) {
+                                o_browse.updateGalleryView(detailOpusId, obsNum);
+                            }
                         }
-                        break;
-                }
-                if (detailOpusId && !$("#galleryViewContents").hasClass("op-disabled")) {
-                    o_browse.updateGalleryView(detailOpusId, obsNum);
+                        return false;
                 }
             }
             // don't return false here or it will snatch all the user input!

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -529,7 +529,7 @@ var o_browse = {
                 // the || is for cross-browser support; firefox does not support keyCode
                 switch (e.which || e.keyCode) {
                     case 32:  // spacebar
-                        if (opus.metadataDetailOpusId !== "") {
+                        if ((opus.metadataDetailOpusId !== "" && opus.metadataDetailOpusId !== undefined) && !$("#galleryViewContents").hasClass("op-disabled")) {
                             o_browse.undoRangeSelect();
                             o_cart.toggleInCart(opus.metadataDetailOpusId);
                         }
@@ -539,18 +539,12 @@ var o_browse = {
                         obsNum++;
                         o_browse.removeEditMetadataDetails();
                         o_browse.loadPageIfNeeded("next", detailOpusId);
-                        if (!$("#galleryViewContents").hasClass("op-disabled")) {
-                            o_browse.updateGalleryView(detailOpusId, obsNum);
-                        }
                         break;
                     case 37:  // prev
                         detailOpusId = $("#galleryView").find(".op-prev").data("id");
                         obsNum--;
                         o_browse.removeEditMetadataDetails();
                         o_browse.loadPageIfNeeded("prev", detailOpusId);
-                        if (!$("#galleryViewContents").hasClass("op-disabled")) {
-                            o_browse.updateGalleryView(detailOpusId, obsNum);
-                        }
                         break;
                     case 38:  // up
                         offset = (o_browse.isGalleryView() ? viewNamespace.galleryBoundingRect.x : 1);
@@ -559,12 +553,8 @@ var o_browse = {
                             detailOpusId = (o_browse.isGalleryView() ? $(tab).find(`.op-thumbnail-container[data-obs='${obsNum}']`).data("id") : $(tab).find(`tr[data-obs='${obsNum}']`).data("id"));
                             o_browse.removeEditMetadataDetails();
                             o_browse.loadPageIfNeeded("prev", detailOpusId);
-                            // note: need to check for detailOpusId because if the next window is loading, it could still be undefined at this point
-                            if (detailOpusId && !$("#galleryViewContents").hasClass("op-disabled")) {
-                                o_browse.updateGalleryView(detailOpusId, obsNum);
-                            }
                         }
-                        return false;
+                        break;
                     case 40:  // down
                         offset = (o_browse.isGalleryView() ? viewNamespace.galleryBoundingRect.x : 1);
                         if (obsNum + offset <= viewNamespace.totalObsCount) {
@@ -572,12 +562,12 @@ var o_browse = {
                             detailOpusId = (o_browse.isGalleryView() ? $(tab).find(`.op-thumbnail-container[data-obs='${obsNum}']`).data("id") : $(tab).find(`tr[data-obs='${obsNum}']`).data("id"));
                             o_browse.removeEditMetadataDetails();
                             o_browse.loadPageIfNeeded("next", detailOpusId);
-                            // note: need to check for detailOpusId because if the next window is loading, it could still be undefined at this point
-                            if (detailOpusId && !$("#galleryViewContents").hasClass("op-disabled")) {
-                                o_browse.updateGalleryView(detailOpusId, obsNum);
-                            }
                         }
-                        return false;
+                        break;
+                }
+                if (detailOpusId && !$("#galleryViewContents").hasClass("op-disabled")) {
+                    o_browse.updateGalleryView(detailOpusId, obsNum);
+                    return false;
                 }
             }
             // don't return false here or it will snatch all the user input!

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -249,6 +249,7 @@ var o_browse = {
         $(".app-body").on("hide.bs.modal", "#galleryView", function(e) {
             let namespace = o_browse.getViewInfo().namespace;
             $(namespace).find(".op-modal-show").removeClass("op-modal-show");
+            opus.metadataDetailOpusId = "";
             o_browse.removeEditMetadataDetails();
         });
 

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -513,6 +513,7 @@ var o_browse = {
                 // reset range select
                 o_browse.undoRangeSelect();
             }
+            let viewNamespace = opus.getViewNamespace();
             if ($("#galleryView").hasClass("show") && !viewNamespace.loadDataInProgress) {
                 /*  Catch the right/left arrow and spacebar while in the modal
                     Up: 38
@@ -522,7 +523,6 @@ var o_browse = {
                     Space: 32 */
 
                 let tab = opus.getViewTab();
-                let viewNamespace = opus.getViewNamespace();
                 let detailOpusId;
                 let offset = 0;
                 let obsNum = $("#galleryViewContents .op-obs-direction a").data("obs");

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1353,9 +1353,6 @@ var o_browse = {
             $(`.op-page-loading-status > .loader`).hide();
             o_browse.pageLoaderSpinnerTimer = null;
         }
-        // this is here because if the selectMetadata modal was the cause of the change AND the galleryView modal
-        // is showing, the detail/right side of the gallery view is not done redrawing until here.
-        $(`.op-metadata-details > .loader`).hide();
         o_utils.enableUserInteraction();
     },
 

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1166,8 +1166,12 @@ var o_browse = {
         }
         o_browse.loadPageIfNeeded("prev", opusId);
         o_browse.updateGalleryView(opusId, obsNum);
-        // this is to make sure modal is at its original position when open again
-        $("#galleryView .modal-dialog").css({top: 0, left: 0});
+        if (!$("#galleryView").hasClass("show")) {
+            // this is to make sure the gallery view/slide modal is at its original position when open again
+            // BUT if the gallery view modal was already open and the user is just
+            // clicking on a different observation, don't recenter...
+            $("#galleryView .modal-dialog").css({top: 0, left: 0});
+        }
         $("#galleryView").modal("show");
 
         // Do the fake API call to write in the Apache log files that

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -513,7 +513,7 @@ var o_browse = {
                 // reset range select
                 o_browse.undoRangeSelect();
             }
-            if ($("#galleryView").hasClass("show")) {
+            if ($("#galleryView").hasClass("show") && !viewNamespace.loadDataInProgress) {
                 /*  Catch the right/left arrow and spacebar while in the modal
                     Up: 38
                     Down: 40

--- a/opus/application/static_media/js/selectMetadata.js
+++ b/opus/application/static_media/js/selectMetadata.js
@@ -134,10 +134,6 @@ var o_selectMetadata = {
             $(".op-select-metadata-row-contents").css("opacity", "0.1");
             o_utils.disableUserInteraction();
         }, opus.spinnerDelay);
-
-        if ($("#galleryView").hasClass("show")) {
-            $(`.op-metadata-details > .loader`).show();
-        }
     },
 
     hideMenuLoaderSpinner: function() {


### PR DESCRIPTION
- Fixes #715
- Were any Django, import pipeline, table_schema, or dictionary files modified? Y/N
  - If YES:
    - Database used: opus3_test_200903
    - All Django tests pass: NA
    - FLAKE8 run on modified code: NA
- Were any JavaScript or CSS files modified? Y
  - If YES:
    - JSHINT run on all affected files: Y
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y/NA
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:
-Catch the up and down arrows when the modal is open; in gallery view, the up/down will move the binoculars up or down one row and update the modal w/the new opusID; in table view, the up/down will do the same as next/prev and move one up or one down, then update the modal.
-if there are no more rows up or down, the up/down arrow will do nothing.

Known problems:
 - there is a bug in the table view that causes the highlighted row to always be at the bottom of the screen once it reaches a certain part of the visible screen.
 - there is a bug for a corner case when the binoculars or highlighted row are scrolled up off the screen, edit of the metadata fields will cause the metadata on the slide view modal to disappear
