### PR TITLE
Fix bugs in multigroup handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,22 +13,11 @@ logs
 log.txt
 nohup.out
 
-venv
-p2venv
-p3venv
+.vscode
+*venv*
 opus_secrets.py
 
 migrations/
 
 .coverage
 htmlcov/
-
-run_log_analyzer_end_of_month.sh
-run_log_analyzer_refresh_all.sh
-run_log_analyzer_update.sh
-log_analyzer/.logs
-TODO
-mypy.ini
-ignored-errors
-venv38/
-opus/application/static_media/coreui/css/style-old.css

--- a/opus/application/apps/cart/views.py
+++ b/opus/application/apps/cart/views.py
@@ -1207,9 +1207,15 @@ def _edit_cart_range(request, session_id, action, recycle_bin, api_code):
             temp_sql += ' LEFT JOIN '+q(table)+' ON '+q('obs_general')+'.'+q('id')
             temp_sql += '='+q(table)+'.'+q('obs_general_id')
         # And JOIN all the mult_ tables together
-        for mult_table, category, field_name in sorted(order_mult_tables):
-            temp_sql += ' LEFT JOIN '+q(mult_table)+' ON '+q(category)+'.'
-            temp_sql += q(field_name)+'='+q(mult_table)+'.'+q('id')
+        for mult_table, is_multigroup, category, field_name in sorted(order_mult_tables):
+            temp_sql += ' LEFT JOIN '+q(mult_table)+' ON '
+            if is_multigroup:
+                temp_sql += 'JSON_EXTRACT('
+            temp_sql += q(category)+'.'+q(field_name)
+            if is_multigroup:
+                # For a MULTIGROUP field, we just sort on the first value
+                temp_sql += ', "$[0]")'
+            temp_sql += '='+q(mult_table)+'.'+q('id')
         temp_sql += ' INNER JOIN '+q('cart')
         temp_sql += ' ON '+q('obs_general')+'.'+q('id')+'='
         temp_sql += q('cart')+'.'+q('obs_general_id')

--- a/opus/application/apps/search/test_search.py
+++ b/opus/application/apps/search/test_search.py
@@ -3388,6 +3388,48 @@ class searchTests(TestCase):
         self.assertIsNone(sql)
         self.assertIsNone(params)
 
+    def test__construct_query_string_mults_multigroup_target_single(self):
+        "[test_search.py] construct_query_string: obs_general intended_target single"
+        selections = {'obs_general.target_name': ['Saturn']}
+        extras = {}
+        sql, params = construct_query_string(selections, extras)
+        print(sql)
+        print(params)
+        expected = 'SELECT `obs_general`.`id` FROM `obs_general` WHERE JSON_CONTAINS(`obs_general`.`target_name`,%s)'
+        expected_params = ['1']
+        print(expected)
+        print(expected_params)
+        self.assertEqual(sql, expected)
+        self.assertEqual(params, expected_params)
+
+    def test__construct_query_string_mults_multigroup_target_dual(self):
+        "[test_search.py] construct_query_string: obs_general intended_target dual"
+        selections = {'obs_general.target_name': ['Saturn', 'Jupiter']}
+        extras = {}
+        sql, params = construct_query_string(selections, extras)
+        print(sql)
+        print(params)
+        expected = 'SELECT `obs_general`.`id` FROM `obs_general` WHERE JSON_CONTAINS(`obs_general`.`target_name`,%s) OR JSON_CONTAINS(`obs_general`.`target_name`,%s)'
+        expected_params = ['1', '19']
+        print(expected)
+        print(expected_params)
+        self.assertEqual(sql, expected)
+        self.assertEqual(params, expected_params)
+
+    def test__construct_query_string_mults_multigroup_target_order(self):
+        "[test_search.py] construct_query_string: obs_general intended_target sort"
+        selections = {}
+        extras = {'order': (['obs_general.target_name'], [False])}
+        sql, params = construct_query_string(selections, extras)
+        print(sql)
+        print(params)
+        expected = 'SELECT `obs_general`.`id` FROM `obs_general` LEFT JOIN `mult_obs_general_target_name` ON JSON_EXTRACT(`obs_general`.`target_name`, "$[0]")=`mult_obs_general_target_name`.`id` ORDER BY mult_obs_general_target_name.label ASC'
+        expected_params = []
+        print(expected)
+        print(expected_params)
+        self.assertEqual(sql, expected)
+        self.assertEqual(params, expected_params)
+
 
             #####################################################
             ######### set_user_search_number UNIT TESTS #########

--- a/opus/application/test_api/test_cart_api.py
+++ b/opus/application/test_api/test_cart_api.py
@@ -1631,6 +1631,21 @@ class ApiCartTests(TestCase, ApiTestHelper):
         expected = {'recycled_count': 0, 'count': 10, 'reqno': 456}
         self._run_json_equal(url, expected)
 
+    def test__api_cart_removerange_sort_multigroup(self):
+        "[test_cart_api.py] /__cart/removerange: add+removerange OPUSIDs with order by multigroup field"
+        url = '/__cart/reset.json?reqno=42'
+        expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
+        self._run_json_equal(url, expected)
+        url = '/__cart/addrange.json?instrument=Voyager+UVS&order=target,opusid&range=vg-uvs-2-n-occ-1989-236-sigsgr-i,vg-uvs-2-u-occ-1986-024-sigsgr-epsilon-i&reqno=456'
+        expected = {'recycled_count': 0, 'count': 8, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/__cart/removerange.json?&instrument=Voyager+UVS&target=Uranus+Rings,Neptune+Rings&order=target,opusid&range=vg-uvs-2-n-occ-1989-236-sigsgr-i,vg-uvs-2-u-occ-1986-024-sigsgr-epsilon-e&reqno=456'
+        expected = {'recycled_count': 0, 'count': 4, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/__cart/status.json?reqno=456'
+        expected = {'recycled_count': 0, 'count': 4, 'reqno': 456}
+        self._run_json_equal(url, expected)
+
 
             ###########################################################
             ######### /__cart/addrange.json (cart): API TESTS #########
@@ -1950,6 +1965,21 @@ class ApiCartTests(TestCase, ApiTestHelper):
         self._run_json_equal(url, expected)
         url = '/__cart/status.json?reqno=456'
         expected = {'recycled_count': 0, 'count': 12, 'reqno': 456}
+        self._run_json_equal(url, expected)
+
+    def test__api_cart_removerange_sort_multigroup_cart(self):
+        "[test_cart_api.py] /__cart/removerange: add+removerange OPUSIDs with order by multigroup field"
+        url = '/__cart/reset.json?reqno=42'
+        expected = {'recycled_count': 0, 'count': 0, 'reqno': 42}
+        self._run_json_equal(url, expected)
+        url = '/__cart/addrange.json?instrument=Voyager+UVS&order=target,opusid&range=vg-uvs-2-n-occ-1989-236-sigsgr-i,vg-uvs-2-u-occ-1986-024-sigsgr-epsilon-i&reqno=456'
+        expected = {'recycled_count': 0, 'count': 8, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/__cart/removerange.json?&view=cart&order=-target,time1,opusid&range=vg-uvs-2-u-occ-1986-024-sigsgr-delta-e,vg-uvs-2-s-occ-1981-237-delsco-i&reqno=456&recyclebin=1'
+        expected = {'recycled_count': 4, 'count': 4, 'error': False, 'reqno': 456}
+        self._run_json_equal(url, expected)
+        url = '/__cart/status.json?reqno=456'
+        expected = {'recycled_count': 4, 'count': 4, 'reqno': 456}
         self._run_json_equal(url, expected)
 
 


### PR DESCRIPTION
- Fixes #1262 
- Were any Django, import pipeline, or table_schema files modified? Y
  - If YES:
    - Database used: opus3_test_220922
    - All Django tests pass: Y
    - FLAKE8 run on modified code: Y
- Were any JavaScript or CSS files modified? N
  - If YES:
    - JSHINT run on all affected files: Y/NA
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y/NA
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): Y/NA
- Was the documentation reviewed for necessary changes or additions? NA
  - About
  - Getting Started
  - FAQ
  - API Guide
  - Tooltips

Description of changes:

See bug #1262 for a description of actions that trigger bugs.

There were a couple of bugs in the previous implementation of multi-valued mult fields:
- Sorting on a MULTIGROUP field while retrieving a search chunk caused a crash
- Performing a cart addrange or removerange while sorting on a MULTIGROUP field caused a crash

These bugs have been fixed and new tests added for those cases.

Known problems:

There are still tests missing to test `get_search_results_chunk`, i.e. data.json or dataimages.json. In fact there are no tests for these API calls at all. See #648.
