### PR TITLE
Make sure highlighted table item is full displayed and scrollbar is properly scrolled when hitting up/down arrows

### DIFF
--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -2133,7 +2133,7 @@ var o_browse = {
             let tableRowHeight = ($(`${tab} .op-data-table tbody tr[data-obs]`).length === 1 ?
                                   $(`${tab} .op-data-table tbody tr[data-obs]`).outerHeight() :
                                   $(`${tab} .op-data-table tbody tr[data-obs]`).eq(1).outerHeight());
-            trCountFloor = o_utils.floor((height-$("th").outerHeight()) / tableRowHeight);
+            trCountFloor = o_utils.floor((height-$(`${tab} .op-data-table th`).outerHeight()) / tableRowHeight);
         }
 
         let xCount = o_utils.floor(width/o_browse.imageSize);

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -752,7 +752,7 @@ var o_browse = {
                 let contentsView = o_browse.getScrollContainerClass();
                 $(`${tab} ${contentsView}`).infiniteScroll("loadNextPage");
             } else {
-                o_browse.setScrollbarPosition(value, value, view);
+                o_browse.setScrollbarPosition(value, value);
             }
         } else {
             // When scrolling on slider and loadData is called, we will fetch 3 * getLimit items
@@ -2127,7 +2127,7 @@ var o_browse = {
 
         let trCountFloor = viewNamespace.galleryBoundingRect.trFloor;
         if (!o_browse.isGalleryView(view) && $(`${tab} .op-data-table tbody tr[data-obs]`).length > 0) {
-            // Note: in table view, if there are more than one row, we divide by the 2nd table tr's
+            // Note: in table view, if there is more than one row, we divide by the 2nd table tr's
             // height because in Firefox & Safari, the first table tr's height will be 1px larger
             // than rest of tr, and this will mess up the calculation.
             let tableRowHeight = ($(`${tab} .op-data-table tbody tr[data-obs]`).length === 1 ?

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -740,7 +740,7 @@ var o_browse = {
                 let contentsView = o_browse.getScrollContainerClass();
                 $(`${tab} ${contentsView}`).infiniteScroll("loadNextPage");
             } else {
-                o_browse.setScrollbarPosition(value, value);
+                o_browse.setScrollbarPosition(value, value, view);
             }
         } else {
             // When scrolling on slider and loadData is called, we will fetch 3 * getLimit items
@@ -2114,8 +2114,13 @@ var o_browse = {
 
         let trCountFloor = viewNamespace.galleryBoundingRect.trFloor;
         if (!o_browse.isGalleryView(view) && $(`${tab} .op-data-table tbody tr[data-obs]`).length > 0) {
-            trCountFloor = o_utils.floor((height-$("th").outerHeight()) /
-                                         $(`${tab} .op-data-table tbody tr[data-obs]`).outerHeight());
+            // Note: in table view, if there are more than one row, we divide by the 2nd table tr's
+            // height because in Firefox & Safari, the first table tr's height will be 1px larger
+            // than rest of tr, and this will mess up the calculation.
+            let tableRowHeight = ($(`${tab} .op-data-table tbody tr[data-obs]`).length === 1 ?
+                                  $(`${tab} .op-data-table tbody tr[data-obs]`).outerHeight() :
+                                  $(`${tab} .op-data-table tbody tr[data-obs]`).eq(1).outerHeight());
+            trCountFloor = o_utils.floor((height-$("th").outerHeight()) / tableRowHeight);
         }
 
         let xCount = o_utils.floor(width/o_browse.imageSize);

--- a/opus/application/static_media/js/utils.js
+++ b/opus/application/static_media/js/utils.js
@@ -150,6 +150,10 @@ $.fn.isOnScreen = function(scope, slop) {
     // hack to take care of table header height
     if (this.is("tr")) {
         top += $("th").outerHeight();
+        // For a table item, the bottom border will be the top of the footer.
+        bottom = $(".app-footer").offset().top;
+        // Make sure highlighted table item is fully displayed.
+        offset = elementHeight;
     }
 
     return (elementTop + offset <= bottom) && (elementTop >= top);


### PR DESCRIPTION
- Fixes #1107 
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - If YES:
    - Database used: opus3_test_200903
    - All Django tests pass: Y
    - FLAKE8 run on modified code: Y
- Were any JavaScript or CSS files modified? Y
  - If YES:
    - JSHINT run on all affected files: Y
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:
- Update the offset and footer top position for isOnScreen to make sure highlighted table item is fully displayed.
- Update the calculation of tr count to get the correct number of table rows on the screen. This will make sure scrollbar is scrolled down by one table row height when we keep hitting down arrow to highlight the next hidden row. Without this change, scrollbar could scroll down by two table row heights in Firefox & Safari.

Known problems:
NA
