### PR TITLE
313 Multiple form types for a single widget

### DIFF
--- a/opus/application/apps/ui/views.py
+++ b/opus/application/apps/ui/views.py
@@ -268,7 +268,7 @@ def api_get_widget(request, **kwargs):
         num_of_u_tags = len(dir_list)
         current_hierarchy = ''
         for idx, dir in enumerate(dir_list):
-            current_hierarchy += (dir + '/')
+            current_hierarchy = dir if idx == 0 else (current_hierarchy + '_' + dir)
             # Check if the current hierarchy exists
             if current_hierarchy in form:
                 # Remove </ul> to make sure the next level directory is wrapped
@@ -290,15 +290,14 @@ def api_get_widget(request, **kwargs):
             # If it's a brand new category, we will create a new mult group container
             html += ("\n\n"
                      +'<div class="mult_group_label_container'
-                     +' mult_group_' + str(dir)
-                     +'" data-hierarchy=' + str(current_hierarchy) + '">'
+                     +' mult_group_' + str(current_hierarchy) + '">'
                      +'<span class="indicator fa fa-plus">'
                      +'</span>'
                      +'<span class="mult_group_label">'
                      +str(dir) + '</span>'
                      +'<span class="hints"></span></div>'
                      +'<ul class="mult_group"'
-                     +' data-group=' + str(dir) + '>')
+                     +' data-group=' + str(current_hierarchy) + '>')
             if idx == len(dir_list) - 1:
                 html += (SearchForm(form_vals,
                                     auto_id='%s_' + str(dir),

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2201,9 +2201,7 @@ even when screen is narrow */
 
 /* For widget with a mix of grouping and non-grouping checkboxes, left align
 grouping icon with non-grouping checkboxes */
-#widget__instrument .mult_group_label_container,
-#widget__occreceiverhost .mult_group_label_container,
-#widget__occsource .mult_group_label_container {
+.mult_group_label_container {
     padding-left: 1%;
 }
 

--- a/opus/import/config_targets.py
+++ b/opus/import/config_targets.py
@@ -937,3 +937,19 @@ PLANET_GROUP_MAPPING = {
     'OTHER': {'label': 'Other',   'disp_order': '100'},
     None:    {'label': 'NULL',    'disp_order': '110'}
 }
+
+# For testing purpose, comment out the above PLANET_GROUP_MAPPING
+# and uncomment this one.
+# PLANET_GROUP_MAPPING = {
+#     'MER':   {'label': 'test1/sub1',             'disp_order': '010'},
+#     'VEN':   {'label': 'test1/sub1/Venus',       'disp_order': '020'},
+#     'EAR':   {'label': 'test1',                  'disp_order': '030'},
+#     'MAR':   {'label': 'test1/sub2/sub3/Mars',   'disp_order': '040'},
+#     'JUP':   {'label': 'test1/sub2/Jupiter',     'disp_order': '050'},
+#     'SAT':   {'label': 'test2/Saturn',           'disp_order': '060'},
+#     'URA':   {'label': 'test2/sub1/sub2/Uranus', 'disp_order': '070'},
+#     'NEP':   {'label': 'test2/sub1',             'disp_order': '080'},
+#     'PLU':   {'label': 'test3/sub1/sub2/Pluto',  'disp_order': '090'},
+#     'OTHER': {'label': 'test3/sub1',             'disp_order': '100'},
+#     None:    {'label': 'NULL',                   'disp_order': '110'}
+# }


### PR DESCRIPTION
- The is the pull request to track issue: #313 
- Implementation done:
    - phase 1: Allow sub-categories in checkbox fields. Allow multiple levels of sub-category.
        - Now ```grouping``` field can store directory tree like main_cat/sub_cat1/sub_cat2  

- Steps to test (phase 1):
1. In config_targets.py, replace the normal PLANET_GROUP_MAPPING to the commented out one and re-import the test database.
2. Intended target name widget will have multiple level of sub categories shown. Each level can have a mix of checkboxes and sub-category.