### PR TITLE
Toolbar did not hide behind cart detail window as it should have.

### DIFF
--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -160,6 +160,13 @@
                             <p class="infinite-scroll-error">No more pages to load</p>
                         </div>
                     </div>
+                    <div class="op-edit-field-tool dropdown-menu dropdown-menu-sm border-top-0 border-dark mt-0" data-toggle="dropdown" aria-labelledby="op-edit-field-tool" aria-haspopup="true" aria-expanded="false">
+                        <div class="d-flex justify-content-between">
+                            <a href="#" class="op-metadata-detail-add" data-action="addBefore" title="Add a metadata field before this column"><i class="fas fa-plus pl-1"></i></a>
+                            <a href="#" class="op-metadata-detail-remove" data-action="remove" title="Remove this metadata field"><i class="far fa-trash-alt"></i></a>
+                            <a href="#" class="op-metadata-detail-add" data-action="addAfter" title="Add a metadata field after this column"><i class="fas fa-plus pr-1"></i></a>
+                        </div>
+                    </div>
                 </div>
             </div>
 
@@ -250,6 +257,13 @@
                                 <p class="infinite-scroll-error">No more pages to load</p>
                             </div>
                         </div>
+                        <div class="op-edit-field-tool dropdown-menu dropdown-menu-sm border-top-0 border-dark mt-0" data-toggle="dropdown" aria-labelledby="op-edit-field-tool" aria-haspopup="true" aria-expanded="false">
+                            <div class="d-flex justify-content-between">
+                                <a href="#" class="op-metadata-detail-add" data-action="addBefore" title="Add a metadata field before this column"><i class="fas fa-plus pl-1"></i></a>
+                                <a href="#" class="op-metadata-detail-remove" data-action="remove" title="Remove this metadata field"><i class="far fa-trash-alt"></i></a>
+                                <a href="#" class="op-metadata-detail-add" data-action="addAfter" title="Add a metadata field after this column"><i class="fas fa-plus pr-1"></i></a>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 <div id="op-cart-download-panel" class="card">
@@ -272,14 +286,6 @@
             </div>
             <div class="op-page-loading-status">
                 <div class="loader"></div>
-            </div>
-
-            <div id="op-edit-field-tool" class="dropdown-menu dropdown-menu-sm border-top-0 border-dark mt-0" data-toggle="dropdown" aria-labelledby="op-edit-field-tool" aria-haspopup="true" aria-expanded="false">
-                <div class="d-flex justify-content-between">
-                    <a href="#" class="op-metadata-detail-add" data-action="addBefore" title="Add a metadata field before this column"><i class="fas fa-plus pl-1"></i></a>
-                    <a href="#" class="op-metadata-detail-remove" data-action="remove" title="Remove this metadata field"><i class="far fa-trash-alt"></i></a>
-                    <a href="#" class="op-metadata-detail-add" data-action="addAfter" title="Add a metadata field after this column"><i class="fas fa-plus pr-1"></i></a>
-                </div>
             </div>
         </div><!-- /tabcontent -->
 

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -754,11 +754,11 @@ th.sticky-header {
     text-decoration: none;
 }
 
-#op-edit-field-tool .dropdown-menu {
+.op-edit-field-tool .dropdown-menu {
     overflow-y: auto;
 }
 
-#op-edit-field-tool {
+.op-edit-field-tool {
     min-width: 0;
     background-color: black;
     border-top-left-radius: 0;
@@ -3121,7 +3121,7 @@ when wrapping into the 2nd line */
         transform: scale(2.5);
     }
 
-    #op-add-metadata-fields, #op-edit-field-tool {
+    #op-add-metadata-fields, .op-edit-field-tool {
         font-size: 75% !important;
     }
 

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -385,7 +385,8 @@ var o_browse = {
         });
 
         $(".op-data-table-view").on("mouseleave", "th.op-draggable", function(e) {
-            let tools = $("#op-edit-field-tool");
+            let tab = opus.getViewTab();
+            let tools = $(`${tab} .op-edit-field-tool`);
             if (e.pageY < Math.floor(tools.offset().top)  ||
                (e.pageY > tools.outerHeight() + tools.offset().top) ||
                (e.pageX < tools.offset().left) ||
@@ -400,16 +401,17 @@ var o_browse = {
             o_browse.hideTableMetadataTools(e);
         });
 
-        $("#op-edit-field-tool").on("mouseleave", function(e) {
+        $(".op-edit-field-tool").on("mouseleave", function(e) {
             // only hide the edit metadata field tool bar if the add metadata menu is not showing
             if (!$("#op-add-metadata-fields").hasClass("show")) {
                 o_browse.hideTableMetadataTools(e);
             }
         });
 
-        $("#op-edit-field-tool a").on("click", function(e) {
+        $(".op-edit-field-tool a").on("click", function(e) {
             let action = $(this).data("action");
-            let slug = $("#op-edit-field-tool").data("slug");
+            let tab = opus.getViewTab();
+            let slug = $(`${tab} .op-edit-field-tool`).data("slug");
             switch (action) {
                 case "addBefore":
                     $("#op-add-metadata-fields").data("slug", slug);
@@ -2362,32 +2364,51 @@ var o_browse = {
     },
 
     showTableMetadataTools: function(e, slug) {
-        let elem = e.currentTarget;
-        let targetPosition = $(elem).offset();
-        let left = targetPosition.left;
-        let width = $(elem).outerWidth();
+        let tab = opus.getViewTab();
+        let targetElem = e.currentTarget;
+        let toolElem = `${tab} .op-edit-field-tool`;
+        let left = $(targetElem).position().left +
+                    $(`${tab} .op-data-table-view .table`).offset().left;
+        let top = $(targetElem).offset().top +
+                  $(targetElem).outerHeight();
+
+        if (tab === "#cart") {
+            if ($(".cart_details:visible").length > 0) {
+                // need to calculate a new offset if the table has scrolled left behind the details window
+                left -= $(".cart_details").outerWidth() + $(".cart_details").offset().left;
+            } else {
+                // when the details are collapsed, need to use the offset instead of position
+                left = $(targetElem).offset().left +
+                       $(`${tab} .op-data-table-view`).position().left -
+                       $(`${tab} .op-data-table-view`).offset().left;
+            }
+            // because the cart is in a container, we need to account for the nav
+            // there is a bit of overlap between the top of the cart gallery and navbar
+            let offset = $("#op-main-nav").outerHeight() - $(".op-cart-gallery-side").offset().top;
+            top -= $("#op-main-nav").outerHeight() - offset;
+        }
+        let width = $(targetElem).outerWidth();
+
         // need to adjust for the PerfectScrollbar overlaying a bit on the last field
         let lastSlug = opus.prefs.cols[opus.prefs.cols.length - 1];
         if (slug === lastSlug) {
-            width -= $(`.op-data-table-view .ps__thumb-y`).width();
+            width -= $(`${tab} .op-data-table-view .ps__thumb-y`).width();
         }
-        let top = $(elem).offset().top +
-                  $(elem).outerHeight();
-
         o_browse.checkForEmptyMetadataList();
 
-        $("#op-edit-field-tool").css({
+        $(toolElem).css({
             display: "block",
             top: top,
             left: left,
             width: width,
         }).fadeIn("slow");
 
-        $("#op-edit-field-tool").data("slug", slug);
+        $(toolElem).data("slug", slug);
     },
 
     hideTableMetadataTools: function() {
-        $("#op-edit-field-tool").removeClass("show").hide();
+        let tab = opus.getViewTab();
+        $(`${tab} .op-edit-field-tool`).removeClass("show").hide();
     },
 
     onDoneUpdateFromTableMetadataDetails: function(e) {


### PR DESCRIPTION
- Fixes #1098
- Were any Django, import pipeline, table_schema, or dictionary files modified? N
  - If YES:
    - Database used: XXX
    - All Django tests pass: Y/NA
    - FLAKE8 run on modified code: Y/NA
- Were any JavaScript or CSS files modified? Y
  - If YES:
    - JSHINT run on all affected files: Y
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): NA

Description of changes:
Moved the toolbar element to under #browse & #cart.  Placing the element with the table header keeps it at the same z-index; having it floating was presenting a problem.

Known problems:
