### PR TITLE
1118 add browse to help

### DIFF
--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -54,8 +54,8 @@
                             <a class="dropdown-item op-help-item" data-action="tutorialVideos" href="#" title="Watch OPUS tutorials on YouTube">Tutorial Videos</a>
                             <a class="dropdown-item op-help-item" data-action="faq" href="#" title="Read the answers to frequently asked questions">FAQ</a>
                             <div class="dropdown-submenu dropleft">
-                                <a class="dropdown-item dropdown-toggle" href="#" id="op-browse-help-menu" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Interpreting Preview Images</a>
-                                <div class="dropdown-menu" aria-labelledby="op-browse-help-menu">
+                                <a class="dropdown-item dropdown-toggle" href="#" id="op-interpret-image-menu" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Interpreting Preview Images</a>
+                                <div class="op-interpret-image dropdown-menu" aria-labelledby="op-interpret-image-menu">
                                     <a class="op-submenu-item dropdown-item" href="#" data-action="COCIRS">Cassini CIRS</a>
                                     <a class="op-submenu-item dropdown-item" href="#" data-action="COUVIS">Cassini UVIS</a>
                                     <a class="op-submenu-item dropdown-item" href="#" data-action="COVIMS">Cassini VIMS</a>

--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -50,6 +50,14 @@
                         </a>
                         <div class="dropdown-menu dropdown-menu-right" aria-labelledby="op-help-menu">
                             <a class="dropdown-item op-help-item" data-action="about" href="#" title="Learn about OPUS and its general capabilities">About</a>
+                            <div class="dropdown-submenu dropleft">
+                                <a class="dropdown-item dropdown-toggle" href="#" id="op-browse-help-menu" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Browse Products</a>
+                                <div class="dropdown-menu" aria-labelledby="op-browse-help-menu">
+                                    <a class="op-submenu-item dropdown-item" href="#" data-action="COCIRS">Cassini CIRS</a>
+                                    <a class="op-submenu-item dropdown-item" href="#" data-action="COUVIS">Cassini UVIS</a>
+                                    <a class="op-submenu-item dropdown-item" href="#" data-action="COVIMS">Cassini VIMS</a>
+                                </div>
+                            </div>
                             <a class="dropdown-item op-help-item" data-action="gettingStarted" href="#" title="View a detailed introduction to each part of OPUS">Getting Started</a>
                             <a class="dropdown-item op-help-item" data-action="tutorialVideos" href="#" title="Watch OPUS tutorials on YouTube">Tutorial Videos</a>
                             <a class="dropdown-item op-help-item" data-action="faq" href="#" title="Read the answers to frequently asked questions">FAQ</a>

--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -50,17 +50,17 @@
                         </a>
                         <div class="dropdown-menu dropdown-menu-right" aria-labelledby="op-help-menu">
                             <a class="dropdown-item op-help-item" data-action="about" href="#" title="Learn about OPUS and its general capabilities">About</a>
+                            <a class="dropdown-item op-help-item" data-action="gettingStarted" href="#" title="View a detailed introduction to each part of OPUS">Getting Started</a>
+                            <a class="dropdown-item op-help-item" data-action="tutorialVideos" href="#" title="Watch OPUS tutorials on YouTube">Tutorial Videos</a>
+                            <a class="dropdown-item op-help-item" data-action="faq" href="#" title="Read the answers to frequently asked questions">FAQ</a>
                             <div class="dropdown-submenu dropleft">
-                                <a class="dropdown-item dropdown-toggle" href="#" id="op-browse-help-menu" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Browse Products</a>
+                                <a class="dropdown-item dropdown-toggle" href="#" id="op-browse-help-menu" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Interpreting Preview Images</a>
                                 <div class="dropdown-menu" aria-labelledby="op-browse-help-menu">
                                     <a class="op-submenu-item dropdown-item" href="#" data-action="COCIRS">Cassini CIRS</a>
                                     <a class="op-submenu-item dropdown-item" href="#" data-action="COUVIS">Cassini UVIS</a>
                                     <a class="op-submenu-item dropdown-item" href="#" data-action="COVIMS">Cassini VIMS</a>
                                 </div>
                             </div>
-                            <a class="dropdown-item op-help-item" data-action="gettingStarted" href="#" title="View a detailed introduction to each part of OPUS">Getting Started</a>
-                            <a class="dropdown-item op-help-item" data-action="tutorialVideos" href="#" title="Watch OPUS tutorials on YouTube">Tutorial Videos</a>
-                            <a class="dropdown-item op-help-item" data-action="faq" href="#" title="Read the answers to frequently asked questions">FAQ</a>
                             <a class="dropdown-item op-help-item" data-action="announcements" href="#" title="View recent announcements about changes to OPUS">Recent Announcements</a>
                             <a class="dropdown-item op-help-item" data-action="volumes" href="#" title="View the list of PDS data volumes available in OPUS">Data Volumes</a>
                             <a class="dropdown-item op-help-item" data-action="apiguide" href="#" title="View a description of the OPUS API for external developers">API Guide</a>

--- a/opus/application/apps/ui/templates/ui/header.html
+++ b/opus/application/apps/ui/templates/ui/header.html
@@ -73,6 +73,7 @@
         const DEFAULT_SORT_ORDER = '{{ default_sort_order }}';
         const STATIC_URL = '{{ STATIC_URL }}';
         const MAX_SELECTIONS_ALLOWED = '{{ max_selections_allowed }}';
+        const PREVIEW_GUIDES = {{ preview_guides|safe }}
     </script>
     {% if chat_key %}
         <!--Start of Tawk.to Script-->

--- a/opus/application/apps/ui/views.py
+++ b/opus/application/apps/ui/views.py
@@ -77,6 +77,7 @@ class main_site(TemplateView):
         context['default_widgets'] = settings.DEFAULT_WIDGETS
         context['default_sort_order'] = settings.DEFAULT_SORT_ORDER
         context['max_selections_allowed'] = settings.MAX_SELECTIONS_ALLOWED
+        context['preview_guides'] = str(settings.PREVIEW_GUIDES).strip('"')
         context['menu'] = menu['menu']
         if settings.OPUS_FILE_VERSION == '':
             settings.OPUS_FILE_VERSION = get_git_version()

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -3218,7 +3218,7 @@ when wrapping into the 2nd line */
     .op-help-item, #op-interpret-image-menu {
         padding-top: 0.1em !important;
         padding-bottom: 0.1em !important;
-        font-size: 90%;
+        font-size: 81%;
     }
 }
 

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -133,12 +133,20 @@ so that both "Recent Announcements" and "Message" can be vertically aligned. */
     padding-right: 0.5rem;
 }
 
+#op-browse-help-menu {
+    padding-left: 0.8em;
+}
+
 @media (max-height: 490px) {
     #op-help a {
         padding-top: 2px;
         padding-bottom: 2px;
         padding-left: 10px;
         padding-right: 10px;
+    }
+
+    #op-browse-help-menu {
+        padding-left: 0.2em !important;
     }
 }
 

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -3215,7 +3215,7 @@ when wrapping into the 2nd line */
     }
 
     /* Reduce spaces between each item in the help menu when screen is short */
-    .op-help-item {
+    .op-help-item, #op-interpret-image-menu {
         padding-top: 0.1em !important;
         padding-bottom: 0.1em !important;
         font-size: 90%;

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -133,7 +133,7 @@ so that both "Recent Announcements" and "Message" can be vertically aligned. */
     padding-right: 0.5rem;
 }
 
-#op-browse-help-menu {
+#op-interpret-image-menu {
     padding-left: 0.8em;
 }
 
@@ -145,7 +145,7 @@ so that both "Recent Announcements" and "Message" can be vertically aligned. */
         padding-right: 10px;
     }
 
-    #op-browse-help-menu {
+    #op-interpret-image-menu {
         padding-left: 0.2em !important;
     }
 }

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -137,7 +137,7 @@ so that both "Recent Announcements" and "Message" can be vertically aligned. */
     padding-left: 0.8em;
 }
 
-@media (max-height: 490px) {
+@media (max-height: 535px) {
     #op-help a {
         padding-top: 2px;
         padding-bottom: 2px;

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -6,7 +6,7 @@
 /* jshint multistr: true */
 /* globals $, _, PerfectScrollbar */
 /* globals o_browse, o_cart, o_detail, o_hash, o_menu, o_selectMetadata, o_sortMetadata, o_mutationObserver, o_search, o_utils, o_widgets, FeedbackMethods */
-/* globals DEFAULT_COLUMNS, DEFAULT_WIDGETS, DEFAULT_SORT_ORDER, STATIC_URL */
+/* globals DEFAULT_COLUMNS, DEFAULT_WIDGETS, DEFAULT_SORT_ORDER, STATIC_URL, PREVIEW_GUIDES */
 
 // defining the opus namespace first; document ready comes after...
 /* jshint varstmt: false */
@@ -838,7 +838,7 @@ var opus = {
         // Click on items inside submenu, we execute something and close the whole dropdown.
         $("#op-help .dropdown-submenu .op-submenu-item").on("click", function(e) {
             let submenuItem = $(this);
-            opus.displayHelpPane(submenuItem.data("action"))
+            opus.displayHelpPane(submenuItem.data("action"));
             submenuItem.parents(".dropdown-menu").removeClass("show");
             e.stopPropagation();
         });

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -845,8 +845,7 @@ var opus = {
 
         // When the parent dropdown is closed, make sure submenu is closed.
         $("#op-help").on("hidden.bs.dropdown", function(e) {
-            let submenu = $("#op-help .dropdown-submenu .dropdown-menu");
-            submenu.removeClass("show");
+            $(".op-interpret-image").hide();
         });
 
         // Clicking on either of the Reset buttons
@@ -1000,6 +999,13 @@ var opus = {
         $("#op-notification-modal").modal("show");
     },
 
+    displayImageInterpretation: function(action) {
+        let url = PREVIEW_GUIDES[action];
+        window.open(url, "_blank");
+        $("#op-help").removeClass("show");
+        $(".op-interpret-image").hide();
+    },
+
     displayHelpPane: function(action) {
         /**
          * Given the name of a help menu entry, open the help pane and load the
@@ -1043,19 +1049,9 @@ var opus = {
                 header = "Getting Started with OPUS";
                 break;
             case "COCIRS":
-                url = PREVIEW_GUIDES[action];
-                window.open(url, "_blank");
-                $("#op-help").removeClass("show");
-                return;
             case "COUVIS":
-                url = PREVIEW_GUIDES[action];
-                window.open(url, "_blank");
-                $("#op-help").removeClass("show");
-                return;
             case "COVIMS":
-                url = PREVIEW_GUIDES[action];
-                window.open(url, "_blank");
-                $("#op-help").removeClass("show");
+                opus.displayImageInterpretation(action);
                 return;
             case "contact":
                 FeedbackMethods.open();

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -829,6 +829,26 @@ var opus = {
             return false;
         });
 
+        // Behavior for help submenu
+        $("#op-help .dropdown-submenu .dropdown-item").on("click", function(e) {
+            $(this).next(".dropdown-menu").toggle("show");
+            e.stopPropagation();
+        });
+
+        // Click on items inside submenu, we execute something and close the whole dropdown.
+        $("#op-help .dropdown-submenu .op-submenu-item").on("click", function(e) {
+            let submenuItem = $(this);
+            opus.displayHelpPane(submenuItem.data("action"))
+            submenuItem.parents(".dropdown-menu").removeClass("show");
+            e.stopPropagation();
+        });
+
+        // When the parent dropdown is closed, make sure submenu is closed.
+        $("#op-help").on("hidden.bs.dropdown", function(e) {
+            let submenu = $("#op-help .dropdown-submenu .dropdown-menu");
+            submenu.removeClass("show");
+        });
+
         // Clicking on either of the Reset buttons
         $(".op-reset-button button").on("click", function() {
             let targetModal = $(this).data("target");
@@ -1022,6 +1042,21 @@ var opus = {
                 pdfURL = baseURL + "gettingstarted.pdf";
                 header = "Getting Started with OPUS";
                 break;
+            case "COCIRS":
+                url = PREVIEW_GUIDES[action];
+                window.open(url, "_blank");
+                $("#op-help").removeClass("show");
+                return;
+            case "COUVIS":
+                url = PREVIEW_GUIDES[action];
+                window.open(url, "_blank");
+                $("#op-help").removeClass("show");
+                return;
+            case "COVIMS":
+                url = PREVIEW_GUIDES[action];
+                window.open(url, "_blank");
+                $("#op-help").removeClass("show");
+                return;
             case "contact":
                 FeedbackMethods.open();
                 return;
@@ -1035,7 +1070,6 @@ var opus = {
                 window.open("https://www.youtube.com/playlist?list=PLgPYitJagzrYj0iMFiuwQpdGImP6Wdt29", "_blank");
                 return;
         }
-
         let buttons = '<div class="op-open-help">';
         buttons += `&nbsp;&nbsp;<button type="button" class="btn btn-sm btn-secondary op-open-help-new-tab" data-action="${action}" title="Open the contents of this panel in a new browser tab">View in new browser tab</button>`;
         if (pdfURL) {


### PR DESCRIPTION
- Fixes #1118
- Were any Django, import pipeline, table_schema, or dictionary files modified? Y/N
  - If YES:
    - Database used: opus3_test_210526
    - All Django tests pass: Y
    - FLAKE8 run on modified code: Y/NA
- Were any JavaScript or CSS files modified? Y
  - If YES:
    - JSHINT run on all affected files: Y
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:
 - added a menu item to the main help dropdown 'Interpreting Preview Images'
 - added a submenu that includes CIRS, UVIS and VIMS preview txt
 - click on submenu item will open the appropriate preview image .txt file in a new tab and close the help menu

Known problems:
