### PR TITLE
Click on preview in slideshow to show full size image

### DIFF
--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -515,7 +515,6 @@ var o_browse = {
                 o_browse.undoRangeSelect();
             }
             if ($("#galleryView").hasClass("show")) {
-                e.preventDefault();
                 if (o_browse.pageLoaderSpinnerTimer === null) {
                     /*  Catch the right/left arrow and spacebar while in the modal
                         Up: 38
@@ -556,6 +555,10 @@ var o_browse = {
                             obsNum += offset;
                             o_browse.moveToNextMetadataSlide(obsNum, "next");
                             break;
+                        default:
+                            // allow exception handling to propagate
+                            // fixes the bug that prevented click on the slide to open a full size image
+                            return true;
                     }
                 }
                 return false;


### PR DESCRIPTION
-Remove preventDefault and allow key clicks to fall thru to the proper exception handler

- Fixes #1116
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - If YES:
    - Database used: XXX
    - All Django tests pass: Y/NA
    - FLAKE8 run on modified code: Y/NA
- Were any JavaScript or CSS files modified? Y
  - If YES:
    - JSHINT run on all affected files: Y
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:
Allow the exception handler to fall thru for the click to open 

Known problems:
