### PR TITLE
1284 opus freeze if spinner delay not met on search tab

### DIFF
--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -2429,6 +2429,8 @@ var o_browse = {
             if (startObs === firstObs && firstObs !== 1) {
                 $(`${tab} ${contentsView}`).trigger("ps-scroll-up");
             }
+
+            o_browse.hidePageLoaderSpinner();
         });
     },
 
@@ -2475,6 +2477,7 @@ var o_browse = {
             // when browser is resized in the middle of infiniteScroll load.
             o_browse.updateSliderHandle(view, false, true);
         }
+        o_browse.hidePageLoaderSpinner();
     },
 
     activateBrowseTab: function() {

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -2429,7 +2429,6 @@ var o_browse = {
             if (startObs === firstObs && firstObs !== 1) {
                 $(`${tab} ${contentsView}`).trigger("ps-scroll-up");
             }
-
             o_browse.hidePageLoaderSpinner();
         });
     },

--- a/opus/application/static_media/js/cart.js
+++ b/opus/application/static_media/js/cart.js
@@ -593,6 +593,7 @@ var o_cart = {
 
             $.getJSON(url, function(data) {
                 if (data.reqno < o_cart.lastProductCountRequestNo) {
+                    o_browse.hidePageLoaderSpinner();
                     return;
                 }
                 // this div lives in the nav menu template
@@ -653,6 +654,8 @@ var o_cart = {
                         $(`.op-cart-deselect-btn[data-category="${productCategory}"]`).prop("disabled", true);
                     }
                 }
+
+                o_browse.hidePageLoaderSpinner();
             });
         } else {
             // Make sure "Add all results to cart" is still hidden in cart tab when user switches

--- a/opus/application/static_media/js/cart.js
+++ b/opus/application/static_media/js/cart.js
@@ -654,7 +654,6 @@ var o_cart = {
                         $(`.op-cart-deselect-btn[data-category="${productCategory}"]`).prop("disabled", true);
                     }
                 }
-
                 o_browse.hidePageLoaderSpinner();
             });
         } else {

--- a/opus/application/static_media/js/menu.js
+++ b/opus/application/static_media/js/menu.js
@@ -61,6 +61,7 @@ var o_menu = {
 
         $.getJSON(url, function(data) {
             if (data.reqno < o_menu.lastSearchMenuRequestNo) {
+                clearTimeout(spinnerTimer);
                 return;
             }
             $("#sidebar").html(data.html);

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -41,7 +41,6 @@ var opus = {
     searchChangeDelay: 1000, // How long to wait after a search changes to do the new search
     spinnerDelay: 250, // The amount of time to wait before showing a spinner in case the API returns quickly
 
-
     // avoiding race conditions in ajax calls
     lastAllNormalizeRequestNo: 0,
     lastResultCountRequestNo: 0,

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -39,8 +39,8 @@ var opus = {
     defaultWidgets: DEFAULT_WIDGETS.split(","),
 
     searchChangeDelay: 1000, // How long to wait after a search changes to do the new search
-    // spinnerDelay: 250, // The amount of time to wait before showing a spinner in case the API returns quickly
-    spinnerDelay: 3000, // The amount of time to wait before showing a spinner in case the API returns quickly
+    spinnerDelay: 250, // The amount of time to wait before showing a spinner in case the API returns quickly
+
 
     // avoiding race conditions in ajax calls
     lastAllNormalizeRequestNo: 0,

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -39,7 +39,8 @@ var opus = {
     defaultWidgets: DEFAULT_WIDGETS.split(","),
 
     searchChangeDelay: 1000, // How long to wait after a search changes to do the new search
-    spinnerDelay: 250, // The amount of time to wait before showing a spinner in case the API returns quickly
+    // spinnerDelay: 250, // The amount of time to wait before showing a spinner in case the API returns quickly
+    spinnerDelay: 3000, // The amount of time to wait before showing a spinner in case the API returns quickly
 
     // avoiding race conditions in ajax calls
     lastAllNormalizeRequestNo: 0,

--- a/opus/application/static_media/js/selectMetadata.js
+++ b/opus/application/static_media/js/selectMetadata.js
@@ -160,11 +160,14 @@ var o_selectMetadata = {
     },
 
     showMenuLoaderSpinner: function() {
-        o_selectMetadata.spinnerTimer = setTimeout(function() {
-            $(".op-select-metadata-load-status > .loader").show();
-            $(".op-select-metadata-row-contents").css("opacity", "0.1");
-            o_utils.disableUserInteraction();
-        }, opus.spinnerDelay);
+        if (o_selectMetadata.spinnerTimer === null) {
+            o_selectMetadata.spinnerTimer = setTimeout(function() {
+                $(".op-select-metadata-load-status > .loader").show();
+                $(".op-select-metadata-row-contents").css("opacity", "0.1");
+                o_utils.disableUserInteraction();
+            }, opus.spinnerDelay);
+        }
+
     },
 
     hideMenuLoaderSpinner: function() {
@@ -213,6 +216,7 @@ var o_selectMetadata = {
 
             $.getJSON(url, function(data) {
                 if (data.reqno < o_selectMetadata.lastMetadataMenuRequestNo) {
+                    o_selectMetadata.hideMenuLoaderSpinner()
                     return;
                 }
                 // cleanup first
@@ -307,6 +311,7 @@ var o_selectMetadata = {
                 o_selectMetadata.adjustHeight();
                 o_selectMetadata.hideOrShowPS();
                 o_selectMetadata.hideOrShowMenuPS();
+                console.log("hide loader in o selectMetadta")
                 o_selectMetadata.hideMenuLoaderSpinner();
                 o_selectMetadata.rendered = true;
             });

--- a/opus/application/static_media/js/selectMetadata.js
+++ b/opus/application/static_media/js/selectMetadata.js
@@ -311,7 +311,6 @@ var o_selectMetadata = {
                 o_selectMetadata.adjustHeight();
                 o_selectMetadata.hideOrShowPS();
                 o_selectMetadata.hideOrShowMenuPS();
-                console.log("hide loader in o selectMetadta")
                 o_selectMetadata.hideMenuLoaderSpinner();
                 o_selectMetadata.rendered = true;
             });

--- a/opus/application/static_media/js/sortMetadata.js
+++ b/opus/application/static_media/js/sortMetadata.js
@@ -109,6 +109,7 @@ let o_sortMetadata = {
 
             o_hash.updateURLFromCurrentHash();
             o_sortMetadata.renderSortedDataFromBeginning();
+            o_browse.hidePageLoaderSpinner();
         });
 
         $(".op-sort-contents").on("click", ".op-sort-order-add-icon", function(e) {
@@ -188,6 +189,7 @@ let o_sortMetadata = {
 
         o_hash.updateURLFromCurrentHash();
         o_sortMetadata.renderSortedDataFromBeginning();
+        o_browse.hidePageLoaderSpinner();
     },
 
     hideMenu: function() {


### PR DESCRIPTION
- Fixes #1284 
- Were any Django, import pipeline, or table_schema files modified? N
  - If YES:
    - Database used (or new import): opus3_test_230109
    - FLAKE8 run on modified code: Y/NA
    - All Django tests pass: Y
    - Code coverage run and still at 100%: Y
- Were any JavaScript or CSS files modified? Y
  - If YES:
    - JSHINT run on all affected files: Y
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: NA
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): NA
- Was the documentation reviewed for necessary changes or additions? NA
  - About
  - Getting Started
  - FAQ
  - API Guide
  - Tooltips
  - Import/database schema

Description of changes:
- The opus freeze is coming from ```o_utils.disableUserInteraction()``` and the spinner on the screen is coming from ```$(".op-select-metadata-load-status > .loader")``` in ```showMenuLoaderSpinner``` function. To fix the issue, a if check is added to make sure the spinner timer is not set again when it has already been set.
Known problems:
