### PR TITLE
Add ability for placing a notification/message into OPUS

### DIFF
--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -535,10 +535,10 @@
             close_by_keyboard="esc"
         %}
         {% include "ui/confirm_modal.html" with
-            id_name="op-notifications-modal"
-            confirm_title="Important Notification to OPUS users."
+            id_name="op-notification-modal"
+            confirm_title="Important Message"
             confirm_msg=""
-            target="op-notifications-modal"
+            target="op-notification-modal"
             yes_text="Do not show again"
             no_text="Close"
             allow_close=True

--- a/opus/application/apps/ui/test_ui.py
+++ b/opus/application/apps/ui/test_ui.py
@@ -53,7 +53,7 @@ class uiTests(TestCase):
         request = self.factory.get('__notifications.json')
         ret = api_notifications(request)
         print(ret)
-        self.assertEqual(ret.content, b'{"lastupdate": "2019-JAN-01", "notifications": null}')
+        self.assertEqual(ret.content, b'{"lastupdate": "2019-JAN-01", "notification": null, "notification_mdate": null}')
 
     def test__api_notifications_bad_update_file(self):
         "[test_ui.py] api_notifications: missing last blog update file"
@@ -62,7 +62,7 @@ class uiTests(TestCase):
         ret = api_notifications(request)
         print(ret)
         print(ret.content)
-        self.assertEqual(ret.content, b'{"lastupdate": null, "notifications": null}')
+        self.assertEqual(ret.content, b'{"lastupdate": null, "notification": null, "notification_mdate": null}')
 
     def test__api_notifications_bad_notification_file(self):
         "[test_ui.py] api_notifications: missing notifications.html file"
@@ -71,7 +71,7 @@ class uiTests(TestCase):
         ret = api_notifications(request)
         print(ret)
         print(ret.content)
-        self.assertEqual(ret.content, b'{"lastupdate": "2019-JAN-01", "notifications": null}')
+        self.assertEqual(ret.content, b'{"lastupdate": "2019-JAN-01", "notification": null, "notification_mdate": null}')
 
 
             ################################################

--- a/opus/application/apps/ui/views.py
+++ b/opus/application/apps/ui/views.py
@@ -89,8 +89,9 @@ def api_notifications(request):
     Format: __notifications.json
 
     JSON return:
-        {'lastupdate': '2019-01-31',               (or if none available 'None')
-         'short_term_notification': '<html code>'  (or if none available 'None')
+        {'lastupdate': '2019-01-31',                (or if none available 'None')
+         'notification': '<html code>',             (or if none available 'None')
+         'notification_mdate': '<file mod date>'   (store as cookie)
         }
     """
     api_code = enter_api_call('api_notifications', request)
@@ -111,26 +112,26 @@ def api_notifications(request):
         except:
             log.error('api_notifications: Failed to read file UNKNOWN')
 
-    notifications = None
-    notifications_modify = None
+    notification = None
+    notification_modify = None
     try:
-        with open(settings.OPUS_NOTIFICATIONS_FILE, 'r') as fp:
-            notifications = fp.read().strip()
+        with open(settings.OPUS_NOTIFICATION_FILE, 'r') as fp:
+            notification = fp.read().strip()
             try:
-                notifications_modify = os.path.getmtime(settings.OPUS_NOTIFICATIONS_FILE)
+                notification_modify = os.path.getmtime(settings.OPUS_NOTIFICATION_FILE)
             except:
-                log.error('api_notifications: Failed to read the modify date of file "%s"',
-                          settings.OPUS_NOTIFICATIONS_FILE)
+                log.error('api_notification: Failed to read the modify date of file "%s"',
+                          settings.OPUS_NOTIFICATION_FILE)
     except:
         try:
             log.error('api_notifications: Failed to read file "%s"',
-                      settings.OPUS_NOTIFICATIONS_FILE)
+                      settings.OPUS_NOTIFICATION_FILE)
         except:
             log.error('api_notifications: Failed to read file UNKNOWN')
 
     ret = json_response({'lastupdate': lastupdate,
-                         'notifications': notifications,
-                         'notifications_cdate': notifications_modify})
+                         'notification': notification,
+                         'notification_mdate': notification_modify})
 
     exit_api_call(api_code, ret)
     return ret

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -442,8 +442,8 @@ var opus = {
                 $("#op-last-blog-update-date").attr("title", "");
             }
             // note: $.cookie compare needs to be != because the cookie is a string number but cdate is a number.
-            if (data.notifications !== null && data.notifications !== "" && $.cookie("notify") != data.notifications_cdate) {
-                opus.displayNotificationsDialog(data.notifications, data.notifications_cdate);
+            if (data.notification !== null && data.notification !== "" && $.cookie("notify") != data.notification_mdate) {
+                opus.displayNotificationDialog(data.notification, data.notification_mdate);
             }
         });
     },
@@ -899,7 +899,7 @@ var opus = {
                         case "op-http-response-error-modal":
                             location.reload();
                             break;
-                        case "op-notifications-modal":
+                        case "op-notification-modal":
                             $.cookie("notify", $(`#${target}`).data("cookie"), {expires: 1000000});
                             break;
                     }
@@ -940,12 +940,12 @@ var opus = {
         $(window).off("touchstart", opus.tooltipRemoveHandler);
     },
 
-    displayNotificationsDialog: function(html, cookie) {
-        $("#op-notifications-modal .modal-body").html(html);
-        $("#op-notifications-modal").data("cookie", cookie);
+    displayNotificationDialog: function(html, cookie) {
+        $("#op-notification-modal .modal-body").html(html);
+        $("#op-notification-modal").data("cookie", cookie);
 
         opus.hideOrShowSplashText();
-        $("#op-notifications-modal").modal("show");
+        $("#op-notification-modal").modal("show");
     },
 
     displayHelpPane: function(action) {

--- a/opus_secrets_template.py
+++ b/opus_secrets_template.py
@@ -103,7 +103,7 @@ OPUS_LOG_FILE = os.path.join(OPUS_LOGFILE_DIR, 'opus_log.txt')
 OPUS_LAST_BLOG_UPDATE_FILE = '<LAST_BLOG_UPDATE_FILE>'
 
 # The file that contains the html for any short-term notifications
-OPUS_NOTIFICATIONS_FILE = '<NOTIFICATIONS_FILE>'
+OPUS_NOTIFICATION_FILE = '<NOTIFICATION_FILE>'
 
 # What level of message to log at each destination
 OPUS_LOG_FILE_LEVEL = 'INFO'


### PR DESCRIPTION
- Fixes #1115
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - If YES:
    - Database used: XXX
    - All Django tests pass: Y/NA
    - FLAKE8 run on modified code: Y/NA
- Were any JavaScript or CSS files modified? Y
  - If YES:
    - JSHINT run on all affected files: Y
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:
 - on open or tab change, check the file notification.html to see if it is empty or has changed; display contents in a modal if so.  Contents should be regular html; no error checking is done on contents of file.
 - User can choose to not see the modal again, which will store a cookie that contains the modification date of the file.  When the file is modified, the contents will be displayed again until the user requests to not see it.
 - the secrets file has been modified to point to the location of the notification.html file

Known problems:
 - No error checking on the contents of the file notifications to verify that it contains valid html.