### PR TITLE
Fixed OPUS freezes issue on select range to add to cart

### DIFF
--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1870,6 +1870,35 @@ var o_browse = {
         let rangeSelectOpusID = $(`${tab} .op-gallery-view`).data("infiniteScroll").options.rangeSelectOpusID;
         o_browse.highlightStartOfRange(rangeSelectOpusID);
 
+        // Initialize tooltips using tooltipster in browse gallery and table
+        // Since we didn't set functionPosition, the tooltip will always open
+        // in the middle of the gallery view's top edge.
+        $(`${tab} .op-browse-gallery-tooltip`).tooltipster({
+            maxWidth: opus.tooltipsMaxWidth,
+            theme: opus.tooltipsTheme,
+            delay: opus.tooltipsDelay,
+            contentAsHTML: true,
+        });
+        $(`${tab} .op-browse-table-tooltip`).tooltipster({
+            maxWidth: opus.tooltipsMaxWidth,
+            theme: opus.tooltipsTheme,
+            delay: opus.tooltipsDelay,
+            contentAsHTML: true,
+            functionBefore: function(instance, helper){
+                // Make sure all other tooltips are closed before a new one is opened
+                // in table view.
+                $.each($.tooltipster.instances(), function(i, inst){
+                    inst.close();
+                });
+            },
+            // Make sure the tooltip position is next to the cursor when users
+            // move around the same row in the browse table view. Without this
+            // function, the tooltip will always open in the middle of the row.
+            functionPosition: function(instance, helper, position){
+                return o_utils.setPreviewImageTooltipPosition(helper, position);
+            }
+        });
+
         // Note: we have to manually set the scrollbar position.
         // - scroll up: when we scroll up and a new page is fetched, we want to keep scrollbar position at the current startObs,
         //   instead of at the first item in newly fetched page.
@@ -2372,34 +2401,6 @@ var o_browse = {
                 o_browse.hideMetadataDetailModal();
             }
             o_browse.renderGalleryAndTable(data, this.url, view);
-            // Initialize tooltips using tooltipster in browse gallery and table
-            // Since we didn't set functionPosition, the tooltip will always open
-            // in the middle of the gallery view's top edge.
-            $(`${tab} .op-browse-gallery-tooltip`).tooltipster({
-                maxWidth: opus.tooltipsMaxWidth,
-                theme: opus.tooltipsTheme,
-                delay: opus.tooltipsDelay,
-                contentAsHTML: true,
-            });
-            $(`${tab} .op-browse-table-tooltip`).tooltipster({
-                maxWidth: opus.tooltipsMaxWidth,
-                theme: opus.tooltipsTheme,
-                delay: opus.tooltipsDelay,
-                contentAsHTML: true,
-                functionBefore: function(instance, helper){
-                    // Make sure all other tooltips are closed before a new one is opened
-                    // in table view.
-                    $.each($.tooltipster.instances(), function(i, inst){
-                        inst.close();
-                    });
-                },
-                // Make sure the tooltip position is next to the cursor when users
-                // move around the same row in the browse table view. Without this
-                // function, the tooltip will always open in the middle of the row.
-                functionPosition: function(instance, helper, position){
-                    return o_utils.setPreviewImageTooltipPosition(helper, position);
-                }
-            });
 
             if (opus.metadataDetailOpusId !== "") {
                 o_browse.metadataboxHtml(opus.metadataDetailOpusId, view);


### PR DESCRIPTION
- Fixes #1246 
- Were any Django, import pipeline, or table_schema files modified? N
  - If YES:
    - Database used: opus3_test_220530
    - All Django tests pass: Y
    - FLAKE8 run on modified code: Y
- Were any JavaScript or CSS files modified? Y
  - If YES:
    - JSHINT run on all affected files: Y
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: NA
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): NA
- Was the documentation reviewed for necessary changes or additions? NA
  - About
  - Getting Started
  - FAQ
  - API Guide
  - Tooltips

Description of changes:
Init tooltipster for the newly loaded browse data in renderGalleryAndTable, this will make sure all the newly loaded data has tooltipster applied to them.

Known problems:
N/A