### PR TITLE
Remove caching of api/fields due to memcached size limit

### DIFF
--- a/opus/application/apps/metadata/views.py
+++ b/opus/application/apps/metadata/views.py
@@ -807,7 +807,7 @@ def get_fields_info(fmt, request, api_code, slug=None, collapse=False):
         entry['full_label'] = f.body_qualified_label_results()
         entry['full_search_label'] = f.body_qualified_label()
         (form_type, form_type_format,
-            form_type_unit_id) = parse_form_type(f.form_type)
+         form_type_unit_id) = parse_form_type(f.form_type)
         entry['default_units'] = get_default_unit(form_type_unit_id)
         entry['available_units'] = get_valid_units(form_type_unit_id)
         if f.old_slug and collapse: # Backwards compatibility

--- a/opus/application/apps/metadata/views.py
+++ b/opus/application/apps/metadata/views.py
@@ -736,7 +736,7 @@ def get_fields_info(fmt, request, api_code, slug=None, collapse=False):
                 disp_order = f.disp_order
                 # A referred slug will never contain a unit specifier
                 f = get_param_info_by_slug(referred_slug, 'col',
-                                            allow_units_override=False)
+                                           allow_units_override=False)
                 f.label = f.body_qualified_label()
                 f.label_results = f.body_qualified_label_results(True)
                 f.referred_slug = referred_slug
@@ -772,14 +772,13 @@ def get_fields_info(fmt, request, api_code, slug=None, collapse=False):
         if collapse:
             collapsed_slug = entry['field_id'] = f.slug.replace('saturn',
                                                                 '<TARGET>')
-            entry['category'] = table_name.label.replace('Saturn',
-                                                            '<TARGET>')
+            entry['category'] = table_name.label.replace('Saturn', '<TARGET>')
         else:
             entry['field_id'] = f.slug
             entry['category'] = table_name.label
         f_type = None
         (form_type, form_type_format,
-            form_type_unit_id) = parse_form_type(f.form_type)
+         form_type_unit_id) = parse_form_type(f.form_type)
         if form_type in settings.RANGE_FORM_TYPES:
             if form_type == 'LONG':
                 f_type = 'range_longitude'

--- a/opus/application/apps/metadata/views.py
+++ b/opus/application/apps/metadata/views.py
@@ -721,120 +721,114 @@ def get_cart_count(session_id):
 # This routine is public because it's called by the API guide in guide/views.py
 def get_fields_info(fmt, request, api_code, slug=None, collapse=False):
     "Helper routine for api_get_fields."
-    cache_key = (settings.CACHE_SERVER_PREFIX + settings.CACHE_KEY_PREFIX
-                 + ':getFields:field:' + str(slug) + ':' + str(collapse))
-    return_obj = cache.get(cache_key)
-    if return_obj is None:
-        if slug:
-            fields = ParamInfo.objects.filter(slug=slug)
+    if slug:
+        fields = ParamInfo.objects.filter(slug=slug)
+    else:
+        fields = ParamInfo.objects.all()
+    fields.order_by('category_name', 'slug')
+    return_obj = {}
+    for f in fields:
+        if not f.slug:
+            # Include referred slug
+            if f.referred_slug is not None:
+                referred_slug = f.referred_slug
+                category = f.category_name
+                disp_order = f.disp_order
+                # A referred slug will never contain a unit specifier
+                f = get_param_info_by_slug(referred_slug, 'col',
+                                            allow_units_override=False)
+                f.label = f.body_qualified_label()
+                f.label_results = f.body_qualified_label_results(True)
+                f.referred_slug = referred_slug
+                f.category_name = category
+                f.disp_order = disp_order
+            else: # pragma: no cover - protection against future bugs
+                # There shouldn't be a case where BOTH the slug and
+                # referred_slug are None, but just to be careful...
+                continue
+        # We cheat with the HTML return because we want to collapse all the
+        # surface geometry down to a single target version to save screen
+        # space. This is a horrible hack, but for right now we just assume
+        # there will always be surface geometry data for Saturn.
+        if (collapse and
+            f.slug.startswith('SURFACEGEO') and
+            not f.slug.startswith('SURFACEGEOsaturn')):
+            continue
+        if f.slug.startswith('**'):
+            # Internal use only
+            continue
+
+        table_name = TableNames.objects.get(table_name=f.category_name)
+        cat = table_name.label
+        if collapse and cat.find('Surface Geometry Constraints') != -1:
+            cat = cat.replace('Saturn', '<TARGET>')
+
+        return_obj[cat] = return_obj.get(cat, {})
+
+        entry = {}
+        return_obj[cat]['table_order'] = table_name.disp_order
+        entry['disp_order'] = f.disp_order
+        collapsed_slug = f.slug
+        if collapse:
+            collapsed_slug = entry['field_id'] = f.slug.replace('saturn',
+                                                                '<TARGET>')
+            entry['category'] = table_name.label.replace('Saturn',
+                                                            '<TARGET>')
         else:
-            fields = ParamInfo.objects.all()
-        fields.order_by('category_name', 'slug')
-        return_obj = {}
-        for f in fields:
-            if not f.slug:
-                # Include referred slug
-                if f.referred_slug is not None:
-                    referred_slug = f.referred_slug
-                    category = f.category_name
-                    disp_order = f.disp_order
-                    # A referred slug will never contain a unit specifier
-                    f = get_param_info_by_slug(referred_slug, 'col',
-                                               allow_units_override=False)
-                    f.label = f.body_qualified_label()
-                    f.label_results = f.body_qualified_label_results(True)
-                    f.referred_slug = referred_slug
-                    f.category_name = category
-                    f.disp_order = disp_order
-                else: # pragma: no cover - protection against future bugs
-                    # There shouldn't be a case where BOTH the slug and
-                    # referred_slug are None, but just to be careful...
-                    continue
-            # We cheat with the HTML return because we want to collapse all the
-            # surface geometry down to a single target version to save screen
-            # space. This is a horrible hack, but for right now we just assume
-            # there will always be surface geometry data for Saturn.
-            if (collapse and
-                f.slug.startswith('SURFACEGEO') and
-                not f.slug.startswith('SURFACEGEOsaturn')):
-                continue
-            if f.slug.startswith('**'):
-                # Internal use only
-                continue
-
-            table_name = TableNames.objects.get(table_name=f.category_name)
-            cat = table_name.label
-            if collapse and cat.find('Surface Geometry Constraints') != -1:
-                cat = cat.replace('Saturn', '<TARGET>')
-
-            return_obj[cat] = return_obj.get(cat, {})
-
-            entry = {}
-            return_obj[cat]['table_order'] = table_name.disp_order
-            entry['disp_order'] = f.disp_order
-            collapsed_slug = f.slug
-            if collapse:
-                collapsed_slug = entry['field_id'] = f.slug.replace('saturn',
-                                                                    '<TARGET>')
-                entry['category'] = table_name.label.replace('Saturn',
-                                                             '<TARGET>')
-            else:
-                entry['field_id'] = f.slug
-                entry['category'] = table_name.label
-            f_type = None
-            (form_type, form_type_format,
-             form_type_unit_id) = parse_form_type(f.form_type)
-            if form_type in settings.RANGE_FORM_TYPES:
-                if form_type == 'LONG':
-                    f_type = 'range_longitude'
-                elif form_type_format is not None:
-                    if form_type_format[-1] == 'd':
-                        f_type = 'range_integer'
-                    elif form_type_format[-1] == 'f':
-                        f_type = 'range_float'
-                    else: # pragma: no cover - error catchall
-                        log.warning('Unparseable form type '+str(f.form_type))
-                elif form_type_unit_id == 'datetime':
-                    f_type = 'range_time'
-                elif form_type_unit_id is not None:
-                    f_type = 'range_special'
+            entry['field_id'] = f.slug
+            entry['category'] = table_name.label
+        f_type = None
+        (form_type, form_type_format,
+            form_type_unit_id) = parse_form_type(f.form_type)
+        if form_type in settings.RANGE_FORM_TYPES:
+            if form_type == 'LONG':
+                f_type = 'range_longitude'
+            elif form_type_format is not None:
+                if form_type_format[-1] == 'd':
+                    f_type = 'range_integer'
+                elif form_type_format[-1] == 'f':
+                    f_type = 'range_float'
                 else: # pragma: no cover - error catchall
-                    f_type = 'Internal Error'
-            elif form_type in settings.MULT_FORM_TYPES:
-                f_type = 'multiple'
-            elif form_type == 'STRING':
-                f_type = 'string'
+                    log.warning('Unparseable form type '+str(f.form_type))
+            elif form_type_unit_id == 'datetime':
+                f_type = 'range_time'
+            elif form_type_unit_id is not None:
+                f_type = 'range_special'
             else: # pragma: no cover - error catchall
-                log.warning('Unparseable form type '+str(f.form_type))
-            entry['type'] = f_type
-            entry['label'] = f.label_results
-            entry['search_label'] = f.label
-            entry['full_label'] = f.body_qualified_label_results()
-            entry['full_search_label'] = f.body_qualified_label()
-            (form_type, form_type_format,
-             form_type_unit_id) = parse_form_type(f.form_type)
-            entry['default_units'] = get_default_unit(form_type_unit_id)
-            entry['available_units'] = get_valid_units(form_type_unit_id)
-            if f.old_slug and collapse: # Backwards compatibility
-                entry['old_slug'] = f.old_slug.replace('saturn', '<TARGET>')
-            else:
-                entry['old_slug'] = f.old_slug
-            entry['slug'] = entry['field_id'] # Backwards compatibility
-            entry['linked'] = True if f.referred_slug else False
-            return_obj[cat][collapsed_slug] = entry
+                f_type = 'Internal Error'
+        elif form_type in settings.MULT_FORM_TYPES:
+            f_type = 'multiple'
+        elif form_type == 'STRING':
+            f_type = 'string'
+        else: # pragma: no cover - error catchall
+            log.warning('Unparseable form type '+str(f.form_type))
+        entry['type'] = f_type
+        entry['label'] = f.label_results
+        entry['search_label'] = f.label
+        entry['full_label'] = f.body_qualified_label_results()
+        entry['full_search_label'] = f.body_qualified_label()
+        (form_type, form_type_format,
+            form_type_unit_id) = parse_form_type(f.form_type)
+        entry['default_units'] = get_default_unit(form_type_unit_id)
+        entry['available_units'] = get_valid_units(form_type_unit_id)
+        if f.old_slug and collapse: # Backwards compatibility
+            entry['old_slug'] = f.old_slug.replace('saturn', '<TARGET>')
+        else:
+            entry['old_slug'] = f.old_slug
+        entry['slug'] = entry['field_id'] # Backwards compatibility
+        entry['linked'] = True if f.referred_slug else False
+        return_obj[cat][collapsed_slug] = entry
 
-        # Organize return_obj before returning
-        # Sort categories by table_order
-        return_obj = dict(sorted(return_obj.items(), key=lambda x: x[1]['table_order']))
-        for cat, cat_data in return_obj.items():
-            del cat_data['table_order']
-            # Sort slugs of each category by disp_order
-            cat_data = dict(sorted(cat_data.items(), key=lambda x: x[1]['disp_order']))
-            return_obj[cat] = cat_data
-            for key, val in cat_data.items():
-                del val['disp_order']
-
-        cache.set(cache_key, return_obj)
+    # Organize return_obj before returning
+    # Sort categories by table_order
+    return_obj = dict(sorted(return_obj.items(), key=lambda x: x[1]['table_order']))
+    for cat, cat_data in return_obj.items():
+        del cat_data['table_order']
+        # Sort slugs of each category by disp_order
+        cat_data = dict(sorted(cat_data.items(), key=lambda x: x[1]['disp_order']))
+        return_obj[cat] = cat_data
+        for key, val in cat_data.items():
+            del val['disp_order']
 
     if fmt == 'raw':
         ret = return_obj

--- a/opus/application/test_api/test_metadata_api.py
+++ b/opus/application/test_api/test_metadata_api.py
@@ -803,23 +803,6 @@ class ApiMetadataTests(TestCase, ApiTestHelper):
             ######### /api/fields: API TESTS #########
             ##########################################
 
-    # Test caching (only visible with code coverage)
-    def test__api_fields_time1_cache(self):
-        "[test_metadata_api.py] /api/fields: time1 json cache"
-        url = '/api/fields/time1.json'
-        expected = {"data": {"General Constraints": {"time1": {"label": "Observation Start Time", "search_label": "Observation Time", "full_label": "Observation Start Time", "full_search_label": "Observation Time [General]", "category": "General Constraints", "slug": "time1", "field_id": "time1", "old_slug": "timesec1", 'linked': False, "default_units": "ymdhms", "available_units": ['ymdhms', 'ydhms', 'jd', 'jed', 'mjd', 'mjed', 'et'], "type": "range_time"}}}}
-        self._run_json_equal(url, expected)
-        url = '/api/fields/time1.json'
-        self._run_json_equal(url, expected)
-        url = '/api/fields/time1.json'
-        self._run_json_equal(url, expected)
-        url = '/api/fields/time1.json'
-        self._run_json_equal(url, expected)
-        url = '/api/fields/time1.json'
-        self._run_json_equal(url, expected)
-        url = '/api/fields/time1.json'
-        self._run_json_equal(url, expected)
-
     def test__api_fields_time1_json(self):
         "[test_metadata_api.py] /api/fields: time1 json"
         url = '/api/fields/time1.json'
@@ -867,35 +850,3 @@ class ApiMetadataTests(TestCase, ApiTestHelper):
         url = '/api/fields.json?collapse=X'
         self._run_status_equal(url, 404,
                                HTTP404_BAD_COLLAPSE('X', '/api/fields.json'))
-
-    def test__api_fields_all_cache(self):
-        "[test_metadata_api.py] /api/fields: all json cache"
-        url = '/api/fields.json'
-        print(url)
-        response = self._get_response(url)
-        self.assertEqual(response.status_code, 200)
-        jdata1 = json.loads(response.content)
-        url = '/api/fields.json'
-        print(url)
-        response = self._get_response(url)
-        self.assertEqual(response.status_code, 200)
-        jdata2 = json.loads(response.content)
-        url = '/api/fields.json?collapse=1'
-        print(url)
-        response = self._get_response(url)
-        self.assertEqual(response.status_code, 200)
-        jdatac1 = json.loads(response.content)
-        url = '/api/fields.json'
-        print(url)
-        response = self._get_response(url)
-        self.assertEqual(response.status_code, 200)
-        jdata3 = json.loads(response.content)
-        url = '/api/fields.json?collapse=1'
-        print(url)
-        response = self._get_response(url)
-        self.assertEqual(response.status_code, 200)
-        jdatac2 = json.loads(response.content)
-        self.assertEqual(jdata1, jdata2)
-        self.assertEqual(jdata2, jdata3)
-        self.assertEqual(jdatac1, jdatac2)
-        self.assertNotEqual(jdata1, jdatac1)


### PR DESCRIPTION
- Fixes #1294 
- Were any Django, import pipeline, or table_schema files modified? Y
  - If YES:
    - Database used (or new import): opus3_test_221201
    - FLAKE8 run on modified code: Y
    - All Django tests pass: Y
    - Code coverage run and still at 100%: Y
- Were any JavaScript or CSS files modified? N
  - If YES:
    - JSHINT run on all affected files: Y/NA
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y/NA
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): Y/NA
- Was the documentation reviewed for necessary changes or additions? NA
  - About
  - Getting Started
  - FAQ
  - API Guide
  - Tooltips
  - Import/database schema

Description of changes:

memcached has a 1MB limit on cached data, which we now exceed when returning /api/fields.json with a full database (but not with a test database). Caching has been removed for this API call and the relevant tests have also been removed.

Known problems:

/api/fields is now slower...
