### PR TITLE
Add total hints for collapsed categories

### DIFF
--- a/opus/application/apps/ui/templates/ui/widget.html
+++ b/opus/application/apps/ui/templates/ui/widget.html
@@ -62,6 +62,7 @@
                             <div class="mult_group_label_container mult_group_{{ group_info.0 }}">
                                 <span class="indicator fa fa-plus"></span>
                                 <span class="mult_group_label">{{ group_info.0 }}</span>
+                                <span class="hints"></span>
                             </div>
                             <ul class="mult_group" data-group="{{ group_info.0 }}">
                                 {% include "ui/customized_input.html" with

--- a/opus/application/apps/ui/views.py
+++ b/opus/application/apps/ui/views.py
@@ -254,7 +254,8 @@ def api_get_widget(request, **kwargs):
                  +'<span class="indicator fa fa-plus">'
                  +'</span>'
                  +'<span class="mult_group_label">'
-                 +str(glabel) + '</span></div>'
+                 +str(glabel) + '</span>'
+                 +'<span class="hints"></span></div>'
                  +'<ul class="mult_group"'
                  +' data-group=' + str(glabel) + '>'
                  +SearchForm(form_vals,

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -1244,7 +1244,7 @@ var o_search = {
                 $("#" + widget + " .mult_group").each( function() {
                     let sum = 0;
                     // The flag used to determine if we will display the total hints or "--"
-                    let displaySum = true;
+                    let displaySum = false;
                     let group = $(this).data("group");
                     let groupClass = `.mult_group_${group}`;
 
@@ -1253,8 +1253,7 @@ var o_search = {
                         let multValInt = parseInt(multVal);
                         if (!isNaN(multValInt)) {
                             sum += multValInt;
-                        } else {
-                            displaySum = false;
+                            displaySum = true;
                         }
                     });
                     if (!displaySum) { sum = "--"; }

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -1204,19 +1204,19 @@ var o_search = {
 
                 let widget = "widget__" + dataSlug;
                 let mults = multdata.mults;
+                let hintsTextClass = "op-hints-info";
                 $("#" + widget + " input").each( function() {
-                    let hintsTextClass = "op-hints-info";
                     let value = $(this).attr("value");
                     let id = "#hint__" + slug + "_" + value.replace(/ /g, "-").replace(/[^\w\s]/gi, "");  // id of hinting span, defined in widgets.js getWidget
 
                     if (!hideHintsForNonSelectedRadioButtons) {
                         if (mults[value]) {
-                            $(id).html(`<span class="${hintsTextClass}">` + mults[value] + "</span>");
+                            $(id).html(`<span class="${hintsTextClass}" data-value=${mults[value]}>` + mults[value] + "</span>");
                             if ($(id).parent().hasClass("fadey")) {
                                 $(id).parent().removeClass("fadey");
                             }
                         } else {
-                            $(id).html(`<span class="${hintsTextClass}">0</span>`);
+                            $(id).html(`<span class="${hintsTextClass}" data-value=0>0</span>`);
                             $(id).parent().addClass("fadey");
                         }
                     } else {
@@ -1224,19 +1224,38 @@ var o_search = {
                         $(id).parent().removeClass("fadey");
                         if (mults[value]) {
                             if ($(this).is(":checked")) {
-                                $(id).html(`<span class="${hintsTextClass}">` + mults[value] + "</span>");
+                                $(id).html(`<span class="${hintsTextClass}" data-value=${mults[value]}>` + mults[value] + "</span>");
                             } else {
-                                $(id).html(`<span class="${hintsTextClass}">--</span>`);
+                                $(id).html(`<span class="${hintsTextClass}" data-value="--">--</span>`);
                             }
                         } else {
                             if ($(this).is(":checked")) {
-                                $(id).html(`<span class="${hintsTextClass}">0</span>`);
-
+                                $(id).html(`<span class="${hintsTextClass}" data-value=0>0</span>`);
                             } else {
-                                $(id).html(`<span class="${hintsTextClass}">--</span>`);
+                                $(id).html(`<span class="${hintsTextClass}" data-value="--">--</span>`);
                             }
                         }
                     }
+                });
+
+                // Count the total hints under each group name and display them in the ui
+                // If the hints are all "--" under a group, we will display "--" next to
+                // the group name.
+                $("#" + widget + " .mult_group").each( function() {
+                    let sum = 0;
+                    // The flag used to determine if we will display the total hints or "--"
+                    let displaySum = false;
+                    let group = $(this).data("group");
+                    let groupClass = `.mult_group_${group}`;
+
+                    $("#" + widget + ` .mult_group[data-group="${group}"] .${hintsTextClass}`).each(function() {
+                        let multVal = $(this).data("value");
+                        if (!displaySum && !isNaN(parseInt(multVal))) displaySum = true;
+                        if (parseInt(multVal)) sum += multVal;
+                    });
+                    if (!displaySum) sum = "--";
+                    let hintHtml = `<span class="${hintsTextClass}">${sum}</span>`;
+                    $("#" + widget + ` ${groupClass} .hints`).html(hintHtml);
                 });
             }
         }); // end mults ajax

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -1250,10 +1250,10 @@ var o_search = {
 
                     $("#" + widget + ` .mult_group[data-group="${group}"] .${hintsTextClass}`).each(function() {
                         let multVal = $(this).data("value");
-                        if (!displaySum && !isNaN(parseInt(multVal))) displaySum = true;
-                        if (parseInt(multVal)) sum += multVal;
+                        if (!displaySum && !isNaN(parseInt(multVal))) { displaySum = true; }
+                        if (parseInt(multVal)) { sum += multVal; }
                     });
-                    if (!displaySum) sum = "--";
+                    if (!displaySum) { sum = "--"; }
                     let hintHtml = `<span class="${hintsTextClass}">${sum}</span>`;
                     $("#" + widget + ` ${groupClass} .hints`).html(hintHtml);
                 });

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -1244,18 +1244,22 @@ var o_search = {
                 $("#" + widget + " .mult_group").each( function() {
                     let sum = 0;
                     // The flag used to determine if we will display the total hints or "--"
-                    let displaySum = false;
+                    let displaySum = true;
                     let group = $(this).data("group");
                     let groupClass = `.mult_group_${group}`;
 
-                    $("#" + widget + ` .mult_group[data-group="${group}"] .${hintsTextClass}`).each(function() {
+                    $(`#${widget} .mult_group[data-group="${group}"] .${hintsTextClass}`).each(function() {
                         let multVal = $(this).data("value");
-                        if (!displaySum && !isNaN(parseInt(multVal))) { displaySum = true; }
-                        if (parseInt(multVal)) { sum += multVal; }
+                        let multValInt = parseInt(multVal);
+                        if (!isNaN(multValInt)) {
+                            sum += multValInt;
+                        } else {
+                            displaySum = false;
+                        }
                     });
                     if (!displaySum) { sum = "--"; }
                     let hintHtml = `<span class="${hintsTextClass}">${sum}</span>`;
-                    $("#" + widget + ` ${groupClass} .hints`).html(hintHtml);
+                    $(`#${widget} ${groupClass} .hints`).html(hintHtml);
                 });
             }
         }); // end mults ajax


### PR DESCRIPTION
- Fixes #1235 
- Were any Django, import pipeline, or table_schema files modified? N
  - If YES:
    - Database used: opus3_test_220530
    - All Django tests pass: Y
    - FLAKE8 run on modified code: Y
    - Were any JavaScript or CSS files modified? Y
  - If YES:
    - JSHINT run on all affected files: Y
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): NA
- Was the documentation reviewed for necessary changes or additions? NA
  - About
  - Getting Started
  - FAQ
  - API Guide
  - Tooltips

Description of changes:
Add total hints for categories. 
Note: If all the hints for inputs are '--', the total hints will be '--' for that category.
Known problems:
N/A