### PR TITLE
Detail view COISS doesn't allow opening of full preview image

### DIFF
--- a/opus/application/apps/tools/file_utils.py
+++ b/opus/application/apps/tools/file_utils.py
@@ -267,7 +267,12 @@ def get_displayed_browse_products(opus_id, version_name='Current'):
     """
     browse_products = get_pds_products(opus_id,
                                        product_types=settings.DISPLAYED_BROWSE_PRODUCTS)
+    # Get full size browse products
+    browse_products_full = get_pds_products(opus_id,
+                                       product_types=settings.FULL_SIZE_BROWSE_PRODUCTS)
+
     selected_browse_products = browse_products[opus_id].get(version_name, [])
+    selected_browse_products_full = browse_products_full[opus_id].get(version_name, [])
     # When there is no preview image, we return settings.THUMBNAIL_NOT_FOUND
     if len(selected_browse_products) == 0:
         return [(settings.THUMBNAIL_NOT_FOUND, settings.THUMBNAIL_NOT_FOUND)]
@@ -277,7 +282,11 @@ def get_displayed_browse_products(opus_id, version_name='Current'):
     # co-uvis-occ-2005-232-alpsco-i
     for p in selected_browse_products:
         for browse_med_url in selected_browse_products[p]:
-            browse_full_url = browse_med_url.replace('_med.', '_full.')
-            res.append((browse_med_url, browse_full_url))
+            basename, _, _ = browse_med_url.partition('_med.')
+            # search for the corresponding full size image in full size browse products
+            for p_full in selected_browse_products_full:
+                for browse_full_url in selected_browse_products_full[p_full]:
+                    if basename in browse_full_url:
+                        res.append((browse_med_url, browse_full_url))
 
     return res

--- a/opus/application/apps/tools/file_utils.py
+++ b/opus/application/apps/tools/file_utils.py
@@ -267,12 +267,8 @@ def get_displayed_browse_products(opus_id, version_name='Current'):
     """
     browse_products = get_pds_products(opus_id,
                                        product_types=settings.DISPLAYED_BROWSE_PRODUCTS)
-    # Get full size browse products
-    browse_products_full = get_pds_products(opus_id,
-                                       product_types=settings.FULL_SIZE_BROWSE_PRODUCTS)
 
     selected_browse_products = browse_products[opus_id].get(version_name, [])
-    selected_browse_products_full = browse_products_full[opus_id].get(version_name, [])
     # When there is no preview image, we return settings.THUMBNAIL_NOT_FOUND
     if len(selected_browse_products) == 0:
         return [(settings.THUMBNAIL_NOT_FOUND, settings.THUMBNAIL_NOT_FOUND)]
@@ -280,13 +276,20 @@ def get_displayed_browse_products(opus_id, version_name='Current'):
     # One opus id could have multiple previews, for example:
     # co-rss-occ-2008-039-rev058c-x43-i
     # co-uvis-occ-2005-232-alpsco-i
+    # Get paired medium and full browse urls in res (mediem url, full url)
+    disp_prod_dict = {}
     for p in selected_browse_products:
-        for browse_med_url in selected_browse_products[p]:
-            basename, _, _ = browse_med_url.partition('_med.')
-            # search for the corresponding full size image in full size browse products
-            for p_full in selected_browse_products_full:
-                for browse_full_url in selected_browse_products_full[p_full]:
-                    if basename in browse_full_url:
-                        res.append((browse_med_url, browse_full_url))
+        for browse_url in selected_browse_products[p]:
+            if '_med.' in browse_url:
+                basename, _, _ = browse_url.partition('_med.')
+                if basename in disp_prod_dict:
+                    res.append((browse_url, disp_prod_dict[basename]))
+                    continue
+            else: # '_full.' in browse_url
+                basename, _, _ = browse_url.partition('_full.')
+                if basename in disp_prod_dict:
+                    res.append((disp_prod_dict[basename], browse_url))
+                    continue
+            disp_prod_dict[basename] = browse_url
 
     return res

--- a/opus/application/apps/tools/file_utils.py
+++ b/opus/application/apps/tools/file_utils.py
@@ -263,7 +263,8 @@ def get_pds_preview_images(opus_id_list, preview_jsons, sizes=None,
 
 def get_displayed_browse_products(opus_id, version_name='Current'):
     """Given an opus_id, return a list of browse product URLs to display in the
-       detail tab.
+       detail tab. The function will return a list of tuples, and each tuple will
+       be (medium browse url, full browse url).
     """
     browse_products = get_pds_products(opus_id,
                                        product_types=settings.DISPLAYED_BROWSE_PRODUCTS)
@@ -276,7 +277,7 @@ def get_displayed_browse_products(opus_id, version_name='Current'):
     # One opus id could have multiple previews, for example:
     # co-rss-occ-2008-039-rev058c-x43-i
     # co-uvis-occ-2005-232-alpsco-i
-    # Get paired medium and full browse urls in res (mediem url, full url)
+    # Get paired medium and full browse urls in res (medium url, full url)
     disp_prod_dict = {}
     for p in selected_browse_products:
         for browse_url in selected_browse_products[p]:

--- a/opus/application/settings.py
+++ b/opus/application/settings.py
@@ -334,8 +334,8 @@ PREVIEW_GUIDES = {
 }
 
 # Browse products displayed in OPUS detail tab
-DISPLAYED_BROWSE_PRODUCTS = ['browse_medium','diagram_medium']
-FULL_SIZE_BROWSE_PRODUCTS = ['browse_full','diagram_full']
+DISPLAYED_BROWSE_PRODUCTS = ['browse_medium','diagram_medium',
+                             'browse_full','diagram_full']
 
 RANGE_FORM_TYPES = ('LONG','RANGE')
 MULT_FORM_TYPES  = ('GROUP','MULTIGROUP')

--- a/opus/application/settings.py
+++ b/opus/application/settings.py
@@ -333,8 +333,9 @@ PREVIEW_GUIDES = {
     'COVIMS': 'https://pds-rings.seti.org/cassini/vims/COVIMS_previews.txt'
 }
 
-# Browse products displayed in OPUS detail tab
+# Browse products displayed in OPUS detail tab or newly open tab
 DISPLAYED_BROWSE_PRODUCTS = ['browse_medium','diagram_medium']
+FULL_SIZE_BROWSE_PRODUCTS = ['browse_full','diagram_full']
 
 RANGE_FORM_TYPES = ('LONG','RANGE')
 MULT_FORM_TYPES  = ('GROUP','MULTIGROUP')

--- a/opus/application/settings.py
+++ b/opus/application/settings.py
@@ -333,7 +333,7 @@ PREVIEW_GUIDES = {
     'COVIMS': 'https://pds-rings.seti.org/cassini/vims/COVIMS_previews.txt'
 }
 
-# Browse products displayed in OPUS detail tab or newly open tab
+# Browse products displayed in OPUS detail tab
 DISPLAYED_BROWSE_PRODUCTS = ['browse_medium','diagram_medium']
 FULL_SIZE_BROWSE_PRODUCTS = ['browse_full','diagram_full']
 

--- a/opus/application/settings.py
+++ b/opus/application/settings.py
@@ -334,8 +334,8 @@ PREVIEW_GUIDES = {
 }
 
 # Browse products displayed in OPUS detail tab
-DISPLAYED_BROWSE_PRODUCTS = ['browse_medium','diagram_medium',
-                             'browse_full','diagram_full']
+DISPLAYED_BROWSE_PRODUCTS = ['browse_medium', 'diagram_medium',
+                             'browse_full', 'diagram_full']
 
 RANGE_FORM_TYPES = ('LONG','RANGE')
 MULT_FORM_TYPES  = ('GROUP','MULTIGROUP')


### PR DESCRIPTION
- Fixes #1255 
- Were any Django, import pipeline, or table_schema files modified? N
  - If YES:
    - Database used: opus3_test_220906
    - All Django tests pass: Y
    - FLAKE8 run on modified code: Y
- Were any JavaScript or CSS files modified? N
  - If YES:
    - JSHINT run on all affected files: NA
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: NA
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): NA
- Was the documentation reviewed for necessary changes or additions? NA
  - About
  - Getting Started
  - FAQ
  - API Guide
  - Tooltips

Description of changes:
Update ```get_displayed_browse_products``` to obtain both displayed (med) and full size browse products. When iterating through the displayed browse products, we will search for the corresponding full size image in full size browse products instead of replacing "_med." with "_full". That way the displayed images can find the corresponding full size image url even if the file extensions are different.

Known problems:
