### PR TITLE
Moved the preventDefault

### DIFF
--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -571,7 +571,6 @@ var o_browse = {
                 o_browse.undoRangeSelect();
             }
             if ($("#op-metadata-detail-view").hasClass("show")) {
-                e.preventDefault();
                 if (o_browse.pageLoaderSpinnerTimer === null) {
                     /*  Catch the right/left arrow and spacebar while in the modal
                         Up: 38
@@ -617,6 +616,7 @@ var o_browse = {
                             // fixes the bug that prevented click on the slide to open a full size image
                             return true;
                     }
+                    e.preventDefault();
                 }
                 return false;
             }


### PR DESCRIPTION
the preventDefault was not allowing the default behaviour on the <a> tag to work.

- Fixes #1222
- Were any Django, import pipeline, or table_schema files modified? N
  - If YES:
    - Database used: XXX
    - All Django tests pass: Y/NA
    - FLAKE8 run on modified code: Y/NA
- Were any JavaScript or CSS files modified? Y
  - If YES:
    - JSHINT run on all affected files: Y
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y/NA
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): NA
- Was the documentation reviewed for necessary changes or additions? NA
  - About
  - Getting Started
  - FAQ
  - API Guide
  - Tooltips

Description of changes:
Moved the e.preventDefault to a more appropriate place

Known problems:
