### PR TITLE
Make sure the last table row on cart tab is fully displayed at max slider 

### DIFF
--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -842,7 +842,6 @@ var o_browse = {
         let firstCachedObs = $(selector).first().data("obs");
 
         let numToDelete = 0;
-
         // When we keep resizing browser and more DOMs are deleted, infiniteScroll load will
         // trigger to load new data (previous page). During the time when infiniteScroll is
         // still loading (before all new obs are rendered), if we keep resizing and cause some
@@ -2127,7 +2126,7 @@ var o_browse = {
 
         let trCountFloor = viewNamespace.galleryBoundingRect.trFloor;
         if (!o_browse.isGalleryView(view) && $(`${tab} .op-data-table tbody tr[data-obs]`).length > 0) {
-            trCountFloor = o_utils.floor((height-$("th").outerHeight()) /
+            trCountFloor = o_utils.floor((height-$(`${tab} .op-data-table th`).outerHeight()) /
                                          $(`${tab} .op-data-table tbody tr[data-obs]`).outerHeight());
         }
 


### PR DESCRIPTION
- Fixes #825 
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - If YES:
    - Database used: opus3_test_200903
    - All Django tests pass: Y
    - FLAKE8 run on modified code: Y
- Were any JavaScript or CSS files modified? Y
  - If YES:
    - JSHINT run on all affected files: Y
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:
- Update the selector of "th" to properly select the "th" in cart tab when calculating "th" height in cart. This will make sure the ```trCountFloor``` is correctly calculated in ```countGalleryImages```. This will make sure the max slider number is correctly calculated in cart tab in ```getSliderMaxValue```.

Known problems: NA
