### PR TITLE
Fix 3 test_results_contents cases broken by pds-webtools pull#46

### DIFF
--- a/opus/application/test_api/responses/results_go_ssi_c0368977800_files.json
+++ b/opus/application/test_api/responses/results_go_ssi_c0368977800_files.json
@@ -14,10 +14,10 @@
                 "https://opus.pds-rings.seti.org/holdings/volumes/GO_0xxx/GO_0017/LABEL/RTLMTAB.FMT"
             ],
             "rms_index": [
-                "https://opus.pds-rings.seti.org/holdings/metadata/GO_0xxx/GO_0017/GO_0017_index.tab",
                 "https://opus.pds-rings.seti.org/holdings/metadata/GO_0xxx/GO_0018/GO_0018_index.tab",
-                "https://opus.pds-rings.seti.org/holdings/metadata/GO_0xxx/GO_0017/GO_0017_index.lbl",
-                "https://opus.pds-rings.seti.org/holdings/metadata/GO_0xxx/GO_0018/GO_0018_index.lbl"
+                "https://opus.pds-rings.seti.org/holdings/metadata/GO_0xxx/GO_0017/GO_0017_index.tab",
+                "https://opus.pds-rings.seti.org/holdings/metadata/GO_0xxx/GO_0018/GO_0018_index.lbl",
+                "https://opus.pds-rings.seti.org/holdings/metadata/GO_0xxx/GO_0017/GO_0017_index.lbl"
             ],
             "browse_thumb": [
                 "https://opus.pds-rings.seti.org/holdings/previews/GO_0xxx/GO_0018/REDO/C3/JUPITER/C0368977800R_thumb.jpg",
@@ -53,10 +53,10 @@
                     "https://opus.pds-rings.seti.org/holdings/volumes/GO_0xxx/GO_0017/LABEL/RTLMTAB.FMT"
                 ],
                 "rms_index": [
-                    "https://opus.pds-rings.seti.org/holdings/metadata/GO_0xxx/GO_0017/GO_0017_index.tab",
                     "https://opus.pds-rings.seti.org/holdings/metadata/GO_0xxx/GO_0018/GO_0018_index.tab",
-                    "https://opus.pds-rings.seti.org/holdings/metadata/GO_0xxx/GO_0017/GO_0017_index.lbl",
-                    "https://opus.pds-rings.seti.org/holdings/metadata/GO_0xxx/GO_0018/GO_0018_index.lbl"
+                    "https://opus.pds-rings.seti.org/holdings/metadata/GO_0xxx/GO_0017/GO_0017_index.tab",
+                    "https://opus.pds-rings.seti.org/holdings/metadata/GO_0xxx/GO_0018/GO_0018_index.lbl",
+                    "https://opus.pds-rings.seti.org/holdings/metadata/GO_0xxx/GO_0017/GO_0017_index.lbl"
                 ],
                 "browse_thumb": [
                     "https://opus.pds-rings.seti.org/holdings/previews/GO_0xxx/GO_0018/REDO/C3/JUPITER/C0368977800R_thumb.jpg",

--- a/opus/application/test_api/responses/results_nh_lorri_lor_0299075349_files.json
+++ b/opus/application/test_api/responses/results_nh_lorri_lor_0299075349_files.json
@@ -150,11 +150,11 @@
                 ]
             },
             "1": {
-                "nh_lorri_raw_alternate": [
+                "nh_lorri_raw": [
                     "https://opus.pds-rings.seti.org/holdings/volumes/NHxxLO_xxxx_v1/NHPELO_1001/data/20150713_029907/lor_0299075349_0x632_eng.fit",
                     "https://opus.pds-rings.seti.org/holdings/volumes/NHxxLO_xxxx_v1/NHPELO_1001/data/20150713_029907/lor_0299075349_0x632_eng.lbl"
                 ],
-                "nh_lorri_calib_alternate": [
+                "nh_lorri_calib": [
                     "https://opus.pds-rings.seti.org/holdings/volumes/NHxxLO_xxxx_v1/NHPELO_2001/data/20150713_029907/lor_0299075349_0x632_sci.fit",
                     "https://opus.pds-rings.seti.org/holdings/volumes/NHxxLO_xxxx_v1/NHPELO_2001/data/20150713_029907/lor_0299075349_0x632_sci.lbl"
                 ]

--- a/opus/application/test_api/responses/results_nh_mvic_mc1_0005261846_files.json
+++ b/opus/application/test_api/responses/results_nh_mvic_mc1_0005261846_files.json
@@ -108,11 +108,11 @@
                 ]
             },
             "1": {
-                "nh_mvic_raw_alternate": [
+                "nh_mvic_raw": [
                     "https://opus.pds-rings.seti.org/holdings/volumes/NHxxMV_xxxx_v1/NHLAMV_1001/data/20060321_000526/mc1_0005261846_0x537_eng_1.fit",
                     "https://opus.pds-rings.seti.org/holdings/volumes/NHxxMV_xxxx_v1/NHLAMV_1001/data/20060321_000526/mc1_0005261846_0x537_eng_1.lbl"
                 ],
-                "nh_mvic_calib_alternate": [
+                "nh_mvic_calib": [
                     "https://opus.pds-rings.seti.org/holdings/volumes/NHxxMV_xxxx_v1/NHLAMV_2001/data/20060321_000526/mc1_0005261846_0x537_sci_1.fit",
                     "https://opus.pds-rings.seti.org/holdings/volumes/NHxxMV_xxxx_v1/NHLAMV_2001/data/20060321_000526/mc1_0005261846_0x537_sci_1.lbl"
                 ]


### PR DESCRIPTION
- Fixes #N/A
- Were any Django, import pipeline, or table_schema files modified? Y
  - If YES:
    - Database used: New import
    - All Django tests pass: Y
    - FLAKE8 run on modified code: NA
- Were any JavaScript or CSS files modified? N
  - If YES:
    - JSHINT run on all affected files: Y/NA
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y/NA
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): Y/NA
- Was the documentation reviewed for necessary changes or additions? NA
  - About
  - Getting Started
  - FAQ
  - API Guide
  - Tooltips

Description of changes:

Fix three test results broken by pds-webtools pull #46, which fixed a bug related to the opus products prioritizer.

Known problems:
