### PR TITLE
Add tooltips to flat zip file structure checkbox

### DIFF
--- a/opus/application/apps/cart/templates/cart/cart.html
+++ b/opus/application/apps/cart/templates/cart/cart.html
@@ -33,9 +33,16 @@
                 </li>
             </div>
             <h1 class="op-download-options-title">Download Options</h1>
-            <div class="op-download-flat-zip-file-structure">
-                <input type="checkbox" checked>
-                <span>Flat zip file structure</span>
+            <div class="row no-gutters op-download-flat-zip-file-structure">
+                <div class="row no-gutters col-7">
+                    <div class="col col-sm-1">
+                        <input type="checkbox" checked>
+                    </div>
+                    <div class="col col-sm-1">
+                        <i class="fas fa-info-circle" title="If unchecked, download products will be added to the zip file using the same directory structure used by the PDS RMS archive. If checked, all download products will be placed in the root directory of the zip file, unless there is an ambiguity caused by multiple files that have the same base filename. In that case those files only will be added using the full directory structure."></i>
+                    </div>
+                <div class="col col-lg">Flat zip file structure</div>
+                </div>
             </div>
             <p class="m-0 mb-1">Select which product types to include in downloads:</p>
             <div class="op-product-types-select-btn-group mb-3">


### PR DESCRIPTION
- Fixes #1071
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - If YES:
    - Database used: opus3_test_210331
    - All Django tests pass: Y
    - FLAKE8 run on modified code: Y
- Were any JavaScript or CSS files modified? N
  - If YES:
    - JSHINT run on all affected files: NA
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: NA
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:
Add tooltips to flat zip file structure checkbox in cart download pane.

Known problems:
NA