### PR TITLE
Update opus.widgetsDrawn to make sure widgets on the new surface geo …

### DIFF
--- a/opus/application/apps/dictionary/urls.py
+++ b/opus/application/apps/dictionary/urls.py
@@ -29,6 +29,5 @@ urlpatterns = [
         RedirectView.as_view(
             url=staticfiles_storage.url('favicon.ico'),
             permanent=False),
-        name='favicon'
-        ),
+        name='favicon'),
 ]

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -176,10 +176,13 @@ var o_widgets = {
 
                 // Update widgets array in opus.prefs
                 $.each(opus.prefs.widgets, function(widgetIdx, widget) {
-                    if (widget.startsWith(oldTargetStr)) {
-                        let newWidget = widget.replace(oldTargetStr, newTargetStr);
-                        opus.prefs.widgets[widgetIdx] = newWidget;
-                    }
+                    o_widgets.updateWidgetsArray(widget, widgetIdx, opus.prefs.widgets, oldTargetStr, newTargetStr);
+                });
+
+                // Update widgets drawn so that widgets on the new target can be properly closed
+                // when clicking on search menu.
+                $.each(opus.widgetsDrawn, function(idx, widgetDrawn) {
+                    o_widgets.updateWidgetsArray(widgetDrawn, idx, opus.widgetsDrawn, oldTargetStr, newTargetStr);
                 });
 
                 // Update metadata selections
@@ -274,6 +277,13 @@ var o_widgets = {
                 dataObj[newSlug] = dataObj[oldTargetSlug];
                 delete dataObj[oldTargetSlug];
             }
+        }
+    },
+
+    updateWidgetsArray: function(currentWidget, idx, targetWidgetsArray, oldTargetStr, newTargetStr) {
+        if (currentWidget.startsWith(oldTargetStr)) {
+            let newWidget = currentWidget.replace(oldTargetStr, newTargetStr);
+            targetWidgetsArray[idx] = newWidget;
         }
     },
 


### PR DESCRIPTION
- Fixes #1220 
- Were any Django, import pipeline, or table_schema files modified? N
  - If YES:
    - Database used: opus3_test_220321    
    - All Django tests pass: Y    
    -  FLAKE8 run on modified code: Y
- Were any JavaScript or CSS files modified? Y
  - If YES:
    - JSHINT run on all affected files: Y
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y      
    (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): NA
- Was the documentation reviewed for necessary changes or additions? NA
  - About
  - Getting Started
  - FAQ
  - API Guide
  - Tooltips

Description of changes:
- Update ```opus.widgetsDrawn``` so that widgets on the new surface geo target can be properly closed when clicking the search menu. 

Known problems:
NA