### PR TITLE
Multi form types for a single widget phase 2 & 3

### DIFF
--- a/opus/application/apps/ui/templates/ui/widget.html
+++ b/opus/application/apps/ui/templates/ui/widget.html
@@ -59,12 +59,12 @@
                     <!-- Customize inputs in the widget -->
                     {% if customized_input %}
                         {% for group_info, choices in grouped_options.items %}
-                            <div class="mult_group_label_container mult_group_{{ group_info.0 }}">
+                            <div class="mult-group-label-container mult-group-{{ group_info.0 }}">
                                 <span class="indicator fa fa-plus"></span>
-                                <span class="mult_group_label">{{ group_info.0 }}</span>
+                                <span class="mult-group-label">{{ group_info.0 }}</span>
                                 <span class="hints"></span>
                             </div>
-                            <ul class="mult_group" data-group="{{ group_info.0 }}">
+                            <ul class="mult-group" data-group="{{ group_info.0 }}">
                                 {% include "ui/customized_input.html" with
                                     slug=slug
                                     options=choices

--- a/opus/application/apps/ui/views.py
+++ b/opus/application/apps/ui/views.py
@@ -289,14 +289,14 @@ def api_get_widget(request, **kwargs):
 
             # If it's a brand new category, we will create a new mult group container
             html += ("\n\n"
-                     +'<div class="mult_group_label_container'
-                     +' mult_group_' + str(current_hierarchy) + '">'
+                     +'<div class="mult-group-label-container'
+                     +' mult-group-' + str(current_hierarchy) + '">'
                      +'<span class="indicator fa fa-plus">'
                      +'</span>'
-                     +'<span class="mult_group_label">'
+                     +'<span class="mult-group-label">'
                      +str(dir) + '</span>'
                      +'<span class="hints"></span></div>'
-                     +'<ul class="mult_group"'
+                     +'<ul class="mult-group"'
                      +' data-group=' + str(current_hierarchy) + '>')
             if idx == len(dir_list) - 1:
                 html += (SearchForm(form_vals,

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2211,7 +2211,7 @@ grouping icon with non-grouping checkboxes */
 
 /* Increase the indentation of subcategories for mult */
 .mult_group {
-    padding-left: 4% !important;
+    padding-left: 1.2em !important;
 }
 
 /* detail tab */

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2185,6 +2185,10 @@ even when screen is narrow */
     font-weight:bold;
 }
 
+.op-checked-indication {
+    margin: 0 2px 0 5px;
+}
+
 .mult_group_label {
     padding: 5px 4px;
     padding-left: 5px;

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2185,7 +2185,7 @@ even when screen is narrow */
     font-weight:bold;
 }
 
-.op-checked-indication {
+.op-mult-group-checked-indication {
     margin: 0 2px 0 5px;
 }
 

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2189,28 +2189,28 @@ even when screen is narrow */
     margin: 0 2px 0 5px;
 }
 
-.mult_group_label {
+.mult-group-label {
     padding: 5px 4px;
     padding-left: 5px;
 }
 
-.mult_group {
+.mult-group {
     padding-left: 0;
     display: none;
 }
 
-.mult_group > .multichoice {
+.mult-group > .multichoice {
     padding-left: 0;
 }
 
 /* For widget with a mix of grouping and non-grouping checkboxes, left align
 grouping icon with non-grouping checkboxes */
-.mult_group_label_container {
+.mult-group-label-container {
     padding-left: 1%;
 }
 
 /* Increase the indentation of subcategories for mult */
-.mult_group {
+.mult-group {
     padding-left: 1.2em !important;
 }
 

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -2209,6 +2209,11 @@ grouping icon with non-grouping checkboxes */
     padding-left: 1%;
 }
 
+/* Increase the indentation of subcategories for mult */
+.mult_group {
+    padding-left: 4% !important;
+}
+
 /* detail tab */
 .op-detail-metadata {
     /* Make detail left pane shrink proportionally when window is narrow

--- a/opus/application/static_media/js/mutationObserver.js
+++ b/opus/application/static_media/js/mutationObserver.js
@@ -138,8 +138,8 @@ var o_mutationObserver = {
             let lastMutationIdx = mutationsList.length - 1;
             mutationsList.forEach((mutation, idx) => {
                 if (mutation.type === "attributes" && idx === lastMutationIdx &&
-                    mutation.target.classList.value.match(/mult_group/)) {
-                    // If new mult_group is open inside widgets, we update ps
+                    mutation.target.classList.value.match(/mult-group/)) {
+                    // If new mult-group is open inside widgets, we update ps
                     let multGroupContentsHeight = mutation.target.clientHeight;
                     let widgetContainerBottomPosition = $("#search #widget-container").offset().top +
                                                         $("#search #widget-container").height();

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -319,6 +319,10 @@ var o_search = {
             let newTargetSlug = $(this).attr("data-slug");
             opus.oldSurfacegeoTarget = opus.oldSurfacegeoTarget || newTargetSlug;
 
+            if ($(this).hasClass("multichoice")) {
+                o_search.addCheckMarkForCategories(id);
+            }
+
             if ($(this).is(":checked")) {
                 let values = [];
                 if (opus.selections[id]) {
@@ -527,6 +531,35 @@ var o_search = {
                 }
             }
         });
+    },
+
+    addCheckMarkForCategories: function(slug) {
+        // let slug = $(this).attr("name");
+        let categories = $(`#widget__${slug} .mult_group`);
+        // Check each checkboxes under each category. If a category
+        // has any checked checkbox, add a check mark next to the
+        // category name
+        for (let cat of categories) {
+            let isChecked = false;
+            let checkboxes = $(cat).find("input.multichoice");
+            for (let checkbox of checkboxes) {
+                isChecked = $(checkbox).is(":checked");
+                if (isChecked) break;
+            }
+
+            let groupName = $(cat).data("group");
+            let parentCatClassName = `mult_group_${groupName}`;
+            let checkMarkClassName = `${parentCatClassName}_checked`;
+            // Add the check mark right next to the category if any checkbox inside the
+            // category is checked && check mark doesn't exist
+            if (isChecked && $(`.mult_group_${groupName} .${checkMarkClassName}`).length === 0) {
+                let checkMark = `<span class=${checkMarkClassName}><i class="fa fa-check"></i></span>`;
+                $(`.${parentCatClassName}`).append(checkMark);
+            } else if (!isChecked) {
+                // Remove the check mark if none of checkboxes under that category is checked.
+                $(`.${checkMarkClassName}`).remove();
+            }
+        }
     },
 
     stringOrRangeChanged: function(target) {

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -534,7 +534,7 @@ var o_search = {
     },
 
     addCheckMarkForCategories: function(slug) {
-        let categories = $(`#widget__${slug} .mult_group`);
+        let categories = $(`#widget__${slug} .mult-group`);
         // Check each checkbox under each category. If a category
         // has any checked checkboxes, add a check mark next to the
         // category name
@@ -549,12 +549,12 @@ var o_search = {
             }
 
             let groupName = $(cat).data("group");
-            let parentCatClassName = `mult_group_${groupName}`;
+            let parentCatClassName = `mult-group-${groupName}`;
             let checkMarkClassName = `${parentCatClassName}_checked`;
 
             // Add the check mark right next to the category if any checkbox inside the
             // category is checked && check mark doesn't exist
-            if (isChecked && $(`.mult_group_${groupName} .${checkMarkClassName}`).length === 0) {
+            if (isChecked && $(`.mult-group-${groupName} .${checkMarkClassName}`).length === 0) {
                 let checkMark = `<span class="${checkMarkClassName} op-mult-group-checked-indication">` +
                                 "<i class='fa fa-check'></i></span>";
                 $(`.${parentCatClassName}`).append(checkMark);
@@ -1277,14 +1277,14 @@ var o_search = {
                 // Count the total hints under each group name and display them in the ui
                 // If the hints are all "--" under a group, we will display "--" next to
                 // the group name.
-                $("#" + widget + " .mult_group").each( function() {
+                $("#" + widget + " .mult-group").each( function() {
                     let sum = 0;
                     // The flag used to determine if we will display the total hints or "--"
                     let displaySum = false;
                     let group = $(this).data("group");
-                    let groupClass = `.mult_group_${group}`;
+                    let groupClass = `.mult-group-${group}`;
 
-                    $(`#${widget} .mult_group[data-group="${group}"] .${hintsTextClass}`).each(function() {
+                    $(`#${widget} .mult-group[data-group="${group}"] .${hintsTextClass}`).each(function() {
                         let multVal = $(this).data("value");
                         let multValInt = parseInt(multVal);
                         if (!isNaN(multValInt)) {

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -543,7 +543,7 @@ var o_search = {
             let checkboxes = $(cat).find("input.multichoice");
             for (let checkbox of checkboxes) {
                 isChecked = $(checkbox).is(":checked");
-                if (isChecked) break;
+                if (isChecked) {break;}
             }
 
             let groupName = $(cat).data("group");

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -534,7 +534,6 @@ var o_search = {
     },
 
     addCheckMarkForCategories: function(slug) {
-        // let slug = $(this).attr("name");
         let categories = $(`#widget__${slug} .mult_group`);
         // Check each checkboxes under each category. If a category
         // has any checked checkbox, add a check mark next to the
@@ -550,10 +549,12 @@ var o_search = {
             let groupName = $(cat).data("group");
             let parentCatClassName = `mult_group_${groupName}`;
             let checkMarkClassName = `${parentCatClassName}_checked`;
+
             // Add the check mark right next to the category if any checkbox inside the
             // category is checked && check mark doesn't exist
             if (isChecked && $(`.mult_group_${groupName} .${checkMarkClassName}`).length === 0) {
-                let checkMark = `<span class=${checkMarkClassName}><i class="fa fa-check"></i></span>`;
+                let checkMark = `<span class="${checkMarkClassName} op-checked-indication">` +
+                                "<i class='fa fa-check'></i></span>";
                 $(`.${parentCatClassName}`).append(checkMark);
             } else if (!isChecked) {
                 // Remove the check mark if none of checkboxes under that category is checked.

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -535,15 +535,17 @@ var o_search = {
 
     addCheckMarkForCategories: function(slug) {
         let categories = $(`#widget__${slug} .mult_group`);
-        // Check each checkboxes under each category. If a category
-        // has any checked checkbox, add a check mark next to the
+        // Check each checkbox under each category. If a category
+        // has any checked checkboxes, add a check mark next to the
         // category name
         for (let cat of categories) {
             let isChecked = false;
             let checkboxes = $(cat).find("input.multichoice");
             for (let checkbox of checkboxes) {
                 isChecked = $(checkbox).is(":checked");
-                if (isChecked) {break;}
+                if (isChecked) {
+                    break;
+                }
             }
 
             let groupName = $(cat).data("group");
@@ -553,11 +555,11 @@ var o_search = {
             // Add the check mark right next to the category if any checkbox inside the
             // category is checked && check mark doesn't exist
             if (isChecked && $(`.mult_group_${groupName} .${checkMarkClassName}`).length === 0) {
-                let checkMark = `<span class="${checkMarkClassName} op-checked-indication">` +
+                let checkMark = `<span class="${checkMarkClassName} op-mult-group-checked-indication">` +
                                 "<i class='fa fa-check'></i></span>";
                 $(`.${parentCatClassName}`).append(checkMark);
             } else if (!isChecked) {
-                // Remove the check mark if none of checkboxes under that category is checked.
+                // Remove the check mark if none of checkboxes under that category are checked.
                 $(`.${checkMarkClassName}`).remove();
             }
         }

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -1437,6 +1437,9 @@ var o_widgets = {
                 o_search.getHinting(slug);
             }
 
+            // Add check mark for mult categories
+            o_search.addCheckMarkForCategories(slug);
+
             // If an input widget just got opened and input slugs are not in opus.selections,
             // we need to update opus.selections to make sure input slugs exist.
             if (widgetInputs.hasClass("RANGE")) {

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -984,12 +984,14 @@ var o_widgets = {
          */
         for (const input of targetInputs) {
             if ($(input).attr("id") && $(input).attr("id").split("_")[0] === slug) {
-                let multGroup = $(input).parents(".mult_group");
-                let groupName = $(input).parents(".mult_group").attr("data-group");
-                let multGroupLabel = $(`.mult_group_${groupName}`);
-                multGroupLabel.find('.indicator').addClass('fa-minus');
-                multGroupLabel.find('.indicator').removeClass('fa-plus');
-                multGroup.slideDown("fast");
+                let parentsMultGroup = $(input).parents(".mult_group");
+                for (let parent of parentsMultGroup) {
+                    let groupName = $(parent).attr("data-group");
+                    let multGroupLabel = $(`.mult_group_${groupName}`);
+                    multGroupLabel.find('.indicator').addClass('fa-minus');
+                    multGroupLabel.find('.indicator').removeClass('fa-plus');
+                    $(parent).slideDown("fast");
+                }
             }
         }
     },

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -97,7 +97,7 @@ var o_widgets = {
         });
 
         // open/close mult groupings in widgets
-        $("#search").on("click", ".mult_group_label_container", function() {
+        $("#search").on("click", ".mult-group-label-container", function() {
             $(this).find(".indicator").toggleClass("fa-plus");
             $(this).find(".indicator").toggleClass("fa-minus");
             let multGroupContents = $(this).next();
@@ -984,10 +984,10 @@ var o_widgets = {
          */
         for (const input of targetInputs) {
             if ($(input).attr("id") && $(input).attr("id").split("_")[0] === slug) {
-                let parentsMultGroup = $(input).parents(".mult_group");
+                let parentsMultGroup = $(input).parents(".mult-group");
                 for (let parent of parentsMultGroup) {
                     let groupName = $(parent).attr("data-group");
-                    let multGroupLabel = $(`.mult_group_${groupName}`);
+                    let multGroupLabel = $(`.mult-group-${groupName}`);
                     multGroupLabel.find('.indicator').addClass('fa-minus');
                     multGroupLabel.find('.indicator').removeClass('fa-plus');
                     $(parent).slideDown("fast");
@@ -1000,7 +1000,7 @@ var o_widgets = {
         /**
          * Expand the corresponding input groups based on the selected planet.
          */
-        let mult_id = ".mult_group_" + selectedPlanet.attr("value");
+        let mult_id = ".mult-group-" + selectedPlanet.attr("value");
         $(mult_id).find(".indicator").addClass("fa-minus");
         $(mult_id).find(".indicator").removeClass("fa-plus");
         $(mult_id).next().slideDown("fast");

--- a/opus/import/do_import.py
+++ b/opus/import/do_import.py
@@ -299,6 +299,7 @@ def _convert_sql_response_to_mult_table(mult_table_name, rows):
             (id_num, value, label, disp_order,
              display, grouping, group_disp_order, aliases) = row
         else:
+            # preprogrammed mult options list doesn't have aliases field
             (id_num, value, label, disp_order,
              display, grouping, group_disp_order) = row
             aliases = None

--- a/opus/import/do_import.py
+++ b/opus/import/do_import.py
@@ -378,7 +378,7 @@ def mult_table_lookup_id(table_name, field_name, table_column, val):
     return None
 
 
-def update_mult_table(table_name, field_name, table_column, val, label,
+def update_mult_table(table_name, field_name, table_column, val, label, disp='Y',
                       disp_order=None, grouping=None, group_disp_order=None):
     """Update a single value in the cached version of a mult table."""
 
@@ -476,7 +476,7 @@ f'Unable to parse "{label}" for type "range_func_name": {e}')
         'value': val,
         'label': label,
         'disp_order': disp_order,
-        'display': 'Y', # if label is not None else 'N'
+        'display': disp, # default display: 'Y'
         'grouping': grouping,
         'group_disp_order': group_disp_order
     }
@@ -1189,6 +1189,7 @@ def import_observation_table(instrument_obj,
                     if isinstance(ret[0], dict):
                         column_val_list = [x['col_val'] for x in ret]
                         mult_label_list = [x['disp_name'] for x in ret]
+                        disp_list = [x['disp'] for x in ret]
                         disp_order_list = [x['disp_order'] for x in ret]
                         grouping_list = [x['grouping'] for x in ret]
                         group_disp_order_list = [x['group_disp_order'] for x in ret]
@@ -1350,7 +1351,9 @@ def import_observation_table(instrument_obj,
 
                 column_val = update_mult_table(
                               table_name, field_name, table_column,
-                              column_val, mult_label, disp_order_list[column_val_num],
+                              column_val, mult_label,
+                              disp_list[column_val_num],
+                              disp_order_list[column_val_num],
                               grouping_list[column_val_num],
                               group_disp_order_list[column_val_num])
 

--- a/opus/import/do_import.py
+++ b/opus/import/do_import.py
@@ -286,8 +286,8 @@ def _mult_table_column_names(table_name):
        constant because various *_target_name tables have an extra
        column used for target name grouping."""
 
-    column_list = ['id', 'value', 'label', 'disp_order', 'display', 'grouping',
-                   'group_disp_order']
+    column_list = ['id', 'value', 'label','disp_order', 'display',
+                   'grouping', 'group_disp_order', 'aliases']
     return column_list
 
 def _convert_sql_response_to_mult_table(mult_table_name, rows):
@@ -295,13 +295,19 @@ def _convert_sql_response_to_mult_table(mult_table_name, rows):
        our internal dictionary representation."""
     mult_rows = []
     for row in rows:
-        (id_num, value, label, disp_order,
-         display, grouping, group_disp_order) = row
+        if len(row) == 8:
+            (id_num, value, label, disp_order,
+             display, grouping, group_disp_order, aliases) = row
+        else:
+            (id_num, value, label, disp_order,
+             display, grouping, group_disp_order) = row
+            aliases = None
 
         row_dict = {
             'id': id_num,
             'value': value,
             'label': str(label),
+            'aliases': aliases,
             'disp_order': disp_order,
             'display': display,
             'grouping': grouping,
@@ -378,8 +384,8 @@ def mult_table_lookup_id(table_name, field_name, table_column, val):
     return None
 
 
-def update_mult_table(table_name, field_name, table_column, val, label, disp='Y',
-                      disp_order=None, grouping=None, group_disp_order=None):
+def update_mult_table(table_name, field_name, table_column, val, label, aliases=None,
+                      disp='Y', disp_order=None, grouping=None, group_disp_order=None):
     """Update a single value in the cached version of a mult table."""
 
     mult_table_name = import_util.table_name_mult(table_name, field_name)
@@ -475,6 +481,7 @@ f'Unable to parse "{label}" for type "range_func_name": {e}')
         'id': next_id,
         'value': val,
         'label': label,
+        'aliases': aliases,
         'disp_order': disp_order,
         'display': disp, # default display: 'Y'
         'grouping': grouping,
@@ -1164,6 +1171,8 @@ def import_observation_table(instrument_obj,
 
             column_val_list = None
             mult_label_list = None
+            aliases_list = None
+            disp_list = None
             disp_order_list = None # Might be set with mult_label but not otherwise
             grouping_list = None
             group_disp_order_list = None
@@ -1189,6 +1198,7 @@ def import_observation_table(instrument_obj,
                     if isinstance(ret[0], dict):
                         column_val_list = [x['col_val'] for x in ret]
                         mult_label_list = [x['disp_name'] for x in ret]
+                        aliases_list = [x['aliases'] for x in ret]
                         disp_list = [x['disp'] for x in ret]
                         disp_order_list = [x['disp_order'] for x in ret]
                         grouping_list = [x['grouping'] for x in ret]
@@ -1352,6 +1362,7 @@ def import_observation_table(instrument_obj,
                 column_val = update_mult_table(
                               table_name, field_name, table_column,
                               column_val, mult_label,
+                              aliases_list[column_val_num],
                               disp_list[column_val_num],
                               disp_order_list[column_val_num],
                               grouping_list[column_val_num],

--- a/opus/import/obs_base.py
+++ b/opus/import/obs_base.py
@@ -354,10 +354,11 @@ class ObsBase(object):
                 planet_id = 'OTHER'
         return PLANET_GROUP_MAPPING[planet_id]
 
-    def _create_mult(self, col_val, disp_name=None, disp_order=None,
+    def _create_mult(self, col_val, disp_name=None, disp='Y', disp_order=None,
                      grouping=None, group_disp_order=None, tooltip=None):
         data_dict = {}
         data_dict['col_val'] = col_val
+        data_dict['disp'] = disp
         data_dict['disp_name'] = disp_name
         data_dict['disp_order'] = disp_order
         data_dict['grouping'] = grouping

--- a/opus/import/obs_base.py
+++ b/opus/import/obs_base.py
@@ -5,6 +5,7 @@
 # It contains information on the observation and basic utility methods.
 ################################################################################
 
+import json
 import pdsfile
 
 from config_targets import (TARGET_NAME_INFO,
@@ -355,7 +356,7 @@ class ObsBase(object):
         return PLANET_GROUP_MAPPING[planet_id]
 
     def _create_mult(self, col_val, disp_name=None, disp='Y', disp_order=None,
-                     grouping=None, group_disp_order=None, tooltip=None):
+                     grouping=None, group_disp_order=None, tooltip=None, aliases=None):
         data_dict = {}
         data_dict['col_val'] = col_val
         data_dict['disp'] = disp
@@ -364,13 +365,21 @@ class ObsBase(object):
         data_dict['grouping'] = grouping
         data_dict['group_disp_order'] = group_disp_order
         data_dict['tooltip'] = tooltip
+        data_dict['aliases'] = json.dumps(aliases) if aliases else None
+        # For testing purpose: uncomment the following code to hide the Dark field
+        # under "Other" in target widget and also store aliases for the field.
+        # if col_val == 'DARK':
+        #     data_dict['disp'] = 'N'
+        #     aliases_list = ['dark_1', 'dark_2', 'dark_3']
+        #     data_dict['aliases'] = json.dumps(aliases_list)
         return data_dict
 
-    def _create_mult_keep_case(self, col_val, disp_order=None, grouping=None,
-                               group_disp_order=None, tooltip=None):
-        return self._create_mult(col_val=col_val, disp_name=col_val,
+    def _create_mult_keep_case(self, col_val, disp='Y', disp_order=None, grouping=None,
+                               group_disp_order=None, tooltip=None, aliases=None):
+        return self._create_mult(col_val=col_val, disp_name=col_val, disp=disp,
                                  disp_order=disp_order, grouping=grouping,
-                                 group_disp_order=group_disp_order, tooltip=tooltip)
+                                 group_disp_order=group_disp_order,
+                                 tooltip=tooltip, aliases=aliases)
 
     def _pdsfile_from_filespec(self, filespec):
         # Create a PdsFile object from a primary filespec.

--- a/opus/import/table_schemas/mult_template.json
+++ b/opus/import/table_schemas/mult_template.json
@@ -38,6 +38,11 @@
         "field_default": null
     },
     {
+        "field_name": "aliases",
+        "field_type": "json",
+        "field_default": null
+    },
+    {
         "field_name": "timestamp",
         "field_type": "timestamp"
     }


### PR DESCRIPTION
- Fixes multi form types for a single widget phase 2 & 3, and #1267 
- Were any Django, import pipeline, or table_schema files modified? Y
  - If YES:
    - Database used: re-import
    - All Django tests pass: Y
    - FLAKE8 run on modified code: Y
- Were any JavaScript or CSS files modified? Y
  - If YES:
    - JSHINT run on all affected files: Y
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): NA
- Was the documentation reviewed for necessary changes or additions? NA
  - About
  - Getting Started
  - FAQ
  - API Guide
  - Tooltips

Description of changes:
- Update _create_mult to:
  - take in disp as a new parameter that will be used to hide/show a mult option.
  - take in aliases as a new parameter that will store a list of aliases for a mult option.
- Add aliases field to mult table (except ones with preprogrammed mult options)
- Add a check mark next to the category that has any children checkboxes checked.

Known problems:
