### PR TITLE
Pull request to track the progress of converting to use Django 4

### DIFF
--- a/opus/application/apps/cart/test_cart.py
+++ b/opus/application/apps/cart/test_cart.py
@@ -37,9 +37,11 @@ class cartTests(TestCase):
 
     def test__api_view_cart_no_request(self):
         "[test_cart.py] api_view_cart: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /__cart/view.html'):
-            api_view_cart(None)
+            api_view_cart(no_request)
 
     def test__api_view_cart_no_get(self):
         "[test_cart.py] api_view_cart: no GET"
@@ -56,9 +58,11 @@ class cartTests(TestCase):
 
     def test__api_cart_status_no_request(self):
         "[test_cart.py] api_cart_status: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /__cart/status.json'):
-            api_cart_status(None)
+            api_cart_status(no_request)
 
     def test__api_cart_status_no_get(self):
         "[test_cart.py] api_cart_status: no GET"
@@ -75,9 +79,11 @@ class cartTests(TestCase):
 
     def test__api_get_cart_csv_no_request(self):
         "[test_cart.py] api_get_cart_csv: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /__cart/data.csv'):
-            api_get_cart_csv(None)
+            api_get_cart_csv(no_request)
 
     def test__api_get_cart_csv_no_get(self):
         "[test_cart.py] api_get_cart_csv: no GET"
@@ -94,9 +100,11 @@ class cartTests(TestCase):
 
     def test__api_edit_cart_no_request(self):
         "[test_cart.py] api_edit_cart: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /__cart/add.json'):
-            api_edit_cart(None, 'add')
+            api_edit_cart(no_request, 'add')
 
     def test__api_edit_cart_no_get(self):
         "[test_cart.py] api_edit_cart: no GET"
@@ -113,9 +121,11 @@ class cartTests(TestCase):
 
     def test__api_reset_session_no_request(self):
         "[test_cart.py] api_reset_session: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /__cart/reset.json'):
-            api_reset_session(None)
+            api_reset_session(no_request)
 
     def test__api_reset_session_no_get(self):
         "[test_cart.py] api_reset_session: no GET"
@@ -132,9 +142,11 @@ class cartTests(TestCase):
 
     def test__api_create_download_no_request(self):
         "[test_cart.py] api_create_download: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /__cart/download.json'):
-            api_create_download(None)
+            api_create_download(no_request)
 
     def test__api_create_download_no_get(self):
         "[test_cart.py] api_create_download: no GET"

--- a/opus/application/apps/cart/urls.py
+++ b/opus/application/apps/cart/urls.py
@@ -1,5 +1,5 @@
 # cart/urls.py
-from django.conf.urls import url
+from django.urls import re_path
 from cart.views import (
     api_view_cart,
     api_cart_status,
@@ -10,12 +10,12 @@ from cart.views import (
 )
 
 urlpatterns = [
-    url(r'^__cart/view.json$', api_view_cart),
-    url(r'^__cart/status.json$', api_cart_status),
-    url(r'^__cart/data.csv$', api_get_cart_csv),
-    url(r'^__cart/(?P<action>add|remove|addrange|removerange|addall).json$', api_edit_cart),
-    url(r'^__cart/reset.json$', api_reset_session),
-    url(r'^__cart/download.json$', api_create_download),
-    url(r'^api/download/(?P<opus_id>[-\w]+).(?P<fmt>zip|tar|tgz)$', api_create_download),
-    url(r'^__api/download/(?P<opus_id>[-\w]+).(?P<fmt>zip|tar|tgz)$', api_create_download),
+    re_path(r'^__cart/view.json$', api_view_cart),
+    re_path(r'^__cart/status.json$', api_cart_status),
+    re_path(r'^__cart/data.csv$', api_get_cart_csv),
+    re_path(r'^__cart/(?P<action>add|remove|addrange|removerange|addall).json$', api_edit_cart),
+    re_path(r'^__cart/reset.json$', api_reset_session),
+    re_path(r'^__cart/download.json$', api_create_download),
+    re_path(r'^api/download/(?P<opus_id>[-\w]+).(?P<fmt>zip|tar|tgz)$', api_create_download),
+    re_path(r'^__api/download/(?P<opus_id>[-\w]+).(?P<fmt>zip|tar|tgz)$', api_create_download),
 ]

--- a/opus/application/apps/cart/views.py
+++ b/opus/application/apps/cart/views.py
@@ -97,7 +97,7 @@ def api_view_cart(request):
     """
     api_code = enter_api_call('api_view_cart', request)
 
-    if not request or request.GET is None:
+    if not request or request.GET is None or request.META is None:
         ret = Http404(HTTP404_NO_REQUEST('/__cart/view.html'))
         exit_api_call(api_code, ret)
         raise ret
@@ -187,7 +187,7 @@ def api_cart_status(request):
     """
     api_code = enter_api_call('api_cart_status', request)
 
-    if not request or request.GET is None:
+    if not request or request.GET is None or request.META is None:
         ret = Http404(HTTP404_NO_REQUEST('/__cart/status.json'))
         exit_api_call(api_code, ret)
         raise ret
@@ -242,7 +242,7 @@ def api_get_cart_csv(request):
     """
     api_code = enter_api_call('api_get_cart_csv', request)
 
-    if not request or request.GET is None:
+    if not request or request.GET is None or request.META is None:
         ret = Http404(HTTP404_NO_REQUEST('/__cart/data.csv'))
         exit_api_call(api_code, ret)
         raise ret
@@ -326,7 +326,7 @@ def api_edit_cart(request, action, **kwargs):
     """
     api_code = enter_api_call('api_edit_cart', request)
 
-    if not request or request.GET is None:
+    if not request or request.GET is None or request.META is None:
         ret = Http404(HTTP404_NO_REQUEST(f'/__cart/{action}.json'))
         exit_api_call(api_code, ret)
         raise ret
@@ -452,7 +452,7 @@ def api_reset_session(request):
     """
     api_code = enter_api_call('api_reset_session', request)
 
-    if not request or request.GET is None:
+    if not request or request.GET is None or request.META is None:
         ret = Http404(HTTP404_NO_REQUEST('/__cart/reset.json'))
         exit_api_call(api_code, ret)
         raise ret
@@ -524,7 +524,7 @@ def api_create_download(request, opus_id=None, fmt=None):
     """
     api_code = enter_api_call('api_create_download', request)
 
-    if not request or request.GET is None:
+    if not request or request.GET is None or request.META is None:
         if opus_id:
             ret = Http404(HTTP404_NO_REQUEST(f'/api/download/{opus_id}.{fmt}'))
         else:

--- a/opus/application/apps/dictionary/urls.py
+++ b/opus/application/apps/dictionary/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.views.generic.base import RedirectView
@@ -13,19 +13,19 @@ from dictionary.views import (
 urlpatterns = [
     # List all definitions that start with a given letter.
     # Requires ?alpha=<letter>
-    url(r'^list.json$', api_get_definition_list, name='list'),
+    re_path(r'^list.json$', api_get_definition_list, name='list'),
 
     # Search for a given term anywhere in the definitions.
     # Requires ?term=<term>
-    url(r'^search.json$', api_search_definitions, name='search'),
+    re_path(r'^search.json$', api_search_definitions, name='search'),
 
     # Display all definitions with an alpha bar
-    url(r'^$', api_display_definitions, name='definitions'),
-    url(r'^definitions.html^$', api_display_definitions, name='definitions'),
+    re_path(r'^$', api_display_definitions, name='definitions'),
+    re_path(r'^definitions.html^$', api_display_definitions, name='definitions'),
 
     # Display a single definition. Requires ?term=<term>
-    url(r'^definition.html$', api_display_definition, name='definition'),
-    url(r'^favicon.ico$',
+    re_path(r'^definition.html$', api_display_definition, name='definition'),
+    re_path(r'^favicon.ico$',
         RedirectView.as_view(
             url=staticfiles_storage.url('favicon.ico'),
             permanent=False),

--- a/opus/application/apps/help/test_help.py
+++ b/opus/application/apps/help/test_help.py
@@ -38,9 +38,11 @@ class helpTests(TestCase):
 
     def test__api_about_no_request(self):
         "[test_help.py] api_about: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /__help/about.html'):
-            api_about(None, 'html')
+            api_about(no_request, 'html')
 
     def test__api_about_no_get(self):
         "[test_help.py] api_about: no GET"
@@ -57,9 +59,11 @@ class helpTests(TestCase):
 
     def test__api_volumes_no_request(self):
         "[test_help.py] api_volumes: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /__help/volumes.html'):
-            api_volumes(None, 'html')
+            api_volumes(no_request, 'html')
 
     def test__api_volumes_no_get(self):
         "[test_help.py] api_volumes: no GET"
@@ -76,9 +80,11 @@ class helpTests(TestCase):
 
     def test__api_faq_no_request(self):
         "[test_help.py] api_faq: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /__help/faq.html'):
-            api_faq(None, 'html')
+            api_faq(no_request, 'html')
 
     def test__api_faq_no_get(self):
         "[test_help.py] api_faq: no GET"
@@ -95,9 +101,11 @@ class helpTests(TestCase):
 
     def test__api_api_guide_no_request(self):
         "[test_help.py] api_api_guide: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /__help/apiguide.html'):
-            api_api_guide(None, 'html')
+            api_api_guide(no_request, 'html')
 
     def test__api_api_guide_no_get(self):
         "[test_help.py] api_api_guide: no GET"
@@ -114,9 +122,11 @@ class helpTests(TestCase):
 
     def test__api_gettingstarted_no_request(self):
         "[test_help.py] api_gettingstarted: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /__help/gettingstarted.html'):
-            api_gettingstarted(None, 'html')
+            api_gettingstarted(no_request, 'html')
 
     def test__api_gettingstarted_no_get(self):
         "[test_help.py] api_gettingstarted: no GET"
@@ -133,9 +143,11 @@ class helpTests(TestCase):
 
     def test__api_splash_no_request(self):
         "[test_help.py] api_splash: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /__help/splash.html'):
-            api_splash(None)
+            api_splash(no_request)
 
     def test__api_splash_no_get(self):
         "[test_help.py] api_splash: no GET"
@@ -152,9 +164,11 @@ class helpTests(TestCase):
 
     def test__api_citing_opus_no_request(self):
         "[test_help.py] api_citing_opus: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /__help/citing.html'):
-            api_citing_opus(None, 'html')
+            api_citing_opus(no_request, 'html')
 
     def test__api_citing_opus_no_get(self):
         "[test_help.py] api_citing_opus: no GET"

--- a/opus/application/apps/help/urls.py
+++ b/opus/application/apps/help/urls.py
@@ -1,5 +1,5 @@
 # help/urls.py
-from django.conf.urls import url
+from django.urls import re_path
 
 from help.views import (
     api_about,
@@ -12,12 +12,12 @@ from help.views import (
 )
 
 urlpatterns = [
-    url(r'^__help/about.(?P<fmt>html|pdf)$', api_about),
-    url(r'^__help/volumes.(?P<fmt>html|pdf)$', api_volumes),
-    url(r'^__help/faq.(?P<fmt>html|pdf)$', api_faq),
-    url(r'^__help/gettingstarted.(?P<fmt>html|pdf)$', api_gettingstarted),
-    url(r'^__help/splash.html$', api_splash),
-    url(r'^apiguide.(?P<fmt>pdf)$', api_api_guide), # Public entrypoint
-    url(r'^__help/apiguide.(?P<fmt>html|pdf)$', api_api_guide),
-    url(r'^__help/citing.(?P<fmt>html|pdf)$', api_citing_opus),
+    re_path(r'^__help/about.(?P<fmt>html|pdf)$', api_about),
+    re_path(r'^__help/volumes.(?P<fmt>html|pdf)$', api_volumes),
+    re_path(r'^__help/faq.(?P<fmt>html|pdf)$', api_faq),
+    re_path(r'^__help/gettingstarted.(?P<fmt>html|pdf)$', api_gettingstarted),
+    re_path(r'^__help/splash.html$', api_splash),
+    re_path(r'^apiguide.(?P<fmt>pdf)$', api_api_guide), # Public entrypoint
+    re_path(r'^__help/apiguide.(?P<fmt>html|pdf)$', api_api_guide),
+    re_path(r'^__help/citing.(?P<fmt>html|pdf)$', api_citing_opus),
 ]

--- a/opus/application/apps/help/views.py
+++ b/opus/application/apps/help/views.py
@@ -63,7 +63,9 @@ def api_about(request, fmt):
     """
     api_code = enter_api_call('api_about', request)
 
-    if not request or request.GET is None or throw_random_http404_error():
+    if (not request or request.GET is None
+        or throw_random_http404_error()
+        or request.META is None):
         ret = Http404(HTTP404_NO_REQUEST(f'/__help/about.{fmt}'))
         exit_api_call(api_code, ret)
         raise ret
@@ -94,7 +96,9 @@ def api_volumes(request, fmt):
     """
     api_code = enter_api_call('api_volumes', request)
 
-    if not request or request.GET is None or throw_random_http404_error():
+    if (not request or request.GET is None
+        or throw_random_http404_error()
+        or request.META is None):
         ret = Http404(HTTP404_NO_REQUEST(f'/__help/volumes.{fmt}'))
         exit_api_call(api_code, ret)
         raise ret
@@ -126,7 +130,9 @@ def api_faq(request, fmt):
     """
     api_code = enter_api_call('api_faq', request)
 
-    if not request or request.GET is None or throw_random_http404_error():
+    if (not request or request.GET is None
+        or throw_random_http404_error()
+        or request.META is None):
         ret = Http404(HTTP404_NO_REQUEST(f'/__help/faq.{fmt}'))
         exit_api_call(api_code, ret)
         raise ret
@@ -162,7 +168,9 @@ def api_gettingstarted(request, fmt):
     """
     api_code = enter_api_call('api_gettingstarted', request)
 
-    if not request or request.GET is None or throw_random_http404_error():
+    if (not request or request.GET is None
+        or throw_random_http404_error()
+        or request.META is None):
         ret = Http404(HTTP404_NO_REQUEST(f'/__help/gettingstarted.{fmt}'))
         exit_api_call(api_code, ret)
         raise ret
@@ -184,7 +192,9 @@ def api_splash(request):
     """
     api_code = enter_api_call('api_splash', request)
 
-    if not request or request.GET is None or throw_random_http404_error():
+    if (not request or request.GET is None
+        or throw_random_http404_error()
+        or request.META is None):
         ret = Http404(HTTP404_NO_REQUEST('/__help/splash.html'))
         exit_api_call(api_code, ret)
         raise ret
@@ -203,7 +213,9 @@ def api_citing_opus(request, fmt):
     """
     api_code = enter_api_call('api_citing_opus', request)
 
-    if not request or request.GET is None or throw_random_http404_error():
+    if (not request or request.GET is None
+        or throw_random_http404_error()
+        or request.META is None):
         ret = Http404(HTTP404_NO_REQUEST(f'/__help/citing.{fmt}'))
         exit_api_call(api_code, ret)
         raise ret
@@ -271,7 +283,9 @@ def api_api_guide(request, fmt):
     """
     api_code = enter_api_call('api_api_guide', request)
 
-    if not request or request.GET is None or throw_random_http404_error():
+    if (not request or request.GET is None
+        or throw_random_http404_error()
+        or request.META is None):
         ret = Http404(HTTP404_NO_REQUEST(f'/__help/apiguide.{fmt}'))
         exit_api_call(api_code, ret)
         raise ret

--- a/opus/application/apps/metadata/test_metadata.py
+++ b/opus/application/apps/metadata/test_metadata.py
@@ -38,9 +38,11 @@ class MetadataTests(TestCase):
 
     def test__api_get_result_count_no_request(self):
         "[test_metadata.py] api_get_result_count: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /api/meta/result_count.json'):
-            api_get_result_count(None, 'json')
+            api_get_result_count(no_request, 'json')
 
     def test__api_get_result_count_no_get(self):
         "[test_metadata.py] api_get_result_count: no GET"
@@ -59,9 +61,11 @@ class MetadataTests(TestCase):
 
     def test__api_get_result_count_no_request_internal(self):
         "[test_metadata.py] api_get_result_count: no request internal"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /api/meta/result_count.json'):
-            api_get_result_count_internal(None)
+            api_get_result_count_internal(no_request)
 
     def test__api_get_result_count_no_get_internal(self):
         "[test_metadata.py] api_get_result_count: no GET internal"
@@ -78,9 +82,11 @@ class MetadataTests(TestCase):
 
     def test__api_get_mult_counts_no_request(self):
         "[test_metadata.py] api_get_mult_counts: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /api/meta/mults/target.json'):
-            api_get_mult_counts(None, 'target', 'json')
+            api_get_mult_counts(no_request, 'target', 'json')
 
     def test__api_get_mult_counts_no_get(self):
         "[test_metadata.py] api_get_mult_counts: no GET"
@@ -99,9 +105,11 @@ class MetadataTests(TestCase):
 
     def test__api_get_mult_counts_no_request_internal(self):
         "[test_metadata.py] api_get_mult_counts: no request internal"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /api/meta/mults/target.json'):
-            api_get_mult_counts_internal(None, 'target')
+            api_get_mult_counts_internal(no_request, 'target')
 
     def test__api_get_mult_counts_no_get_internal(self):
         "[test_metadata.py] api_get_mult_counts: no GET internal"
@@ -118,9 +126,11 @@ class MetadataTests(TestCase):
 
     def test__api_get_range_endpoints_no_request(self):
         "[test_metadata.py] api_get_range_endpoints: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /api/meta/range/endpoints/observationduration.json'):
-            api_get_range_endpoints(None, 'observationduration', 'json')
+            api_get_range_endpoints(no_request, 'observationduration', 'json')
 
     def test__api_get_range_endpoints_no_get(self):
         "[test_metadata.py] api_get_range_endpoints: no GET"
@@ -139,9 +149,11 @@ class MetadataTests(TestCase):
 
     def test__api_get_range_endpoints_no_request_internal(self):
         "[test_metadata.py] api_get_range_endpoints: no request internal"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /api/meta/range/endpoints/observationduration.json'):
-            api_get_range_endpoints_internal(None, 'observationduration')
+            api_get_range_endpoints_internal(no_request, 'observationduration')
 
     def test__api_get_range_endpoints_no_get_internal(self):
         "[test_metadata.py] api_get_range_endpoints: no GET internal"
@@ -158,9 +170,11 @@ class MetadataTests(TestCase):
 
     def test__api_get_fields_no_request(self):
         "[test_metadata.py] api_get_fields: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /api/fields/None.json'):
-            api_get_fields(None, 'json')
+            api_get_fields(no_request, 'json')
 
     def test__api_get_fields_no_get(self):
         "[test_metadata.py] api_get_fields: no GET"

--- a/opus/application/apps/metadata/urls.py
+++ b/opus/application/apps/metadata/urls.py
@@ -1,5 +1,5 @@
 # metadata/urls.py
-from django.conf.urls import url
+from django.urls import re_path
 
 from metadata.views import (
     api_get_result_count,
@@ -12,15 +12,15 @@ from metadata.views import (
 )
 
 urlpatterns = [
-    url(r'^api/meta/result_count.(?P<fmt>json|html|csv)$', api_get_result_count),
-    url(r'^__api/meta/result_count.json$', api_get_result_count_internal),
+    re_path(r'^api/meta/result_count.(?P<fmt>json|html|csv)$', api_get_result_count),
+    re_path(r'^__api/meta/result_count.json$', api_get_result_count_internal),
 
-    url(r'^api/meta/mults/(?P<slug>[-\w]+).(?P<fmt>json|html|csv)$', api_get_mult_counts),
-    url(r'^__api/meta/mults/(?P<slug>[-\w]+).json$', api_get_mult_counts_internal),
+    re_path(r'^api/meta/mults/(?P<slug>[-\w]+).(?P<fmt>json|html|csv)$', api_get_mult_counts),
+    re_path(r'^__api/meta/mults/(?P<slug>[-\w]+).json$', api_get_mult_counts_internal),
 
-    url(r'^api/meta/range/endpoints/(?P<slug>[-\w]+).(?P<fmt>json|html|csv)$', api_get_range_endpoints),
-    url(r'^__api/meta/range/endpoints/(?P<slug>[-\w]+).json$', api_get_range_endpoints_internal),
+    re_path(r'^api/meta/range/endpoints/(?P<slug>[-\w]+).(?P<fmt>json|html|csv)$', api_get_range_endpoints),
+    re_path(r'^__api/meta/range/endpoints/(?P<slug>[-\w]+).json$', api_get_range_endpoints_internal),
 
-    url(r'^api/fields/(?P<slug>\w+).(?P<fmt>json|csv)$', api_get_fields),
-    url(r'^api/fields.(?P<fmt>json|csv)$', api_get_fields),
+    re_path(r'^api/fields/(?P<slug>\w+).(?P<fmt>json|csv)$', api_get_fields),
+    re_path(r'^api/fields.(?P<fmt>json|csv)$', api_get_fields),
 ]

--- a/opus/application/apps/metadata/views.py
+++ b/opus/application/apps/metadata/views.py
@@ -30,7 +30,7 @@ from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Max, Min, Count
 from django.http import Http404, HttpResponseServerError
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.views.decorators.cache import never_cache
 
 from cart.models import Cart
@@ -132,7 +132,9 @@ def api_get_result_count(request, fmt, internal=False):
     if fmt == 'json':
         ret = json_response({'data': [data]})
     elif fmt == 'html':
-        ret = render_to_response('metadata/result_count.html', {'data': data})
+        ret = render(request,
+                     'metadata/result_count.html',
+                     {'data': data})
     elif fmt == 'csv':
         ret = csv_response('result_count', [['result count', count]])
     else: # pragma: no cover
@@ -323,7 +325,7 @@ def api_get_mult_counts(request, slug, fmt, internal=False):
     if fmt == 'json':
         ret = json_response(data)
     elif fmt == 'html':
-        ret = render_to_response('metadata/mults.html', data)
+        ret = render(request, 'metadata/mults.html', data)
     elif fmt == 'csv':
         ret = csv_response(slug, [list(mults.values())],
                            column_names=list(mults.keys()))
@@ -541,8 +543,9 @@ def api_get_range_endpoints(request, slug, fmt, internal=False):
     if fmt == 'json':
         ret = json_response(range_endpoints)
     elif fmt == 'html':
-        ret = render_to_response('metadata/endpoints.html',
-                                 {'data': range_endpoints})
+        ret = render(request,
+                     'metadata/endpoints.html',
+                     {'data': range_endpoints})
     elif fmt == 'csv':
         ret = csv_response(slug, [[range_endpoints['min'],
                                    range_endpoints['max'],

--- a/opus/application/apps/metadata/views.py
+++ b/opus/application/apps/metadata/views.py
@@ -108,7 +108,7 @@ def api_get_result_count(request, fmt, internal=False):
     """
     api_code = enter_api_call('api_get_result_count', request)
 
-    if not request or request.GET is None:
+    if not request or request.GET is None or request.META is None:
         ret = Http404(HTTP404_NO_REQUEST(f'/api/meta/result_count.{fmt}'))
         exit_api_call(api_code, ret)
         raise ret
@@ -184,7 +184,7 @@ def api_get_mult_counts(request, slug, fmt, internal=False):
     """
     api_code = enter_api_call('api_get_mult_counts', request)
 
-    if not request or request.GET is None:
+    if not request or request.GET is None or request.META is None:
         ret = Http404(HTTP404_NO_REQUEST(f'/api/meta/mults/{slug}.{fmt}'))
         exit_api_call(api_code, ret)
         raise ret
@@ -387,7 +387,7 @@ def api_get_range_endpoints(request, slug, fmt, internal=False):
     """
     api_code = enter_api_call('api_get_range_endpoints', request)
 
-    if not request or request.GET is None:
+    if not request or request.GET is None or request.META is None:
         ret = Http404(HTTP404_NO_REQUEST(
                                     f'/api/meta/range/endpoints/{slug}.{fmt}'))
         exit_api_call(api_code, ret)
@@ -610,7 +610,7 @@ def api_get_fields(request, fmt, slug=None):
     """
     api_code = enter_api_call('api_get_fields', request)
 
-    if not request or request.GET is None:
+    if not request or request.GET is None or request.META is None:
         ret = Http404(HTTP404_NO_REQUEST(f'/api/fields/{slug}.{fmt}'))
         exit_api_call(api_code, ret)
         raise ret

--- a/opus/application/apps/results/test_results.py
+++ b/opus/application/apps/results/test_results.py
@@ -60,9 +60,11 @@ class resultsTests(TestCase):
 
     def test__api_get_data_and_images_no_request(self):
         "[test_results.py] api_get_data_and_images: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /__api/dataimages.json'):
-            api_get_data_and_images(None)
+            api_get_data_and_images(no_request)
 
     def test__api_get_data_and_images_no_get(self):
         "[test_results.py] api_get_data_and_images: no GET"
@@ -79,9 +81,11 @@ class resultsTests(TestCase):
 
     def test__api_get_data_no_request(self):
         "[test_results.py] api_get_data: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /api/data.json'):
-            api_get_data(None, 'json')
+            api_get_data(no_request, 'json')
 
     def test__api_get_data_no_get(self):
         "[test_results.py] api_get_data: no GET"
@@ -99,9 +103,11 @@ class resultsTests(TestCase):
 
     def test__api_get_metadata_no_request(self):
         "[test_results.py] api_get_metadata: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /api/metadata_v2/vg-iss-2-s-c4360845.json'):
-            api_get_metadata(None, 'vg-iss-2-s-c4360845', 'json')
+            api_get_metadata(no_request, 'vg-iss-2-s-c4360845', 'json')
 
     def test__api_get_metadata_no_get(self):
         "[test_results.py] api_get_metadata: no GET"
@@ -118,9 +124,11 @@ class resultsTests(TestCase):
 
     def test__api_get_metadata_v2_no_request(self):
         "[test_results.py] api_get_metadata_v2: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /api/metadata_v2/vg-iss-2-s-c4360845.json'):
-            api_get_metadata_v2(None, 'vg-iss-2-s-c4360845', 'json')
+            api_get_metadata_v2(no_request, 'vg-iss-2-s-c4360845', 'json')
 
     def test__api_get_metadata_v2_no_get(self):
         "[test_results.py] api_get_metadata_v2: no GET"
@@ -137,9 +145,11 @@ class resultsTests(TestCase):
 
     def test__api_get_images_no_request(self):
         "[test_results.py] api_get_images: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /api/images/None.json'):
-            api_get_images(None, 'json')
+            api_get_images(no_request, 'json')
 
     def test__api_get_images_no_get(self):
         "[test_results.py] api_get_images: no GET"
@@ -156,9 +166,11 @@ class resultsTests(TestCase):
 
     def test__api_get_images_by_size_no_request(self):
         "[test_results.py] api_get_images_by_size: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /api/images/small.json'):
-            api_get_images_by_size(None, 'small', 'json')
+            api_get_images_by_size(no_request, 'small', 'json')
 
     def test__api_get_images_by_size_no_get(self):
         "[test_results.py] api_get_images_by_size: no GET"
@@ -175,9 +187,11 @@ class resultsTests(TestCase):
 
     def test__api_get_image_no_request(self):
         "[test_results.py] api_get_image: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /api/images/small.json'):
-            api_get_image(None, 'vg-iss-2-s-c4360845', 'small', 'json')
+            api_get_image(no_request, 'vg-iss-2-s-c4360845', 'small', 'json')
 
     def test__api_get_image_no_get(self):
         "[test_results.py] api_get_image: no GET"
@@ -194,9 +208,11 @@ class resultsTests(TestCase):
 
     def test__api_get_files_no_request(self):
         "[test_results.py] api_get_files: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /api/files/vg-iss-2-s-c4360845.json'):
-            api_get_files(None, 'vg-iss-2-s-c4360845')
+            api_get_files(no_request, 'vg-iss-2-s-c4360845')
 
     def test__api_get_files_no_get(self):
         "[test_results.py] api_get_files: no GET"
@@ -213,9 +229,11 @@ class resultsTests(TestCase):
 
     def test__api_get_categories_for_opus_id_no_request(self):
         "[test_results.py] api_get_categories_for_opus_id: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /api/categories/vg-iss-2-s-c4360845.json'):
-            api_get_categories_for_opus_id(None, 'vg-iss-2-s-c4360845')
+            api_get_categories_for_opus_id(no_request, 'vg-iss-2-s-c4360845')
 
     def test__api_get_categories_for_opus_id_no_get(self):
         "[test_results.py] api_get_categories_for_opus_id: no GET"
@@ -233,9 +251,11 @@ class resultsTests(TestCase):
 
     def test__api_get_categories_for_search_no_request(self):
         "[test_results.py] api_get_categories_for_search: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /api/categories.json'):
-            api_get_categories_for_search(None)
+            api_get_categories_for_search(no_request)
 
     def test__api_get_categories_for_search_no_get(self):
         "[test_results.py] api_get_categories_for_search: no GET"
@@ -252,9 +272,11 @@ class resultsTests(TestCase):
 
     def test__api_get_product_types_for_opus_id_no_request(self):
         "[test_results.py] api_get_product_types_for_opus_id: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /api/product_types/vg-iss-2-s-c4360845.json'):
-            api_get_product_types_for_opus_id(None, 'vg-iss-2-s-c4360845')
+            api_get_product_types_for_opus_id(no_request, 'vg-iss-2-s-c4360845')
 
     def test__api_get_product_types_for_opus_id_no_get(self):
         "[test_results.py] api_get_product_types_for_opus_id: no GET"
@@ -272,9 +294,11 @@ class resultsTests(TestCase):
 
     def test__api_get_product_types_for_search_no_request(self):
         "[test_results.py] api_get_product_types_for_search: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /api/product_types.json'):
-            api_get_product_types_for_search(None)
+            api_get_product_types_for_search(no_request)
 
     def test__api_get_product_types_for_search_no_get(self):
         "[test_results.py] api_get_product_types_for_search: no GET"

--- a/opus/application/apps/results/urls.py
+++ b/opus/application/apps/results/urls.py
@@ -1,5 +1,5 @@
 # results/urls.py
-from django.conf.urls import url
+from django.urls import re_path
 from results.views import (
     api_get_data_and_images,
     api_get_data,
@@ -20,32 +20,32 @@ from ui.views import api_dummy
 urlpatterns = [
     # The internal version of api/data and api/images that we don't advertise
     # so we don't have to maintain backwards compatibility.
-    url(r'^__api/dataimages.json$', api_get_data_and_images),
+    re_path(r'^__api/dataimages.json$', api_get_data_and_images),
     # Called when we don't actually need data but want a user action recorded
     # in the web log file.
-    url(r'^__fake/__api/dataimages.json$', api_dummy),
+    re_path(r'^__fake/__api/dataimages.json$', api_dummy),
 
-    url(r'^api/data.(?P<fmt>json|html|csv)$', api_get_data),
-    url(r'^__api/data.(?P<fmt>csv)$', api_get_data),
+    re_path(r'^api/data.(?P<fmt>json|html|csv)$', api_get_data),
+    re_path(r'^__api/data.(?P<fmt>csv)$', api_get_data),
 
     # Backwards compatibility
-    url(r'^api/metadata/(?P<opus_id>[-\w]+).(?P<fmt>json|html|csv)$', api_get_metadata),
+    re_path(r'^api/metadata/(?P<opus_id>[-\w]+).(?P<fmt>json|html|csv)$', api_get_metadata),
 
-    url(r'^api/metadata_v2/(?P<opus_id>[-\w]+).(?P<fmt>json|html|csv)$', api_get_metadata_v2),
-    url(r'^__api/metadata_v2/(?P<opus_id>[-\w]+).(?P<fmt>json|html|csv)$', api_get_metadata_v2_internal),
+    re_path(r'^api/metadata_v2/(?P<opus_id>[-\w]+).(?P<fmt>json|html|csv)$', api_get_metadata_v2),
+    re_path(r'^__api/metadata_v2/(?P<opus_id>[-\w]+).(?P<fmt>json|html|csv)$', api_get_metadata_v2_internal),
 
-    url(r'^api/images/(?P<size>thumb|small|med|full).(?P<fmt>json|html|csv)$', api_get_images_by_size),
-    url(r'^api/images.(?P<fmt>json|csv)$', api_get_images),
-    url(r'^api/image/(?P<size>thumb|small|med|full)/(?P<opus_id>[-\w]+).(?P<fmt>json|html|csv)$', api_get_image),
-    url(r'^__api/image/(?P<size>thumb|small|med|full)/(?P<opus_id>[-\w]+).(?P<fmt>json)$', api_get_image),
+    re_path(r'^api/images/(?P<size>thumb|small|med|full).(?P<fmt>json|html|csv)$', api_get_images_by_size),
+    re_path(r'^api/images.(?P<fmt>json|csv)$', api_get_images),
+    re_path(r'^api/image/(?P<size>thumb|small|med|full)/(?P<opus_id>[-\w]+).(?P<fmt>json|html|csv)$', api_get_image),
+    re_path(r'^__api/image/(?P<size>thumb|small|med|full)/(?P<opus_id>[-\w]+).(?P<fmt>json)$', api_get_image),
 
-    url(r'^api/files/(?P<opus_id>[-\w]+).json$', api_get_files),
-    url(r'^api/files.json$', api_get_files),
+    re_path(r'^api/files/(?P<opus_id>[-\w]+).json$', api_get_files),
+    re_path(r'^api/files.json$', api_get_files),
 
-    url(r'^api/categories/(?P<opus_id>[-\w]+).json$', api_get_categories_for_opus_id),
-    url(r'^__api/categories/(?P<opus_id>[-\w]+).json$', api_get_categories_for_opus_id),
-    url(r'^api/categories.json$', api_get_categories_for_search),
+    re_path(r'^api/categories/(?P<opus_id>[-\w]+).json$', api_get_categories_for_opus_id),
+    re_path(r'^__api/categories/(?P<opus_id>[-\w]+).json$', api_get_categories_for_opus_id),
+    re_path(r'^api/categories.json$', api_get_categories_for_search),
 
-    url(r'^api/product_types/(?P<opus_id>[-\w]+).json$', api_get_product_types_for_opus_id),
-    url(r'^api/product_types.json$', api_get_product_types_for_search),
+    re_path(r'^api/product_types/(?P<opus_id>[-\w]+).json$', api_get_product_types_for_opus_id),
+    re_path(r'^api/product_types.json$', api_get_product_types_for_search),
 ]

--- a/opus/application/apps/results/views.py
+++ b/opus/application/apps/results/views.py
@@ -154,7 +154,7 @@ def api_get_data_and_images(request):
     """
     api_code = enter_api_call('api_get_data_and_images', request)
 
-    if not request or request.GET is None:
+    if not request or request.GET is None or request.META is None:
         ret = Http404(HTTP404_NO_REQUEST('/__api/dataimages.json'))
         exit_api_call(api_code, ret)
         raise ret
@@ -339,7 +339,7 @@ def api_get_data(request, fmt):
     """
     api_code = enter_api_call('api_get_data', request)
 
-    if not request or request.GET is None:
+    if not request or request.GET is None or request.META is None:
         ret = Http404(HTTP404_NO_REQUEST(f'/api/data.{fmt}'))
         exit_api_call(api_code, ret)
         raise ret
@@ -495,7 +495,7 @@ def api_get_metadata_v2_internal(request, opus_id, fmt):
 
 def get_metadata(request, opus_id, fmt, api_name, return_db_names, internal):
     api_code = enter_api_call(api_name, request)
-    if not request or request.GET is None:
+    if not request or request.GET is None or request.META is None:
         # This could technically be the wrong string for the error message,
         # but since this can never actually happen outside of testing we
         # don't care.
@@ -777,7 +777,7 @@ def api_get_image(request, opus_id, size, fmt):
     """
     api_code = enter_api_call('api_get_image', request)
 
-    if request is not None and request.GET is not None:
+    if request is not None and request.GET is not None or request.META is None:
         request.GET = request.GET.copy()
         request.GET['opusid'] = opus_id
         request.GET['qtype-opusid'] = 'matches'
@@ -787,7 +787,7 @@ def api_get_image(request, opus_id, size, fmt):
     return ret
 
 def _api_get_images(request, fmt, api_code, size, include_search, opus_id):
-    if not request or request.GET is None:
+    if not request or request.GET is None or request.META is None:
         # This could technically be the wrong string for the error message,
         # but since this can never actually happen outside of testing we
         # don't care.
@@ -934,7 +934,7 @@ def api_get_files(request, opus_id=None):
     """
     api_code = enter_api_call('api_get_files', request)
 
-    if not request or request.GET is None:
+    if not request or request.GET is None or request.META is None:
         ret = Http404(HTTP404_NO_REQUEST(f'/api/files/{opus_id}.json'))
         exit_api_call(api_code, ret)
         raise ret
@@ -1015,7 +1015,7 @@ def api_get_categories_for_opus_id(request, opus_id):
     """
     api_code = enter_api_call('api_get_categories_for_opus_id', request)
 
-    if not request or request.GET is None:
+    if not request or request.GET is None or request.META is None:
         ret = Http404(HTTP404_NO_REQUEST(f'/api/categories/{opus_id}.json'))
         exit_api_call(api_code, ret)
         raise ret
@@ -1071,7 +1071,7 @@ def api_get_categories_for_search(request):
     """
     api_code = enter_api_call('api_get_categories_for_search', request)
 
-    if not request or request.GET is None:
+    if not request or request.GET is None or request.META is None:
         ret = Http404(HTTP404_NO_REQUEST('/api/categories.json'))
         exit_api_call(api_code, ret)
         raise ret
@@ -1115,7 +1115,7 @@ def api_get_product_types_for_opus_id(request, opus_id):
     """
     api_code = enter_api_call('api_get_product_types_for_opus_id', request)
 
-    if not request or request.GET is None:
+    if not request or request.GET is None or request.META is None:
         ret = Http404(HTTP404_NO_REQUEST(f'/api/product_types/{opus_id}.json'))
         exit_api_call(api_code, ret)
         raise ret
@@ -1178,7 +1178,7 @@ def api_get_product_types_for_search(request):
     """
     api_code = enter_api_call('api_get_product_types_for_search', request)
 
-    if not request or request.GET is None:
+    if not request or request.GET is None or request.META is None:
         ret = Http404(HTTP404_NO_REQUEST('/api/product_types.json'))
         exit_api_call(api_code, ret)
         raise ret

--- a/opus/application/apps/search/forms.py
+++ b/opus/application/apps/search/forms.py
@@ -162,9 +162,9 @@ class SearchForm(forms.Form):
                             attrs={'tabindex':0, 'class':"RANGE"}
                         ),
                     )
-                    self.fields.keyOrder = [slug_no_num+'1', slug_no_num+'2', 'qtype-'+slug_no_num]  # makes sure min is first! boo ya!
+                    self.field_order = [slug_no_num+'1', slug_no_num+'2', 'qtype-'+slug_no_num]  # makes sure min is first! boo ya!
                 else:
-                    self.fields.keyOrder = [slug_no_num+'1', slug_no_num+'2']  # makes sure min is first! boo ya!
+                    self.field_order = [slug_no_num+'1', slug_no_num+'2']  # makes sure min is first! boo ya!
 
             elif form_type in settings.MULT_FORM_TYPES:
                 # self.fields[slug]= MultiStringField(forms.Field)

--- a/opus/application/apps/search/urls.py
+++ b/opus/application/apps/search/urls.py
@@ -1,11 +1,11 @@
 # search/urls.py
-from django.conf.urls import url
+from django.urls import re_path
 from search.views import (
     api_normalize_input,
     api_string_search_choices,
 )
 
 urlpatterns = [
-    url(r'^__api/normalizeinput.json$', api_normalize_input),
-    url(r'^__api/stringsearchchoices/(?P<slug>\w+).json$', api_string_search_choices),
+    re_path(r'^__api/normalizeinput.json$', api_normalize_input),
+    re_path(r'^__api/stringsearchchoices/(?P<slug>\w+).json$', api_string_search_choices),
 ]

--- a/opus/application/apps/ui/test_ui.py
+++ b/opus/application/apps/ui/test_ui.py
@@ -37,16 +37,13 @@ class uiTests(TestCase):
 
     def test__api_notifications_no_request(self):
         "[test_ui.py] api_notifications: no request"
-        try:
-            with self.assertRaisesRegex(Http404,
-                r'Internal error \(No request was provided\) for /__notifications.json'):
-                api_notifications(None)
-        except TypeError as e:
-            # In Django 4.0, never_cache will raise an error when no request is passed in.
-            if "didn't receive an HttpRequest" in str(e):
-                assert True
-            else:
-                assert False, "Unexpected error when no request was provided."
+        # Set META to None so that TypeError won't be raised by never_cache
+        # in Django 4.
+        no_request = self.factory.get('dummy')
+        no_request.META = None
+        with self.assertRaisesRegex(Http404,
+            r'Internal error \(No request was provided\) for /__notifications.json'):
+            api_notifications(no_request)
 
     def test__api_notifications_no_get(self):
         "[test_ui.py] api_notifications: no GET"
@@ -150,9 +147,11 @@ class uiTests(TestCase):
 
     def test__api_normalize_url_no_request(self):
         "[test_ui.py] api_normalize_url: no request"
+        no_request = self.factory.get('dummy')
+        no_request.META = None
         with self.assertRaisesRegex(Http404,
             r'Internal error \(No request was provided\) for /__normalizeurl.json'):
-            api_normalize_url(None)
+            api_normalize_url(no_request)
 
     def test__api_normalize_url_no_get(self):
         "[test_ui.py] api_normalize_url: no GET"

--- a/opus/application/apps/ui/test_ui.py
+++ b/opus/application/apps/ui/test_ui.py
@@ -37,9 +37,16 @@ class uiTests(TestCase):
 
     def test__api_notifications_no_request(self):
         "[test_ui.py] api_notifications: no request"
-        with self.assertRaisesRegex(Http404,
-            r'Internal error \(No request was provided\) for /__notifications.json'):
-            api_notifications(None)
+        try:
+            with self.assertRaisesRegex(Http404,
+                r'Internal error \(No request was provided\) for /__notifications.json'):
+                api_notifications(None)
+        except TypeError as e:
+            # In Django 4.0, never_cache will raise an error when no request is passed in.
+            if "didn't receive an HttpRequest" in str(e):
+                assert True
+            else:
+                assert False, "Unexpected error when no request was provided."
 
     def test__api_notifications_no_get(self):
         "[test_ui.py] api_notifications: no GET"

--- a/opus/application/apps/ui/urls.py
+++ b/opus/application/apps/ui/urls.py
@@ -1,5 +1,5 @@
 # ui/urls.py
-from django.conf.urls import url
+from django.urls import re_path
 from django.contrib import admin
 
 from ui.views import (
@@ -13,14 +13,14 @@ from ui.views import (
 )
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-    url(r'^__notifications.json$', api_notifications),
-    url(r'^__menu.json$', api_get_menu),
-    url(r'^__metadata_selector.json$', api_get_metadata_selector),
-    url(r'^__widget/(?P<slug>[-\w]+).html$', api_get_widget),
-    url(r'^__initdetail/(?P<opus_id>[-\w]+).html$', api_init_detail_page),
-    url(r'^__normalizeurl.json$', api_normalize_url),
-    url(r'^__dummy.json$', api_dummy),
-    url(r'^__fake/__viewmetadatamodal/(?P<opus_id>[-\w]+).json$', api_dummy),
-    url(r'^__fake/__selectmetadatamodal.json$', api_dummy)
+    re_path(r'^admin/', admin.site.urls),
+    re_path(r'^__notifications.json$', api_notifications),
+    re_path(r'^__menu.json$', api_get_menu),
+    re_path(r'^__metadata_selector.json$', api_get_metadata_selector),
+    re_path(r'^__widget/(?P<slug>[-\w]+).html$', api_get_widget),
+    re_path(r'^__initdetail/(?P<opus_id>[-\w]+).html$', api_init_detail_page),
+    re_path(r'^__normalizeurl.json$', api_normalize_url),
+    re_path(r'^__dummy.json$', api_dummy),
+    re_path(r'^__fake/__viewmetadatamodal/(?P<opus_id>[-\w]+).json$', api_dummy),
+    re_path(r'^__fake/__selectmetadatamodal.json$', api_dummy)
 ]

--- a/opus/application/apps/ui/views.py
+++ b/opus/application/apps/ui/views.py
@@ -108,7 +108,6 @@ def api_notifications(request):
         }
     """
     api_code = enter_api_call('api_notifications', request)
-
     if not request or request.GET is None:
         ret = Http404(HTTP404_NO_REQUEST('/__notifications.json'))
         exit_api_call(api_code, ret)

--- a/opus/application/apps/ui/views.py
+++ b/opus/application/apps/ui/views.py
@@ -108,7 +108,7 @@ def api_notifications(request):
         }
     """
     api_code = enter_api_call('api_notifications', request)
-    if not request or request.GET is None:
+    if not request or request.GET is None or request.META is None:
         ret = Http404(HTTP404_NO_REQUEST('/__notifications.json'))
         exit_api_call(api_code, ret)
         raise ret
@@ -653,7 +653,7 @@ def api_normalize_url(request):
 
     api_code = enter_api_call('api_normalize_url', request)
 
-    if not request or request.GET is None:
+    if not request or request.GET is None or request.META is None:
         ret = Http404(HTTP404_NO_REQUEST('/__normalizeurl.json'))
         exit_api_call(api_code, ret)
         raise ret

--- a/opus/application/settings.py
+++ b/opus/application/settings.py
@@ -167,7 +167,7 @@ CACHE_KEY_PREFIX = 'opus:' + DB_SCHEMA_NAME
 
 INTERNAL_IPS = ('127.0.0.1',)
 
-# TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
 DEBUG_TOOLBAR_CONFIG = { 'INTERCEPT_REDIRECTS': False }
 

--- a/opus/application/settings.py
+++ b/opus/application/settings.py
@@ -78,10 +78,13 @@ MIDDLEWARE = (
 
 ROOT_URLCONF = 'urls'
 
+FORM_RENDERER = 'django.forms.renderers.TemplatesSetting'
+
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [
+            PROJECT_ROOT + '/templates',
             PROJECT_ROOT + '/apps/',
             PROJECT_ROOT + '/apps/ui/templates/',
             PROJECT_ROOT + '/apps/dictionary/templates/',
@@ -90,6 +93,7 @@ TEMPLATES = [
             PROJECT_ROOT + '/apps/quide/templates/',
             PROJECT_ROOT + '/apps/search/templates/',
         ],
+        # 'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
                 'django.contrib.auth.context_processors.auth',
@@ -121,6 +125,7 @@ INSTALLED_APPS = (
     # 'django_nose',
     'django_memcached',
     'django.contrib.admindocs',
+    'django.forms',
     'storages',
     'search',
     'paraminfo',

--- a/opus/application/settings.py
+++ b/opus/application/settings.py
@@ -99,6 +99,7 @@ TEMPLATES = [
                 'django.template.context_processors.static',
                 'django.template.context_processors.tz',
                 'django.contrib.messages.context_processors.messages',
+                'django.template.context_processors.request',
             ],
             'loaders': [
                 'django.template.loaders.filesystem.Loader',
@@ -117,7 +118,7 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.humanize',
-    'django_nose',
+    # 'django_nose',
     'django_memcached',
     'django.contrib.admindocs',
     'storages',
@@ -161,7 +162,7 @@ CACHE_KEY_PREFIX = 'opus:' + DB_SCHEMA_NAME
 
 INTERNAL_IPS = ('127.0.0.1',)
 
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+# TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
 DEBUG_TOOLBAR_CONFIG = { 'INTERCEPT_REDIRECTS': False }
 
@@ -369,3 +370,5 @@ DOWNLOAD_FORMATS = {
     'tar': ('application/x-tar', 'w', 'r'),
     'tgz': ('application/gzip', 'w:gz', 'r:gz'), # same as .tar.gz, we will use .tgz here
 }
+
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/opus/application/settings.py
+++ b/opus/application/settings.py
@@ -93,7 +93,6 @@ TEMPLATES = [
             PROJECT_ROOT + '/apps/quide/templates/',
             PROJECT_ROOT + '/apps/search/templates/',
         ],
-        # 'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
                 'django.contrib.auth.context_processors.auth',
@@ -122,7 +121,6 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.humanize',
-    # 'django_nose',
     'django_memcached',
     'django.contrib.admindocs',
     'django.forms',
@@ -166,8 +164,6 @@ else:
 CACHE_KEY_PREFIX = 'opus:' + DB_SCHEMA_NAME
 
 INTERNAL_IPS = ('127.0.0.1',)
-
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
 DEBUG_TOOLBAR_CONFIG = { 'INTERCEPT_REDIRECTS': False }
 

--- a/opus/application/templates/django/forms/widgets/input.html
+++ b/opus/application/templates/django/forms/widgets/input.html
@@ -1,0 +1,1 @@
+<input type="{{ widget.type }}" name="{{ widget.name }}"{% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}{% include "django/forms/widgets/attrs.html" %}>

--- a/opus/application/templates/django/forms/widgets/input_option.html
+++ b/opus/application/templates/django/forms/widgets/input_option.html
@@ -1,0 +1,1 @@
+{% if widget.wrap_label %}<label{% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>{% endif %}{% include "django/forms/widgets/input.html" %}{% if widget.wrap_label %} {{ widget.label }}</label>{% endif %}

--- a/opus/application/templates/django/forms/widgets/multiple_input.html
+++ b/opus/application/templates/django/forms/widgets/multiple_input.html
@@ -1,0 +1,5 @@
+{% with id=widget.attrs.id %}<ul{% if id %} id="{{ id }}"{% endif %}{% if widget.attrs.class %} class="{{ widget.attrs.class }}"{% endif %}>{% for group, options, index in widget.optgroups %}{% if group %}
+  <li>{{ group }}<ul{% if id %} id="{{ id }}_{{ index }}"{% endif %}>{% endif %}{% for option in options %}
+    <li>{% include option.template_name with widget=option %}</li>{% endfor %}{% if group %}
+  </ul></li>{% endif %}{% endfor %}
+</ul>{% endwith %}

--- a/opus/application/test_api/test_cart_api.py
+++ b/opus/application/test_api/test_cart_api.py
@@ -14,7 +14,7 @@ from tools.app_utils import (HTTP404_BAD_OR_MISSING_RANGE,
                              HTTP404_SEARCH_PARAMS_INVALID,
                              HTTP404_UNKNOWN_DOWNLOAD_FILE_FORMAT)
 
-from api_test_helper import ApiTestHelper
+from .api_test_helper import ApiTestHelper
 
 import settings
 

--- a/opus/application/test_api/test_help_api.py
+++ b/opus/application/test_api/test_help_api.py
@@ -7,7 +7,7 @@ from unittest import TestCase
 from django.core.cache import cache
 from rest_framework.test import RequestsClient
 
-from api_test_helper import ApiTestHelper
+from .api_test_helper import ApiTestHelper
 
 import settings
 

--- a/opus/application/test_api/test_metadata_api.py
+++ b/opus/application/test_api/test_metadata_api.py
@@ -14,7 +14,7 @@ from tools.app_utils import (HTTP404_BAD_COLLAPSE,
                              HTTP404_UNKNOWN_UNITS,
                              HTTP404_UNKNOWN_SLUG)
 
-from api_test_helper import ApiTestHelper
+from .api_test_helper import ApiTestHelper
 
 import settings
 

--- a/opus/application/test_api/test_results_api.py
+++ b/opus/application/test_api/test_results_api.py
@@ -14,7 +14,7 @@ from tools.app_utils import (HTTP404_BAD_OR_MISSING_REQNO,
                              HTTP404_UNKNOWN_RING_OBS_ID,
                              HTTP404_UNKNOWN_SLUG)
 
-from api_test_helper import ApiTestHelper
+from .api_test_helper import ApiTestHelper
 
 import settings
 

--- a/opus/application/test_api/test_results_contents.py
+++ b/opus/application/test_api/test_results_contents.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 from django.core.cache import cache
 from rest_framework.test import RequestsClient
 
-from api_test_helper import ApiTestHelper
+from .api_test_helper import ApiTestHelper
 
 import settings
 

--- a/opus/application/test_api/test_return_formats.py
+++ b/opus/application/test_api/test_return_formats.py
@@ -7,7 +7,7 @@ from unittest import TestCase
 from django.core.cache import cache
 from rest_framework.test import RequestsClient
 
-from api_test_helper import ApiTestHelper
+from .api_test_helper import ApiTestHelper
 
 import settings
 

--- a/opus/application/test_api/test_search_api.py
+++ b/opus/application/test_api/test_search_api.py
@@ -16,7 +16,7 @@ from tools.app_utils import (HTTP404_BAD_LIMIT,
                              HTTP404_UNKNOWN_RING_OBS_ID,
                              HTTP404_UNKNOWN_SLUG)
 
-from api_test_helper import ApiTestHelper
+from .api_test_helper import ApiTestHelper
 
 import settings
 

--- a/opus/application/test_api/test_ui_api.py
+++ b/opus/application/test_api/test_ui_api.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 from django.core.cache import cache
 from rest_framework.test import RequestsClient
 
-from api_test_helper import ApiTestHelper
+from .api_test_helper import ApiTestHelper
 
 import settings
 

--- a/opus/application/urls.py
+++ b/opus/application/urls.py
@@ -1,5 +1,5 @@
 # urls.py
-from django.conf.urls import url, include
+from django.urls import re_path, include
 from django.conf import settings
 from django.contrib import admin
 from django.views.generic import TemplateView
@@ -10,23 +10,23 @@ from ui.views import main_site
 
 # UI resources - the homepage - ui.views
 base_urlpatterns = [
-    url(r'^$', main_site.as_view()),
-    url(r'^opus/$', main_site.as_view()),
-    url(r'^', include('ui.urls')),
-    url(r'^', include('results.urls')),
-    url(r'^', include('metadata.urls')),
-    url(r'^', include('search.urls')),
-    url(r'^', include('help.urls')),
-    url(r'^', include('cart.urls')),
+    re_path(r'^$', main_site.as_view()),
+    re_path(r'^opus/$', main_site.as_view()),
+    re_path(r'^', include('ui.urls')),
+    re_path(r'^', include('results.urls')),
+    re_path(r'^', include('metadata.urls')),
+    re_path(r'^', include('search.urls')),
+    re_path(r'^', include('help.urls')),
+    re_path(r'^', include('cart.urls')),
 ]
 
 dictionary_urlpatterns = [
-    url(r'^', include('dictionary.urls'))
+    re_path(r'^', include('dictionary.urls'))
 ]
 
 urlpatterns = [
-    url('^', include(base_urlpatterns)),
-    url('^%s/' % settings.BASE_PATH, include(base_urlpatterns)),  # dev
-    url('^dictionary/', include(dictionary_urlpatterns)),
-    url('^__dictionary/', include(dictionary_urlpatterns)),
+    re_path('^', include(base_urlpatterns)),
+    re_path('^%s/' % settings.BASE_PATH, include(base_urlpatterns)),  # dev
+    re_path('^dictionary/', include(dictionary_urlpatterns)),
+    re_path('^__dictionary/', include(dictionary_urlpatterns)),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+asgiref==3.5.0
 attrs==21.4.0
 certifi==2021.10.8
 chardet==4.0.0
@@ -22,6 +23,7 @@ mccabe==0.6.1
 mistune==2.0.2
 mysqlclient==2.1.0
 nose==1.3.7
+nose-py3==1.4.0
 numpy==1.22.1
 oyaml==1.0
 packaging==21.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,12 @@ chardet==4.0.0
 charset-normalizer==2.0.10
 colorclass==2.2.2
 coverage==6.2
-Django==2.2.6
+Django==4.0.3
 django-annoying==0.10.5
 django-memcached==0.1.2
-django-nose==1.4.6
-django-storages==1.7.2
-djangorestframework==3.10.3
+django-nose==1.4.7
+django-storages==1.12.3
+djangorestframework==3.13.1
 docopt==0.6.2
 flake8==4.0.1
 hurry.filesize==0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,8 +22,6 @@ MarkupSafe==2.0.1
 mccabe==0.6.1
 mistune==2.0.2
 mysqlclient==2.1.0
-nose==1.3.7
-nose-py3==1.4.0
 numpy==1.22.1
 oyaml==1.0
 packaging==21.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ coverage==6.2
 Django==4.0.3
 django-annoying==0.10.5
 django-memcached==0.1.2
-django-nose==1.4.7
 django-storages==1.12.3
 djangorestframework==3.13.1
 docopt==0.6.2


### PR DESCRIPTION
Related to https://github.com/SETI/pds-opus/issues/1084

Changes done to work with Django 4:
- Change ```from django.conf.urls import url``` to ```from django.urls import re_path```
    - change the ```url``` call to ```re_path``` call
- Change ```from django.shortcuts import render_to_response``` to ```from django.shortcuts import render```
    - change ```render_to_response``` call to ```render``` call and make sure to pass in ```request```
- Add DEFAULT_AUTO_FIELD = 'django.db.models.AutoField' to settings.py to get rid of the warnings. (https://koenwoortman.com/python-django-auto-created-primary-key-used-when-not-defining-primary-key-type/)
- Add ```'django.template.context_processors.request'``` in context processors in settings.py
- Get rid of django-nose. Django nose will only support up to Django 2.2 and Python 3.7. (https://pypi.org/project/django-nose/) We will removed it from ```INSTALLED_APPS``` and remove ```TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'``` in settings.py.
    - Note: we can still make django-nose work with Django 4 by changing line 406 in ```runner.py``` from: ```flush_statements = connection.ops.sql_flush(
        style, tables, connection.introspection.sequence_list())``` to ```flush_statements = connection.ops.sql_flush(
        style, tables)```

Pending items:
- RadioSelect and CheckboxSelectMultiple widgets are now rendered in ```<div>``` instead of ```<li>```
    - Two ways to solve this:
        1. Override the widget template as suggested from https://docs.djangoproject.com/en/4.0/releases/4.0/ to keep the previous form behavior.
        2. Update/modify our current styling and codes so that new template will work.
- Modify tests with no request passed in. Now never cache will raise a type error when no request is passed in. Here is the code differece between 2.2.6 & 4.0.3:
2.2.6:
```
def never_cache(view_func):
    """
    Decorator that adds headers to a response so that it will never be cached.
    """
    @wraps(view_func)
    def _wrapped_view_func(request, *args, **kwargs):
        response = view_func(request, *args, **kwargs)
        add_never_cache_headers(response)
        return response
    return _wrapped_view_func
```
4.0.3
```
def never_cache(view_func):
    """
    Decorator that adds headers to a response so that it will never be cached.
    """

    @wraps(view_func)
    def _wrapped_view_func(request, *args, **kwargs):
        # Ensure argument looks like a request.
        if not hasattr(request, "META"):
            raise TypeError(
                "never_cache didn't receive an HttpRequest. If you are "
                "decorating a classmethod, be sure to use @method_decorator."
            )
        response = view_func(request, *args, **kwargs)
        add_never_cache_headers(response)
        return response

    return _wrapped_view_func
```
We can do something like this: (use ```test__api_notifications_no_request``` as an example)
```
    def test__api_notifications_no_request(self):
        "[test_ui.py] api_notifications: no request"
        try:
            with self.assertRaisesRegex(Http404,
                r'Internal error \(No request was provided\) for /__notifications.json'):
                api_notifications(None)
        except TypeError as e:
            # In Django 4.0, never_cache will raise an error when no request is passed in.
            if "didn't receive an HttpRequest" in str(e):
                assert True
            else:
                assert False, "Unexpected error when no request was provided."
```