### PR TITLE
1070 allow selection of download file output format

### DIFF
--- a/opus/application/apps/cart/templates/cart/cart.html
+++ b/opus/application/apps/cart/templates/cart/cart.html
@@ -41,7 +41,14 @@
                     <div class="col col-sm-1">
                         <i class="fas fa-info-circle" title="If unchecked, download products will be added to the zip file using the same directory structure used by the PDS RMS archive. If checked, all download products will be placed in the root directory of the zip file, unless there is an ambiguity caused by multiple files that have the same base filename. In that case those files only will be added using the full directory structure."></i>
                     </div>
-                <div class="col col-lg">Flat zip file structure</div>
+                <div class="col col-lg">Flat compressed file structure</div>
+                </div>
+                <div class="col">File format:&nbsp;
+                    <select class="op-download-format" tabindex="0">
+                        {% for fmt in format %}
+                            <option value="{{ fmt }}">{{ fmt }}</option>
+                        {% endfor %}
+                    <select>
                 </div>
             </div>
             <p class="m-0 mb-1">Select which product types to include in downloads:</p>

--- a/opus/application/apps/cart/templates/cart/cart.html
+++ b/opus/application/apps/cart/templates/cart/cart.html
@@ -41,7 +41,7 @@
                     <div class="col col-sm-1">
                         <i class="fas fa-info-circle" title="If unchecked, download products will be added to the zip file using the same directory structure used by the PDS RMS archive. If checked, all download products will be placed in the root directory of the zip file, unless there is an ambiguity caused by multiple files that have the same base filename. In that case those files only will be added using the full directory structure."></i>
                     </div>
-                <div class="col col-lg">Flat file structure</div>
+                    <div class="col col-lg">Flat file structure</div>
                 </div>
                 <div class="col">File format:&nbsp;
                     <select class="op-download-format" tabindex="0">

--- a/opus/application/apps/cart/templates/cart/cart.html
+++ b/opus/application/apps/cart/templates/cart/cart.html
@@ -41,7 +41,7 @@
                     <div class="col col-sm-1">
                         <i class="fas fa-info-circle" title="If unchecked, download products will be added to the zip file using the same directory structure used by the PDS RMS archive. If checked, all download products will be placed in the root directory of the zip file, unless there is an ambiguity caused by multiple files that have the same base filename. In that case those files only will be added using the full directory structure."></i>
                     </div>
-                <div class="col col-lg">Flat compressed file structure</div>
+                <div class="col col-lg">Flat file structure</div>
                 </div>
                 <div class="col">File format:&nbsp;
                     <select class="op-download-format" tabindex="0">

--- a/opus/application/apps/cart/test_cart.py
+++ b/opus/application/apps/cart/test_cart.py
@@ -150,4 +150,4 @@ class cartTests(TestCase):
         request.GET = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /api/download/testopusid.zip'):
-            api_create_download(request, 'testopusid')
+            api_create_download(request, 'testopusid', 'zip')

--- a/opus/application/apps/cart/urls.py
+++ b/opus/application/apps/cart/urls.py
@@ -16,6 +16,6 @@ urlpatterns = [
     url(r'^__cart/(?P<action>add|remove|addrange|removerange|addall).json$', api_edit_cart),
     url(r'^__cart/reset.json$', api_reset_session),
     url(r'^__cart/download.json$', api_create_download),
-    url(r'^api/download/(?P<opus_id>[-\w]+).zip$', api_create_download),
-    url(r'^__api/download/(?P<opus_id>[-\w]+).zip$', api_create_download),
+    url(r'^api/download/(?P<opus_id>[-\w]+).(?P<fmt>zip|tar|tgz)$', api_create_download),
+    url(r'^__api/download/(?P<opus_id>[-\w]+).(?P<fmt>zip|tar|tgz)$', api_create_download),
 ]

--- a/opus/application/apps/cart/views.py
+++ b/opus/application/apps/cart/views.py
@@ -759,8 +759,8 @@ def api_create_download(request, opus_id=None, fmt=None):
         response['Content-Disposition'] = f'attachment; filename={cmp_base_file_name}'
         ret = response
     else:
-        zip_url = settings.TAR_FILE_URL_PATH + cmp_base_file_name
-        ret = json_response({'filename': zip_url})
+        cmp_url = settings.TAR_FILE_URL_PATH + cmp_base_file_name
+        ret = json_response({'filename': cmp_url})
 
     exit_api_call(api_code, '<Encoded zip file>')
     return ret

--- a/opus/application/apps/cart/views.py
+++ b/opus/application/apps/cart/views.py
@@ -129,7 +129,7 @@ def api_view_cart(request):
 
     info['count'] = count
     info['recycled_count'] = recycled_count
-    info['format'] = settings.DOWNLOAD_FORMAT.keys()
+    info['format'] = settings.DOWNLOAD_FORMATS.keys()
 
     cart_template = get_template('cart/cart.html')
     html = cart_template.render(info)
@@ -639,8 +639,8 @@ def api_create_download(request, opus_id=None, fmt=None):
             return ret
         request.session['cum_download_size'] = int(cum_download_size)
 
-    mime_type = settings.DOWNLOAD_FORMAT[fmt][0]
-    write_mode = settings.DOWNLOAD_FORMAT[fmt][1]
+    mime_type = settings.DOWNLOAD_FORMATS[fmt][0]
+    write_mode = settings.DOWNLOAD_FORMATS[fmt][1]
     # Add each file to the new zip file and create a manifest too
     if return_directly:
         response = HttpResponse(content_type=mime_type)

--- a/opus/application/apps/tools/app_utils.py
+++ b/opus/application/apps/tools/app_utils.py
@@ -328,6 +328,11 @@ def HTTP404_UNKNOWN_CATEGORY(r):
         r = r.path
     return f'Unknown category for {r}'
 
+def HTTP404_UNKNOWN_DOWNLOAD_FILE_FORMAT(fmt, r):
+    if type(r) != str:
+        r = r.path
+    return f'Unknown DOWNLOAD FILE FORMAT "{fmt}" for {r}'
+
 def wrap_http500_string(s):
     # This duplicates the format for the Django debug page
     ret = f'<div id="info">{s}</div>'

--- a/opus/application/settings.py
+++ b/opus/application/settings.py
@@ -363,9 +363,9 @@ TEST_RESULT_COUNTS_AGAINST_INTERNAL_DB = False
 OPUS_FILE_VERSION = ''
 
 # OPUS supported cart download format, a dictionary keyed by format, and MIME
-# type & write mode corresponding to each format.
+# type & accessing (w/r) modes corresponding to each format.
 DOWNLOAD_FORMAT = {
-    'zip': ('application/zip', 'w'),
-    'tar': ('application/x-tar', 'w'),
-    'tgz': ('application/gzip', 'w:gz'), # same as .tar.gz, we will use .tgz here
+    'zip': ('application/zip', 'w', 'r'),
+    'tar': ('application/x-tar', 'w', 'r'),
+    'tgz': ('application/gzip', 'w:gz', 'r:gz'), # same as .tar.gz, we will use .tgz here
 }

--- a/opus/application/settings.py
+++ b/opus/application/settings.py
@@ -362,9 +362,9 @@ TEST_RESULT_COUNTS_AGAINST_INTERNAL_DB = False
 
 OPUS_FILE_VERSION = ''
 
-# OPUS supported cart download format, a dictionary keyed by format, and MIME
-# type & accessing (w/r) modes corresponding to each format.
-DOWNLOAD_FORMAT = {
+# OPUS supported cart download formats, a dictionary keyed by format, and value
+# is a tuple containing MIME type & accessing (w/r) modes for the format.
+DOWNLOAD_FORMATS = {
     'zip': ('application/zip', 'w', 'r'),
     'tar': ('application/x-tar', 'w', 'r'),
     'tgz': ('application/gzip', 'w:gz', 'r:gz'), # same as .tar.gz, we will use .tgz here

--- a/opus/application/settings.py
+++ b/opus/application/settings.py
@@ -361,3 +361,11 @@ MAX_CUM_DOWNLOAD_SIZE = 50*1024*1024*1024 # 50 gigs max cum downloads for a sess
 TEST_RESULT_COUNTS_AGAINST_INTERNAL_DB = False
 
 OPUS_FILE_VERSION = ''
+
+# OPUS supported cart download format, a dictionary keyed by format, and MIME
+# type & write mode corresponding to each format.
+DOWNLOAD_FORMAT = {
+    'zip': ('application/zip', 'w'),
+    'tar': ('application/x-tar', 'w'),
+    'tgz': ('application/gzip', 'w:gz'), # same as .tar.gz, we will use .tgz here
+}

--- a/opus/application/static_media/js/cart.js
+++ b/opus/application/static_media/js/cart.js
@@ -349,7 +349,9 @@ var o_cart = {
 
         // Check if the "Flat zip file structure" is selected.
         let hierarchical = $(".op-download-flat-zip-file-structure input").prop("checked") ? 0 : 1;
-        url += `&hierarchical=${hierarchical}`;
+        // Check download file format.
+        let fmt = $(".op-download-format option:selected").val();
+        url += `&hierarchical=${hierarchical}&fmt=${fmt}`;
         $.ajax({
             url: url,
             dataType: "json",

--- a/opus/application/test_api/api_test_helper.py
+++ b/opus/application/test_api/api_test_helper.py
@@ -3,6 +3,7 @@ from io import BytesIO
 import json
 import os
 import zipfile
+import tarfile
 
 import settings
 
@@ -169,20 +170,39 @@ class ApiTestHelper:
         print(expected)
         self.assertEqual(resp, expected)
 
-    def _run_zip_equal(self, url, expected, response_type='json'):
+    def _run_cmp_file_equal(self, url, expected,
+                            response_type='json', fmt='zip'):
         print(url)
         response = self._get_response(url)
         self.assertEqual(response.status_code, 200)
+        compressed_file_path = None
         if response_type == 'json':
             jdata = json.loads(response.content)
             file = jdata['filename']
             path = file.replace(settings.TAR_FILE_URL_PATH,
                                     settings.TAR_FILE_PATH)
-            zip_file = zipfile.ZipFile(path, mode='r')
+            read_mode = settings.DOWNLOAD_FORMAT[fmt][2]
+            compressed_file_path = path
+            if fmt == 'zip':
+                compressed_file = zipfile.ZipFile(path, mode=read_mode)
+            else:
+                compressed_file = tarfile.open(name=path, mode=read_mode)
         else:
             binary_stream = BytesIO(response.content)
-            zip_file = zipfile.ZipFile(binary_stream, mode='r')
-        resp = zip_file.namelist()
+            read_mode = settings.DOWNLOAD_FORMAT[fmt][2]
+            file = response.headers['Content-Disposition']
+            compressed_file_path = (settings.TAR_FILE_PATH
+                                    + file[file.index('=')+1::])
+            if fmt == 'zip':
+                compressed_file = zipfile.ZipFile(binary_stream, mode=read_mode)
+            else:
+                compressed_file = tarfile.open(mode=read_mode,
+                                               fileobj=binary_stream)
+        if fmt == 'zip':
+            resp = compressed_file.namelist()
+        else:
+            resp = compressed_file.getnames()
+
         resp.sort()
         expected.sort()
         print('Got:')
@@ -190,7 +210,7 @@ class ApiTestHelper:
         print('Expected:')
         print(expected)
         self.assertListEqual(resp, expected)
-        # Remove the .zip stored under settings.TAR_FILE_PATH
-        zip_file_path = zip_file.filename
-        if zip_file_path and os.path.exists(zip_file_path):
-            os.remove(zip_file_path)
+
+        # Remove the compressed file stored under settings.TAR_FILE_PATH
+        if compressed_file_path and os.path.exists(compressed_file_path):
+            os.remove(compressed_file_path)

--- a/opus/application/test_api/api_test_helper.py
+++ b/opus/application/test_api/api_test_helper.py
@@ -181,7 +181,7 @@ class ApiTestHelper:
             file = jdata['filename']
             path = file.replace(settings.TAR_FILE_URL_PATH,
                                     settings.TAR_FILE_PATH)
-            read_mode = settings.DOWNLOAD_FORMAT[fmt][2]
+            read_mode = settings.DOWNLOAD_FORMATS[fmt][2]
             compressed_file_path = path
             if fmt == 'zip':
                 compressed_file = zipfile.ZipFile(path, mode=read_mode)
@@ -189,7 +189,7 @@ class ApiTestHelper:
                 compressed_file = tarfile.open(name=path, mode=read_mode)
         else:
             binary_stream = BytesIO(response.content)
-            read_mode = settings.DOWNLOAD_FORMAT[fmt][2]
+            read_mode = settings.DOWNLOAD_FORMATS[fmt][2]
             file = response.headers['Content-Disposition']
             compressed_file_path = (settings.TAR_FILE_PATH
                                     + file[file.index('=')+1::])

--- a/opus/application/test_api/api_test_helper.py
+++ b/opus/application/test_api/api_test_helper.py
@@ -2,8 +2,8 @@
 from io import BytesIO
 import json
 import os
-import zipfile
 import tarfile
+import zipfile
 
 import settings
 
@@ -170,38 +170,38 @@ class ApiTestHelper:
         print(expected)
         self.assertEqual(resp, expected)
 
-    def _run_cmp_file_equal(self, url, expected,
+    def _run_archive_file_equal(self, url, expected,
                             response_type='json', fmt='zip'):
         print(url)
         response = self._get_response(url)
         self.assertEqual(response.status_code, 200)
-        compressed_file_path = None
+        archive_file_path = None
         if response_type == 'json':
             jdata = json.loads(response.content)
             file = jdata['filename']
             path = file.replace(settings.TAR_FILE_URL_PATH,
                                     settings.TAR_FILE_PATH)
             read_mode = settings.DOWNLOAD_FORMATS[fmt][2]
-            compressed_file_path = path
+            archive_file_path = path
             if fmt == 'zip':
-                compressed_file = zipfile.ZipFile(path, mode=read_mode)
+                archive_file = zipfile.ZipFile(path, mode=read_mode)
             else:
-                compressed_file = tarfile.open(name=path, mode=read_mode)
+                archive_file = tarfile.open(name=path, mode=read_mode)
         else:
             binary_stream = BytesIO(response.content)
             read_mode = settings.DOWNLOAD_FORMATS[fmt][2]
             file = response.headers['Content-Disposition']
-            compressed_file_path = (settings.TAR_FILE_PATH
+            archive_file_path = (settings.TAR_FILE_PATH
                                     + file[file.index('=')+1::])
             if fmt == 'zip':
-                compressed_file = zipfile.ZipFile(binary_stream, mode=read_mode)
+                archive_file = zipfile.ZipFile(binary_stream, mode=read_mode)
             else:
-                compressed_file = tarfile.open(mode=read_mode,
+                archive_file = tarfile.open(mode=read_mode,
                                                fileobj=binary_stream)
         if fmt == 'zip':
-            resp = compressed_file.namelist()
+            resp = archive_file.namelist()
         else:
-            resp = compressed_file.getnames()
+            resp = archive_file.getnames()
 
         resp.sort()
         expected.sort()
@@ -211,6 +211,6 @@ class ApiTestHelper:
         print(expected)
         self.assertListEqual(resp, expected)
 
-        # Remove the compressed file stored under settings.TAR_FILE_PATH
-        if compressed_file_path and os.path.exists(compressed_file_path):
-            os.remove(compressed_file_path)
+        # Remove the archive file stored under settings.TAR_FILE_PATH
+        if archive_file_path and os.path.exists(archive_file_path):
+            os.remove(archive_file_path)

--- a/opus/application/test_api/test_cart_api.py
+++ b/opus/application/test_api/test_cart_api.py
@@ -11,7 +11,8 @@ from tools.app_utils import (HTTP404_BAD_OR_MISSING_RANGE,
                              HTTP404_BAD_OR_MISSING_REQNO,
                              HTTP404_BAD_RECYCLEBIN,
                              HTTP404_MISSING_OPUS_ID,
-                             HTTP404_SEARCH_PARAMS_INVALID)
+                             HTTP404_SEARCH_PARAMS_INVALID,
+                             HTTP404_UNKNOWN_DOWNLOAD_FILE_FORMAT)
 
 from api_test_helper import ApiTestHelper
 
@@ -2386,7 +2387,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=0'
         expected = ['N1462840881_1.IMG', 'N1462840881_1.LBL', 'prefix2.fmt', 'tlmtab.fmt', 'N1462840881_1_CALIB.IMG', 'N1462840881_1_CALIB.LBL', 'N1462840881_1_full.png', 'manifest.csv', 'data.csv', 'urls.txt']
-        self._run_cmp_file_equal(url, expected)
+        self._run_archive_file_equal(url, expected)
 
     def test__api_cart_download_single_no_hierarchical_tar(self):
         "[test_cart_api.py] /__cart/download.json: single opus id & no hierarchical & fmt=tar"
@@ -2398,7 +2399,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=0&fmt=tar'
         expected = ['N1462840881_1.IMG', 'N1462840881_1.LBL', 'prefix2.fmt', 'tlmtab.fmt', 'N1462840881_1_CALIB.IMG', 'N1462840881_1_CALIB.LBL', 'N1462840881_1_full.png', 'manifest.csv', 'data.csv', 'urls.txt']
-        self._run_cmp_file_equal(url, expected, fmt='tar')
+        self._run_archive_file_equal(url, expected, fmt='tar')
 
     def test__api_cart_download_single_no_hierarchical_tgz(self):
         "[test_cart_api.py] /__cart/download.json: single opus id & no hierarchical & fmt=tgz"
@@ -2410,7 +2411,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=0&fmt=tgz'
         expected = ['N1462840881_1.IMG', 'N1462840881_1.LBL', 'prefix2.fmt', 'tlmtab.fmt', 'N1462840881_1_CALIB.IMG', 'N1462840881_1_CALIB.LBL', 'N1462840881_1_full.png', 'manifest.csv', 'data.csv', 'urls.txt']
-        self._run_cmp_file_equal(url, expected, fmt='tgz')
+        self._run_archive_file_equal(url, expected, fmt='tgz')
 
     def test__api_cart_download_single_hierarchical_zip(self):
         "[test_cart_api.py] /__cart/download.json: single opus id & hierarchical & fmt=zip"
@@ -2422,7 +2423,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=1'
         expected = ['volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.IMG', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.LBL', 'volumes/COISS_2xxx/COISS_2002/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2002/label/tlmtab.fmt', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.LBL', 'previews/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_full.png', 'manifest.csv', 'data.csv', 'urls.txt']
-        self._run_cmp_file_equal(url, expected)
+        self._run_archive_file_equal(url, expected)
 
     def test__api_cart_download_single_hierarchical_tar(self):
         "[test_cart_api.py] /__cart/download.json: single opus id & hierarchical & fmt=tar"
@@ -2434,7 +2435,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=1&fmt=tar'
         expected = ['volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.IMG', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.LBL', 'volumes/COISS_2xxx/COISS_2002/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2002/label/tlmtab.fmt', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.LBL', 'previews/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_full.png', 'manifest.csv', 'data.csv', 'urls.txt']
-        self._run_cmp_file_equal(url, expected, fmt='tar')
+        self._run_archive_file_equal(url, expected, fmt='tar')
 
     def test__api_cart_download_single_hierarchical_tgz(self):
         "[test_cart_api.py] /__cart/download.json: single opus id & hierarchical & fmt=tgz"
@@ -2446,7 +2447,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=1&fmt=tgz'
         expected = ['volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.IMG', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.LBL', 'volumes/COISS_2xxx/COISS_2002/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2002/label/tlmtab.fmt', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.LBL', 'previews/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_full.png', 'manifest.csv', 'data.csv', 'urls.txt']
-        self._run_cmp_file_equal(url, expected, fmt='tgz')
+        self._run_archive_file_equal(url, expected, fmt='tgz')
 
     # Two opus ids (from the same volume) with duplicated prefix2.fmt & tlmtab.fmt
     def test__api_cart_download_multiple_duplicated_no_hierarchical_zip(self):
@@ -2462,7 +2463,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=0'
         expected = ['N1460973661_1.IMG', 'N1460973661_1.LBL', 'N1460973661_1_CALIB.IMG', 'N1460973661_1_CALIB.LBL', 'N1460973661_1_full.png', 'N1462840881_1.IMG', 'N1462840881_1.LBL', 'N1462840881_1_CALIB.IMG', 'N1462840881_1_CALIB.LBL', 'N1462840881_1_full.png', 'data.csv', 'manifest.csv', 'prefix2.fmt', 'tlmtab.fmt', 'urls.txt']
-        self._run_cmp_file_equal(url, expected)
+        self._run_archive_file_equal(url, expected)
 
     # Two opus ids (from the same volume) with duplicated prefix2.fmt & tlmtab.fmt
     def test__api_cart_download_multiple_duplicated_no_hierarchical_tar(self):
@@ -2478,7 +2479,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=0&fmt=tar'
         expected = ['N1460973661_1.IMG', 'N1460973661_1.LBL', 'N1460973661_1_CALIB.IMG', 'N1460973661_1_CALIB.LBL', 'N1460973661_1_full.png', 'N1462840881_1.IMG', 'N1462840881_1.LBL', 'N1462840881_1_CALIB.IMG', 'N1462840881_1_CALIB.LBL', 'N1462840881_1_full.png', 'data.csv', 'manifest.csv', 'prefix2.fmt', 'tlmtab.fmt', 'urls.txt']
-        self._run_cmp_file_equal(url, expected, fmt='tar')
+        self._run_archive_file_equal(url, expected, fmt='tar')
 
     # Two opus ids (from the same volume) with duplicated prefix2.fmt & tlmtab.fmt
     def test__api_cart_download_multiple_duplicated_no_hierarchical_tgz(self):
@@ -2494,7 +2495,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=0&fmt=tgz'
         expected = ['N1460973661_1.IMG', 'N1460973661_1.LBL', 'N1460973661_1_CALIB.IMG', 'N1460973661_1_CALIB.LBL', 'N1460973661_1_full.png', 'N1462840881_1.IMG', 'N1462840881_1.LBL', 'N1462840881_1_CALIB.IMG', 'N1462840881_1_CALIB.LBL', 'N1462840881_1_full.png', 'data.csv', 'manifest.csv', 'prefix2.fmt', 'tlmtab.fmt', 'urls.txt']
-        self._run_cmp_file_equal(url, expected, fmt='tgz')
+        self._run_archive_file_equal(url, expected, fmt='tgz')
 
     # Two opus ids (from the same volume) with duplicated prefix2.fmt & tlmtab.fmt
     def test__api_cart_download_multiple_duplicated_hierarchical_zip(self):
@@ -2510,7 +2511,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=1'
         expected = ['calibrated/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1_CALIB.LBL', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.LBL', 'data.csv', 'manifest.csv', 'previews/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1_full.png', 'previews/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_full.png', 'urls.txt', 'volumes/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1.IMG', 'volumes/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1.LBL', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.IMG', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.LBL', 'volumes/COISS_2xxx/COISS_2002/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2002/label/tlmtab.fmt']
-        self._run_cmp_file_equal(url, expected)
+        self._run_archive_file_equal(url, expected)
 
     # Two opus ids (from the same volume) with duplicated prefix2.fmt & tlmtab.fmt
     def test__api_cart_download_multiple_duplicated_hierarchical_tar(self):
@@ -2526,7 +2527,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=1&fmt=tar'
         expected = ['calibrated/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1_CALIB.LBL', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.LBL', 'data.csv', 'manifest.csv', 'previews/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1_full.png', 'previews/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_full.png', 'urls.txt', 'volumes/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1.IMG', 'volumes/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1.LBL', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.IMG', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.LBL', 'volumes/COISS_2xxx/COISS_2002/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2002/label/tlmtab.fmt']
-        self._run_cmp_file_equal(url, expected, fmt='tar')
+        self._run_archive_file_equal(url, expected, fmt='tar')
 
     # Two opus ids (from the same volume) with duplicated prefix2.fmt & tlmtab.fmt
     def test__api_cart_download_multiple_duplicated_hierarchical_tgz(self):
@@ -2542,7 +2543,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=1&fmt=tgz'
         expected = ['calibrated/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1_CALIB.LBL', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.LBL', 'data.csv', 'manifest.csv', 'previews/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1_full.png', 'previews/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_full.png', 'urls.txt', 'volumes/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1.IMG', 'volumes/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1.LBL', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.IMG', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.LBL', 'volumes/COISS_2xxx/COISS_2002/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2002/label/tlmtab.fmt']
-        self._run_cmp_file_equal(url, expected, fmt='tgz')
+        self._run_archive_file_equal(url, expected, fmt='tgz')
 
     # Two opus ids (from the different volumes) with not duplicated prefix2.fmt & tlmtab.fmt
     def test__api_cart_download_multiple_no_duplicated_no_hierarchical_zip(self):
@@ -2558,7 +2559,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=0'
         expected = ['N1462840881_1.IMG', 'N1462840881_1.LBL', 'N1462840881_1_CALIB.IMG', 'N1462840881_1_CALIB.LBL', 'N1462840881_1_full.png', 'N1481265970_1.IMG', 'N1481265970_1.LBL', 'N1481265970_1_CALIB.IMG', 'N1481265970_1_CALIB.LBL', 'N1481265970_1_full.png', 'data.csv', 'manifest.csv', 'urls.txt', 'volumes/COISS_2xxx/COISS_2002/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2002/label/tlmtab.fmt', 'volumes/COISS_2xxx/COISS_2008/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2008/label/tlmtab.fmt']
-        self._run_cmp_file_equal(url, expected)
+        self._run_archive_file_equal(url, expected)
 
     # Two opus ids (from the different volumes) with not duplicated prefix2.fmt & tlmtab.fmt
     def test__api_cart_download_multiple_no_duplicated_no_hierarchical_tar(self):
@@ -2574,7 +2575,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=0&fmt=tar'
         expected = ['N1462840881_1.IMG', 'N1462840881_1.LBL', 'N1462840881_1_CALIB.IMG', 'N1462840881_1_CALIB.LBL', 'N1462840881_1_full.png', 'N1481265970_1.IMG', 'N1481265970_1.LBL', 'N1481265970_1_CALIB.IMG', 'N1481265970_1_CALIB.LBL', 'N1481265970_1_full.png', 'data.csv', 'manifest.csv', 'urls.txt', 'volumes/COISS_2xxx/COISS_2002/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2002/label/tlmtab.fmt', 'volumes/COISS_2xxx/COISS_2008/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2008/label/tlmtab.fmt']
-        self._run_cmp_file_equal(url, expected, fmt='tar')
+        self._run_archive_file_equal(url, expected, fmt='tar')
 
     # Two opus ids (from the different volumes) with not duplicated prefix2.fmt & tlmtab.fmt
     def test__api_cart_download_multiple_no_duplicated_no_hierarchical_tgz(self):
@@ -2590,7 +2591,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=0&fmt=tgz'
         expected = ['N1462840881_1.IMG', 'N1462840881_1.LBL', 'N1462840881_1_CALIB.IMG', 'N1462840881_1_CALIB.LBL', 'N1462840881_1_full.png', 'N1481265970_1.IMG', 'N1481265970_1.LBL', 'N1481265970_1_CALIB.IMG', 'N1481265970_1_CALIB.LBL', 'N1481265970_1_full.png', 'data.csv', 'manifest.csv', 'urls.txt', 'volumes/COISS_2xxx/COISS_2002/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2002/label/tlmtab.fmt', 'volumes/COISS_2xxx/COISS_2008/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2008/label/tlmtab.fmt']
-        self._run_cmp_file_equal(url, expected, fmt='tgz')
+        self._run_archive_file_equal(url, expected, fmt='tgz')
 
     # Two opus ids (from the different volumes) with not duplicated prefix2.fmt & tlmtab.fmt
     def test__api_cart_download_multiple_no_duplicated_hierarchical_zip(self):
@@ -2606,7 +2607,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=1'
         expected = ['calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.LBL', 'calibrated/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_CALIB.LBL', 'data.csv', 'manifest.csv', 'previews/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_full.png', 'previews/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_full.png', 'urls.txt', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.IMG', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.LBL', 'volumes/COISS_2xxx/COISS_2002/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2002/label/tlmtab.fmt', 'volumes/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1.IMG', 'volumes/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1.LBL', 'volumes/COISS_2xxx/COISS_2008/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2008/label/tlmtab.fmt']
-        self._run_cmp_file_equal(url, expected)
+        self._run_archive_file_equal(url, expected)
 
     # Two opus ids (from the different volumes) with not duplicated prefix2.fmt & tlmtab.fmt
     def test__api_cart_download_multiple_no_duplicated_hierarchical_tar(self):
@@ -2622,7 +2623,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=1&fmt=tar'
         expected = ['calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.LBL', 'calibrated/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_CALIB.LBL', 'data.csv', 'manifest.csv', 'previews/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_full.png', 'previews/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_full.png', 'urls.txt', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.IMG', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.LBL', 'volumes/COISS_2xxx/COISS_2002/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2002/label/tlmtab.fmt', 'volumes/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1.IMG', 'volumes/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1.LBL', 'volumes/COISS_2xxx/COISS_2008/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2008/label/tlmtab.fmt']
-        self._run_cmp_file_equal(url, expected, fmt='tar')
+        self._run_archive_file_equal(url, expected, fmt='tar')
 
     # Two opus ids (from the different volumes) with not duplicated prefix2.fmt & tlmtab.fmt
     def test__api_cart_download_multiple_no_duplicated_hierarchical_tgz(self):
@@ -2638,10 +2639,23 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=1&fmt=tgz'
         expected = ['calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.LBL', 'calibrated/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_CALIB.LBL', 'data.csv', 'manifest.csv', 'previews/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_full.png', 'previews/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_full.png', 'urls.txt', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.IMG', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.LBL', 'volumes/COISS_2xxx/COISS_2002/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2002/label/tlmtab.fmt', 'volumes/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1.IMG', 'volumes/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1.LBL', 'volumes/COISS_2xxx/COISS_2008/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2008/label/tlmtab.fmt']
-        self._run_cmp_file_equal(url, expected, fmt='tgz')
+        self._run_archive_file_equal(url, expected, fmt='tgz')
+
+    # Unsupported format
+    def test__api_cart_download_unsupported_format(self):
+        "[test_cart_api.py] /__cart/download.json: fmt=xxx not supported"
+        url = '/__cart/reset.json?reqno=42'
+        expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
+        self._run_json_equal(url, expected)
+        url = '/__cart/add.json?opusid=co-iss-n1462840881&reqno=456'
+        expected = {'recycled_count': 0, 'count': 1, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=0&fmt=xxx'
+        self._run_status_equal(url, 404,
+                               HTTP404_UNKNOWN_DOWNLOAD_FILE_FORMAT('xxx', '/__cart/download.json'))
 
             #########################################################
-            ######### /api/download/<opusid>.<fmt>: API TESTS #########
+            ######### /api/download/<opusid>.<fmt>: API TESTS #######
             #########################################################
     def test__api_download_no_hierarchical_zip(self):
         "[test_cart_api.py] /__api/download/<opusid>.zip: one opus id & no hierarchical"
@@ -2650,7 +2664,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__api/download/co-iss-n1481265970.zip?types=coiss_raw,coiss_calib,browse_full&hierarchical=0'
         expected = ['N1481265970_1.IMG', 'N1481265970_1.LBL', 'N1481265970_1_CALIB.IMG', 'N1481265970_1_CALIB.LBL', 'N1481265970_1_full.png', 'data.csv', 'manifest.csv', 'prefix2.fmt', 'tlmtab.fmt', 'urls.txt']
-        self._run_cmp_file_equal(url, expected, response_type='binary')
+        self._run_archive_file_equal(url, expected, response_type='binary')
 
     def test__api_download_no_hierarchical_tar(self):
         "[test_cart_api.py] /__api/download/<opusid>.tar: one opus id & no hierarchical"
@@ -2659,7 +2673,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__api/download/co-iss-n1481265970.tar?types=coiss_raw,coiss_calib,browse_full&hierarchical=0'
         expected = ['N1481265970_1.IMG', 'N1481265970_1.LBL', 'N1481265970_1_CALIB.IMG', 'N1481265970_1_CALIB.LBL', 'N1481265970_1_full.png', 'data.csv', 'manifest.csv', 'prefix2.fmt', 'tlmtab.fmt', 'urls.txt']
-        self._run_cmp_file_equal(url, expected, response_type='binary', fmt='tar')
+        self._run_archive_file_equal(url, expected, response_type='binary', fmt='tar')
 
     def test__api_download_no_hierarchical_tgz(self):
         "[test_cart_api.py] /__api/download/<opusid>.tgz: one opus id & no hierarchical"
@@ -2668,7 +2682,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__api/download/co-iss-n1481265970.tgz?types=coiss_raw,coiss_calib,browse_full&hierarchical=0'
         expected = ['N1481265970_1.IMG', 'N1481265970_1.LBL', 'N1481265970_1_CALIB.IMG', 'N1481265970_1_CALIB.LBL', 'N1481265970_1_full.png', 'data.csv', 'manifest.csv', 'prefix2.fmt', 'tlmtab.fmt', 'urls.txt']
-        self._run_cmp_file_equal(url, expected, response_type='binary', fmt='tgz')
+        self._run_archive_file_equal(url, expected, response_type='binary', fmt='tgz')
 
     def test__api_download_hierarchical_zip(self):
         "[test_cart_api.py] /__api/download/<opusid>.zip: one opus id & hierarchical"
@@ -2677,7 +2691,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__api/download/co-iss-n1481265970.zip?types=coiss_raw,coiss_calib,browse_full&hierarchical=1'
         expected = ['calibrated/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_CALIB.LBL', 'data.csv', 'manifest.csv', 'previews/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_full.png', 'urls.txt', 'volumes/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1.IMG', 'volumes/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1.LBL', 'volumes/COISS_2xxx/COISS_2008/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2008/label/tlmtab.fmt']
-        self._run_cmp_file_equal(url, expected, response_type='binary')
+        self._run_archive_file_equal(url, expected, response_type='binary')
 
     def test__api_download_hierarchical_tar(self):
         "[test_cart_api.py] /__api/download/<opusid>.tar: one opus id & hierarchical"
@@ -2686,7 +2700,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__api/download/co-iss-n1481265970.tar?types=coiss_raw,coiss_calib,browse_full&hierarchical=1'
         expected = ['calibrated/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_CALIB.LBL', 'data.csv', 'manifest.csv', 'previews/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_full.png', 'urls.txt', 'volumes/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1.IMG', 'volumes/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1.LBL', 'volumes/COISS_2xxx/COISS_2008/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2008/label/tlmtab.fmt']
-        self._run_cmp_file_equal(url, expected, response_type='binary', fmt='tar')
+        self._run_archive_file_equal(url, expected, response_type='binary', fmt='tar')
 
     def test__api_download_hierarchical_tgz(self):
         "[test_cart_api.py] /__api/download/<opusid>.tgz: one opus id & hierarchical"
@@ -2695,7 +2709,7 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__api/download/co-iss-n1481265970.tgz?types=coiss_raw,coiss_calib,browse_full&hierarchical=1'
         expected = ['calibrated/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_CALIB.LBL', 'data.csv', 'manifest.csv', 'previews/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_full.png', 'urls.txt', 'volumes/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1.IMG', 'volumes/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1.LBL', 'volumes/COISS_2xxx/COISS_2008/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2008/label/tlmtab.fmt']
-        self._run_cmp_file_equal(url, expected, response_type='binary', fmt='tgz')
+        self._run_archive_file_equal(url, expected, response_type='binary', fmt='tgz')
 
 
             ################################################

--- a/opus/application/test_api/test_cart_api.py
+++ b/opus/application/test_api/test_cart_api.py
@@ -2654,9 +2654,9 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_status_equal(url, 404,
                                HTTP404_UNKNOWN_DOWNLOAD_FILE_FORMAT('xxx', '/__cart/download.json'))
 
-            #########################################################
-            ######### /api/download/<opusid>.<fmt>: API TESTS #######
-            #########################################################
+            ###########################################################
+            ######### /api/download/<opusid>.<fmt>: API TESTS #########
+            ###########################################################
     def test__api_download_no_hierarchical_zip(self):
         "[test_cart_api.py] /__api/download/<opusid>.zip: one opus id & no hierarchical"
         url = '/__cart/reset.json?reqno=42'

--- a/opus/application/test_api/test_cart_api.py
+++ b/opus/application/test_api/test_cart_api.py
@@ -2376,8 +2376,8 @@ class ApiCartTests(TestCase, ApiTestHelper):
             ####################################################
             ######### /__cart/download.json: API TESTS #########
             ####################################################
-    def test__api_cart_download_single_no_hierarchical(self):
-        "[test_cart_api.py] /__cart/download.json: single opus id & no hierarchical"
+    def test__api_cart_download_single_no_hierarchical_zip(self):
+        "[test_cart_api.py] /__cart/download.json: single opus id & no hierarchical & fmt=zip"
         url = '/__cart/reset.json?reqno=42'
         expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
         self._run_json_equal(url, expected)
@@ -2386,10 +2386,34 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=0'
         expected = ['N1462840881_1.IMG', 'N1462840881_1.LBL', 'prefix2.fmt', 'tlmtab.fmt', 'N1462840881_1_CALIB.IMG', 'N1462840881_1_CALIB.LBL', 'N1462840881_1_full.png', 'manifest.csv', 'data.csv', 'urls.txt']
-        self._run_zip_equal(url, expected)
+        self._run_cmp_file_equal(url, expected)
 
-    def test__api_cart_download_single_hierarchical(self):
-        "[test_cart_api.py] /__cart/download.json: single opus id & hierarchical"
+    def test__api_cart_download_single_no_hierarchical_tar(self):
+        "[test_cart_api.py] /__cart/download.json: single opus id & no hierarchical & fmt=tar"
+        url = '/__cart/reset.json?reqno=42'
+        expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
+        self._run_json_equal(url, expected)
+        url = '/__cart/add.json?opusid=co-iss-n1462840881&reqno=456'
+        expected = {'recycled_count': 0, 'count': 1, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=0&fmt=tar'
+        expected = ['N1462840881_1.IMG', 'N1462840881_1.LBL', 'prefix2.fmt', 'tlmtab.fmt', 'N1462840881_1_CALIB.IMG', 'N1462840881_1_CALIB.LBL', 'N1462840881_1_full.png', 'manifest.csv', 'data.csv', 'urls.txt']
+        self._run_cmp_file_equal(url, expected, fmt='tar')
+
+    def test__api_cart_download_single_no_hierarchical_tgz(self):
+        "[test_cart_api.py] /__cart/download.json: single opus id & no hierarchical & fmt=tgz"
+        url = '/__cart/reset.json?reqno=42'
+        expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
+        self._run_json_equal(url, expected)
+        url = '/__cart/add.json?opusid=co-iss-n1462840881&reqno=456'
+        expected = {'recycled_count': 0, 'count': 1, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=0&fmt=tgz'
+        expected = ['N1462840881_1.IMG', 'N1462840881_1.LBL', 'prefix2.fmt', 'tlmtab.fmt', 'N1462840881_1_CALIB.IMG', 'N1462840881_1_CALIB.LBL', 'N1462840881_1_full.png', 'manifest.csv', 'data.csv', 'urls.txt']
+        self._run_cmp_file_equal(url, expected, fmt='tgz')
+
+    def test__api_cart_download_single_hierarchical_zip(self):
+        "[test_cart_api.py] /__cart/download.json: single opus id & hierarchical & fmt=zip"
         url = '/__cart/reset.json?reqno=42'
         expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
         self._run_json_equal(url, expected)
@@ -2398,11 +2422,35 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=1'
         expected = ['volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.IMG', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.LBL', 'volumes/COISS_2xxx/COISS_2002/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2002/label/tlmtab.fmt', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.LBL', 'previews/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_full.png', 'manifest.csv', 'data.csv', 'urls.txt']
-        self._run_zip_equal(url, expected)
+        self._run_cmp_file_equal(url, expected)
+
+    def test__api_cart_download_single_hierarchical_tar(self):
+        "[test_cart_api.py] /__cart/download.json: single opus id & hierarchical & fmt=tar"
+        url = '/__cart/reset.json?reqno=42'
+        expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
+        self._run_json_equal(url, expected)
+        url = '/__cart/add.json?opusid=co-iss-n1462840881&reqno=456'
+        expected = {'recycled_count': 0, 'count': 1, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=1&fmt=tar'
+        expected = ['volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.IMG', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.LBL', 'volumes/COISS_2xxx/COISS_2002/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2002/label/tlmtab.fmt', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.LBL', 'previews/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_full.png', 'manifest.csv', 'data.csv', 'urls.txt']
+        self._run_cmp_file_equal(url, expected, fmt='tar')
+
+    def test__api_cart_download_single_hierarchical_tgz(self):
+        "[test_cart_api.py] /__cart/download.json: single opus id & hierarchical & fmt=tgz"
+        url = '/__cart/reset.json?reqno=42'
+        expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
+        self._run_json_equal(url, expected)
+        url = '/__cart/add.json?opusid=co-iss-n1462840881&reqno=456'
+        expected = {'recycled_count': 0, 'count': 1, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=1&fmt=tgz'
+        expected = ['volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.IMG', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.LBL', 'volumes/COISS_2xxx/COISS_2002/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2002/label/tlmtab.fmt', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.LBL', 'previews/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_full.png', 'manifest.csv', 'data.csv', 'urls.txt']
+        self._run_cmp_file_equal(url, expected, fmt='tgz')
 
     # Two opus ids (from the same volume) with duplicated prefix2.fmt & tlmtab.fmt
-    def test__api_cart_download_multiple_duplicated_no_hierarchical(self):
-        "[test_cart_api.py] /__cart/download.json: multiple opus ids with duplicated files & no hierarchical"
+    def test__api_cart_download_multiple_duplicated_no_hierarchical_zip(self):
+        "[test_cart_api.py] /__cart/download.json: multiple opus ids with duplicated files & no hierarchical & fmt=zip"
         url = '/__cart/reset.json?reqno=42'
         expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
         self._run_json_equal(url, expected)
@@ -2414,11 +2462,43 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=0'
         expected = ['N1460973661_1.IMG', 'N1460973661_1.LBL', 'N1460973661_1_CALIB.IMG', 'N1460973661_1_CALIB.LBL', 'N1460973661_1_full.png', 'N1462840881_1.IMG', 'N1462840881_1.LBL', 'N1462840881_1_CALIB.IMG', 'N1462840881_1_CALIB.LBL', 'N1462840881_1_full.png', 'data.csv', 'manifest.csv', 'prefix2.fmt', 'tlmtab.fmt', 'urls.txt']
-        self._run_zip_equal(url, expected)
+        self._run_cmp_file_equal(url, expected)
 
     # Two opus ids (from the same volume) with duplicated prefix2.fmt & tlmtab.fmt
-    def test__api_cart_download_multiple_duplicated_hierarchical(self):
-        "[test_cart_api.py] /__cart/download.json: multiple opus ids with duplicated files & hierarchical"
+    def test__api_cart_download_multiple_duplicated_no_hierarchical_tar(self):
+        "[test_cart_api.py] /__cart/download.json: multiple opus ids with duplicated files & no hierarchical & fmt=tar"
+        url = '/__cart/reset.json?reqno=42'
+        expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
+        self._run_json_equal(url, expected)
+        url = '/__cart/add.json?opusid=co-iss-n1462840881&reqno=456'
+        expected = {'recycled_count': 0, 'count': 1, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/__cart/add.json?opusid=co-iss-n1460973661&reqno=457'
+        expected = {'recycled_count': 0, 'count': 2, 'error': False, 'reqno': 457}
+        self._run_json_equal(url, expected)
+        url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=0&fmt=tar'
+        expected = ['N1460973661_1.IMG', 'N1460973661_1.LBL', 'N1460973661_1_CALIB.IMG', 'N1460973661_1_CALIB.LBL', 'N1460973661_1_full.png', 'N1462840881_1.IMG', 'N1462840881_1.LBL', 'N1462840881_1_CALIB.IMG', 'N1462840881_1_CALIB.LBL', 'N1462840881_1_full.png', 'data.csv', 'manifest.csv', 'prefix2.fmt', 'tlmtab.fmt', 'urls.txt']
+        self._run_cmp_file_equal(url, expected, fmt='tar')
+
+    # Two opus ids (from the same volume) with duplicated prefix2.fmt & tlmtab.fmt
+    def test__api_cart_download_multiple_duplicated_no_hierarchical_tgz(self):
+        "[test_cart_api.py] /__cart/download.json: multiple opus ids with duplicated files & no hierarchical & fmt=tgz"
+        url = '/__cart/reset.json?reqno=42'
+        expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
+        self._run_json_equal(url, expected)
+        url = '/__cart/add.json?opusid=co-iss-n1462840881&reqno=456'
+        expected = {'recycled_count': 0, 'count': 1, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/__cart/add.json?opusid=co-iss-n1460973661&reqno=457'
+        expected = {'recycled_count': 0, 'count': 2, 'error': False, 'reqno': 457}
+        self._run_json_equal(url, expected)
+        url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=0&fmt=tgz'
+        expected = ['N1460973661_1.IMG', 'N1460973661_1.LBL', 'N1460973661_1_CALIB.IMG', 'N1460973661_1_CALIB.LBL', 'N1460973661_1_full.png', 'N1462840881_1.IMG', 'N1462840881_1.LBL', 'N1462840881_1_CALIB.IMG', 'N1462840881_1_CALIB.LBL', 'N1462840881_1_full.png', 'data.csv', 'manifest.csv', 'prefix2.fmt', 'tlmtab.fmt', 'urls.txt']
+        self._run_cmp_file_equal(url, expected, fmt='tgz')
+
+    # Two opus ids (from the same volume) with duplicated prefix2.fmt & tlmtab.fmt
+    def test__api_cart_download_multiple_duplicated_hierarchical_zip(self):
+        "[test_cart_api.py] /__cart/download.json: multiple opus ids with duplicated files & hierarchical & fmt=zip"
         url = '/__cart/reset.json?reqno=42'
         expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
         self._run_json_equal(url, expected)
@@ -2430,11 +2510,43 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=1'
         expected = ['calibrated/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1_CALIB.LBL', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.LBL', 'data.csv', 'manifest.csv', 'previews/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1_full.png', 'previews/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_full.png', 'urls.txt', 'volumes/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1.IMG', 'volumes/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1.LBL', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.IMG', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.LBL', 'volumes/COISS_2xxx/COISS_2002/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2002/label/tlmtab.fmt']
-        self._run_zip_equal(url, expected)
+        self._run_cmp_file_equal(url, expected)
+
+    # Two opus ids (from the same volume) with duplicated prefix2.fmt & tlmtab.fmt
+    def test__api_cart_download_multiple_duplicated_hierarchical_tar(self):
+        "[test_cart_api.py] /__cart/download.json: multiple opus ids with duplicated files & hierarchical & fmt=tar"
+        url = '/__cart/reset.json?reqno=42'
+        expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
+        self._run_json_equal(url, expected)
+        url = '/__cart/add.json?opusid=co-iss-n1462840881&reqno=456'
+        expected = {'recycled_count': 0, 'count': 1, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/__cart/add.json?opusid=co-iss-n1460973661&reqno=457'
+        expected = {'recycled_count': 0, 'count': 2, 'error': False, 'reqno': 457}
+        self._run_json_equal(url, expected)
+        url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=1&fmt=tar'
+        expected = ['calibrated/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1_CALIB.LBL', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.LBL', 'data.csv', 'manifest.csv', 'previews/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1_full.png', 'previews/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_full.png', 'urls.txt', 'volumes/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1.IMG', 'volumes/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1.LBL', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.IMG', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.LBL', 'volumes/COISS_2xxx/COISS_2002/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2002/label/tlmtab.fmt']
+        self._run_cmp_file_equal(url, expected, fmt='tar')
+
+    # Two opus ids (from the same volume) with duplicated prefix2.fmt & tlmtab.fmt
+    def test__api_cart_download_multiple_duplicated_hierarchical_tgz(self):
+        "[test_cart_api.py] /__cart/download.json: multiple opus ids with duplicated files & hierarchical & fmt=tgz"
+        url = '/__cart/reset.json?reqno=42'
+        expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
+        self._run_json_equal(url, expected)
+        url = '/__cart/add.json?opusid=co-iss-n1462840881&reqno=456'
+        expected = {'recycled_count': 0, 'count': 1, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/__cart/add.json?opusid=co-iss-n1460973661&reqno=457'
+        expected = {'recycled_count': 0, 'count': 2, 'error': False, 'reqno': 457}
+        self._run_json_equal(url, expected)
+        url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=1&fmt=tgz'
+        expected = ['calibrated/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1_CALIB.LBL', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.LBL', 'data.csv', 'manifest.csv', 'previews/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1_full.png', 'previews/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_full.png', 'urls.txt', 'volumes/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1.IMG', 'volumes/COISS_2xxx/COISS_2002/data/1460960653_1461048959/N1460973661_1.LBL', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.IMG', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.LBL', 'volumes/COISS_2xxx/COISS_2002/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2002/label/tlmtab.fmt']
+        self._run_cmp_file_equal(url, expected, fmt='tgz')
 
     # Two opus ids (from the different volumes) with not duplicated prefix2.fmt & tlmtab.fmt
-    def test__api_cart_download_multiple_no_duplicated_no_hierarchical(self):
-        "[test_cart_api.py] /__cart/download.json: multiple opus ids without duplicated files & no hierarchical"
+    def test__api_cart_download_multiple_no_duplicated_no_hierarchical_zip(self):
+        "[test_cart_api.py] /__cart/download.json: multiple opus ids without duplicated files & no hierarchical & fmt=zip"
         url = '/__cart/reset.json?reqno=42'
         expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
         self._run_json_equal(url, expected)
@@ -2446,11 +2558,43 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=0'
         expected = ['N1462840881_1.IMG', 'N1462840881_1.LBL', 'N1462840881_1_CALIB.IMG', 'N1462840881_1_CALIB.LBL', 'N1462840881_1_full.png', 'N1481265970_1.IMG', 'N1481265970_1.LBL', 'N1481265970_1_CALIB.IMG', 'N1481265970_1_CALIB.LBL', 'N1481265970_1_full.png', 'data.csv', 'manifest.csv', 'urls.txt', 'volumes/COISS_2xxx/COISS_2002/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2002/label/tlmtab.fmt', 'volumes/COISS_2xxx/COISS_2008/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2008/label/tlmtab.fmt']
-        self._run_zip_equal(url, expected)
+        self._run_cmp_file_equal(url, expected)
 
     # Two opus ids (from the different volumes) with not duplicated prefix2.fmt & tlmtab.fmt
-    def test__api_cart_download_multiple_no_duplicated_hierarchical(self):
-        "[test_cart_api.py] /__cart/download.json: multiple opus ids without duplicated files & hierarchical"
+    def test__api_cart_download_multiple_no_duplicated_no_hierarchical_tar(self):
+        "[test_cart_api.py] /__cart/download.json: multiple opus ids without duplicated files & no hierarchical & fmt=tar"
+        url = '/__cart/reset.json?reqno=42'
+        expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
+        self._run_json_equal(url, expected)
+        url = '/__cart/add.json?opusid=co-iss-n1462840881&reqno=456'
+        expected = {'recycled_count': 0, 'count': 1, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/__cart/add.json?opusid=co-iss-n1481265970&reqno=457'
+        expected = {'recycled_count': 0, 'count': 2, 'error': False, 'reqno': 457}
+        self._run_json_equal(url, expected)
+        url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=0&fmt=tar'
+        expected = ['N1462840881_1.IMG', 'N1462840881_1.LBL', 'N1462840881_1_CALIB.IMG', 'N1462840881_1_CALIB.LBL', 'N1462840881_1_full.png', 'N1481265970_1.IMG', 'N1481265970_1.LBL', 'N1481265970_1_CALIB.IMG', 'N1481265970_1_CALIB.LBL', 'N1481265970_1_full.png', 'data.csv', 'manifest.csv', 'urls.txt', 'volumes/COISS_2xxx/COISS_2002/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2002/label/tlmtab.fmt', 'volumes/COISS_2xxx/COISS_2008/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2008/label/tlmtab.fmt']
+        self._run_cmp_file_equal(url, expected, fmt='tar')
+
+    # Two opus ids (from the different volumes) with not duplicated prefix2.fmt & tlmtab.fmt
+    def test__api_cart_download_multiple_no_duplicated_no_hierarchical_tgz(self):
+        "[test_cart_api.py] /__cart/download.json: multiple opus ids without duplicated files & no hierarchical & fmt=tgz"
+        url = '/__cart/reset.json?reqno=42'
+        expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
+        self._run_json_equal(url, expected)
+        url = '/__cart/add.json?opusid=co-iss-n1462840881&reqno=456'
+        expected = {'recycled_count': 0, 'count': 1, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/__cart/add.json?opusid=co-iss-n1481265970&reqno=457'
+        expected = {'recycled_count': 0, 'count': 2, 'error': False, 'reqno': 457}
+        self._run_json_equal(url, expected)
+        url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=0&fmt=tgz'
+        expected = ['N1462840881_1.IMG', 'N1462840881_1.LBL', 'N1462840881_1_CALIB.IMG', 'N1462840881_1_CALIB.LBL', 'N1462840881_1_full.png', 'N1481265970_1.IMG', 'N1481265970_1.LBL', 'N1481265970_1_CALIB.IMG', 'N1481265970_1_CALIB.LBL', 'N1481265970_1_full.png', 'data.csv', 'manifest.csv', 'urls.txt', 'volumes/COISS_2xxx/COISS_2002/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2002/label/tlmtab.fmt', 'volumes/COISS_2xxx/COISS_2008/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2008/label/tlmtab.fmt']
+        self._run_cmp_file_equal(url, expected, fmt='tgz')
+
+    # Two opus ids (from the different volumes) with not duplicated prefix2.fmt & tlmtab.fmt
+    def test__api_cart_download_multiple_no_duplicated_hierarchical_zip(self):
+        "[test_cart_api.py] /__cart/download.json: multiple opus ids without duplicated files & hierarchical & fmt=zip"
         url = '/__cart/reset.json?reqno=42'
         expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
         self._run_json_equal(url, expected)
@@ -2462,28 +2606,96 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=1'
         expected = ['calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.LBL', 'calibrated/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_CALIB.LBL', 'data.csv', 'manifest.csv', 'previews/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_full.png', 'previews/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_full.png', 'urls.txt', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.IMG', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.LBL', 'volumes/COISS_2xxx/COISS_2002/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2002/label/tlmtab.fmt', 'volumes/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1.IMG', 'volumes/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1.LBL', 'volumes/COISS_2xxx/COISS_2008/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2008/label/tlmtab.fmt']
-        self._run_zip_equal(url, expected)
+        self._run_cmp_file_equal(url, expected)
+
+    # Two opus ids (from the different volumes) with not duplicated prefix2.fmt & tlmtab.fmt
+    def test__api_cart_download_multiple_no_duplicated_hierarchical_tar(self):
+        "[test_cart_api.py] /__cart/download.json: multiple opus ids without duplicated files & hierarchical & fmt=tar"
+        url = '/__cart/reset.json?reqno=42'
+        expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
+        self._run_json_equal(url, expected)
+        url = '/__cart/add.json?opusid=co-iss-n1462840881&reqno=456'
+        expected = {'recycled_count': 0, 'count': 1, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/__cart/add.json?opusid=co-iss-n1481265970&reqno=457'
+        expected = {'recycled_count': 0, 'count': 2, 'error': False, 'reqno': 457}
+        self._run_json_equal(url, expected)
+        url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=1&fmt=tar'
+        expected = ['calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.LBL', 'calibrated/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_CALIB.LBL', 'data.csv', 'manifest.csv', 'previews/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_full.png', 'previews/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_full.png', 'urls.txt', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.IMG', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.LBL', 'volumes/COISS_2xxx/COISS_2002/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2002/label/tlmtab.fmt', 'volumes/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1.IMG', 'volumes/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1.LBL', 'volumes/COISS_2xxx/COISS_2008/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2008/label/tlmtab.fmt']
+        self._run_cmp_file_equal(url, expected, fmt='tar')
+
+    # Two opus ids (from the different volumes) with not duplicated prefix2.fmt & tlmtab.fmt
+    def test__api_cart_download_multiple_no_duplicated_hierarchical_tgz(self):
+        "[test_cart_api.py] /__cart/download.json: multiple opus ids without duplicated files & hierarchical & fmt=tgz"
+        url = '/__cart/reset.json?reqno=42'
+        expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
+        self._run_json_equal(url, expected)
+        url = '/__cart/add.json?opusid=co-iss-n1462840881&reqno=456'
+        expected = {'recycled_count': 0, 'count': 1, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/__cart/add.json?opusid=co-iss-n1481265970&reqno=457'
+        expected = {'recycled_count': 0, 'count': 2, 'error': False, 'reqno': 457}
+        self._run_json_equal(url, expected)
+        url = '/__cart/download.json?types=coiss_raw,coiss_calib,browse_full&hierarchical=1&fmt=tgz'
+        expected = ['calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_CALIB.LBL', 'calibrated/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_CALIB.LBL', 'data.csv', 'manifest.csv', 'previews/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1_full.png', 'previews/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_full.png', 'urls.txt', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.IMG', 'volumes/COISS_2xxx/COISS_2002/data/1462783195_1462915477/N1462840881_1.LBL', 'volumes/COISS_2xxx/COISS_2002/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2002/label/tlmtab.fmt', 'volumes/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1.IMG', 'volumes/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1.LBL', 'volumes/COISS_2xxx/COISS_2008/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2008/label/tlmtab.fmt']
+        self._run_cmp_file_equal(url, expected, fmt='tgz')
 
             #########################################################
-            ######### /api/download/<opusid>.zip: API TESTS #########
+            ######### /api/download/<opusid>.<fmt>: API TESTS #########
             #########################################################
-    def test__api_download_no_hierarchical(self):
+    def test__api_download_no_hierarchical_zip(self):
         "[test_cart_api.py] /__api/download/<opusid>.zip: one opus id & no hierarchical"
         url = '/__cart/reset.json?reqno=42'
         expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
         self._run_json_equal(url, expected)
         url = '/__api/download/co-iss-n1481265970.zip?types=coiss_raw,coiss_calib,browse_full&hierarchical=0'
         expected = ['N1481265970_1.IMG', 'N1481265970_1.LBL', 'N1481265970_1_CALIB.IMG', 'N1481265970_1_CALIB.LBL', 'N1481265970_1_full.png', 'data.csv', 'manifest.csv', 'prefix2.fmt', 'tlmtab.fmt', 'urls.txt']
-        self._run_zip_equal(url, expected, response_type='binary')
+        self._run_cmp_file_equal(url, expected, response_type='binary')
 
-    def test__api_download_hierarchical(self):
+    def test__api_download_no_hierarchical_tar(self):
+        "[test_cart_api.py] /__api/download/<opusid>.tar: one opus id & no hierarchical"
+        url = '/__cart/reset.json?reqno=42'
+        expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
+        self._run_json_equal(url, expected)
+        url = '/__api/download/co-iss-n1481265970.tar?types=coiss_raw,coiss_calib,browse_full&hierarchical=0'
+        expected = ['N1481265970_1.IMG', 'N1481265970_1.LBL', 'N1481265970_1_CALIB.IMG', 'N1481265970_1_CALIB.LBL', 'N1481265970_1_full.png', 'data.csv', 'manifest.csv', 'prefix2.fmt', 'tlmtab.fmt', 'urls.txt']
+        self._run_cmp_file_equal(url, expected, response_type='binary', fmt='tar')
+
+    def test__api_download_no_hierarchical_tgz(self):
+        "[test_cart_api.py] /__api/download/<opusid>.tgz: one opus id & no hierarchical"
+        url = '/__cart/reset.json?reqno=42'
+        expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
+        self._run_json_equal(url, expected)
+        url = '/__api/download/co-iss-n1481265970.tgz?types=coiss_raw,coiss_calib,browse_full&hierarchical=0'
+        expected = ['N1481265970_1.IMG', 'N1481265970_1.LBL', 'N1481265970_1_CALIB.IMG', 'N1481265970_1_CALIB.LBL', 'N1481265970_1_full.png', 'data.csv', 'manifest.csv', 'prefix2.fmt', 'tlmtab.fmt', 'urls.txt']
+        self._run_cmp_file_equal(url, expected, response_type='binary', fmt='tgz')
+
+    def test__api_download_hierarchical_zip(self):
         "[test_cart_api.py] /__api/download/<opusid>.zip: one opus id & hierarchical"
         url = '/__cart/reset.json?reqno=42'
         expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
         self._run_json_equal(url, expected)
         url = '/__api/download/co-iss-n1481265970.zip?types=coiss_raw,coiss_calib,browse_full&hierarchical=1'
         expected = ['calibrated/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_CALIB.LBL', 'data.csv', 'manifest.csv', 'previews/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_full.png', 'urls.txt', 'volumes/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1.IMG', 'volumes/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1.LBL', 'volumes/COISS_2xxx/COISS_2008/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2008/label/tlmtab.fmt']
-        self._run_zip_equal(url, expected, response_type='binary')
+        self._run_cmp_file_equal(url, expected, response_type='binary')
+
+    def test__api_download_hierarchical_tar(self):
+        "[test_cart_api.py] /__api/download/<opusid>.tar: one opus id & hierarchical"
+        url = '/__cart/reset.json?reqno=42'
+        expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
+        self._run_json_equal(url, expected)
+        url = '/__api/download/co-iss-n1481265970.tar?types=coiss_raw,coiss_calib,browse_full&hierarchical=1'
+        expected = ['calibrated/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_CALIB.LBL', 'data.csv', 'manifest.csv', 'previews/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_full.png', 'urls.txt', 'volumes/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1.IMG', 'volumes/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1.LBL', 'volumes/COISS_2xxx/COISS_2008/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2008/label/tlmtab.fmt']
+        self._run_cmp_file_equal(url, expected, response_type='binary', fmt='tar')
+
+    def test__api_download_hierarchical_tgz(self):
+        "[test_cart_api.py] /__api/download/<opusid>.tgz: one opus id & hierarchical"
+        url = '/__cart/reset.json?reqno=42'
+        expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
+        self._run_json_equal(url, expected)
+        url = '/__api/download/co-iss-n1481265970.tgz?types=coiss_raw,coiss_calib,browse_full&hierarchical=1'
+        expected = ['calibrated/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_CALIB.IMG', 'calibrated/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_CALIB.LBL', 'data.csv', 'manifest.csv', 'previews/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1_full.png', 'urls.txt', 'volumes/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1.IMG', 'volumes/COISS_2xxx/COISS_2008/data/1481264980_1481267140/N1481265970_1.LBL', 'volumes/COISS_2xxx/COISS_2008/label/prefix2.fmt', 'volumes/COISS_2xxx/COISS_2008/label/tlmtab.fmt']
+        self._run_cmp_file_equal(url, expected, response_type='binary', fmt='tgz')
 
 
             ################################################


### PR DESCRIPTION
- Fixes #1070 
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - If YES:
    - Database used: re-import with the latest pds-webtools
    - All Django tests pass: Y
    - FLAKE8 run on modified code: Y
- Were any JavaScript or CSS files modified? Y
  - If YES:
    - JSHINT run on all affected files: Y (cart.js)
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:
- Add a select input (default: zip) in cart download pane for users to select download file format (zip/tar/tgz).
- Add the same zip file tests for the other two formats. 

Known problems:
