### PR TITLE
Fixed multiple tooltips issues (1265, 1273, 1274)

### DIFF
--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1908,7 +1908,7 @@ var o_browse = {
             // move around the same row in the browse table view. Without this
             // function, the tooltip will always open in the middle of the row.
             functionPosition: function(instance, helper, position){
-                return o_utils.setPreviewImageTooltipPosition(helper, position);
+                return o_utils.setTableColumnToolTipPostion(helper, position);
             }
         });
 

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1828,7 +1828,7 @@ var o_browse = {
 
                 // detail overlay
                 let hideDetail = (opus.prefs.detail === opusId ?  "" : "op-hide-element");
-                galleryHtml += `<div class="op-detail-overlay text-success op-browse-gallery-tooltip ${hideDetail}" title="Shown on Detail tab"></div>`;
+                galleryHtml += `<div class="op-detail-overlay text-success op-browse-gallery-detail-tooltip ${hideDetail}" title="Shown on Detail tab"></div>`;
 
                 galleryHtml += '<div class="op-thumb-overlay">';
                 galleryHtml += `<div class="op-tools dropdown" data-id="${opusId}">`;
@@ -1891,6 +1891,22 @@ var o_browse = {
             contentAsHTML: true,
             debug: false,
         });
+
+        // For the tooltip of the "Detail" icon on the gallery view
+        $(`${tab} .op-browse-gallery-detail-tooltip`).tooltipster({
+            maxWidth: opus.tooltipsMaxWidth,
+            theme: opus.tooltipsTheme,
+            delay: opus.tooltipsDelay,
+            contentAsHTML: true,
+            debug: false,
+            functionPosition: function(instance, helper, position){
+                // Set the tooltip postion next to the "Detail icon"
+                position.target += $(`${tab} .op-thumbnail-container`).width();
+                return position
+            }
+        });
+
+        // For the tooltips of the table view
         $(`${tab} .op-browse-table-tooltip`).tooltipster({
             maxWidth: opus.tooltipsMaxWidth,
             theme: opus.tooltipsTheme,

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1819,7 +1819,7 @@ var o_browse = {
                 galleryHtml += '<div class="op-modal-overlay">';
                 galleryHtml += '<p class="content-text"><i class="fas fa-binoculars fa-4x text-info" aria-hidden="true"></i></p>';
                 galleryHtml += '</div></a>';
-                galleryHtml += `<div class="op-last-modal-overlay text-success op-hide-element op-browse-gallery-tooltip" title="Last viewed in slideshow mode"></div>`;
+                galleryHtml += `<div class="op-last-modal-overlay text-success op-hide-element op-browse-gallery-bino-tooltip" title="Last viewed in slideshow mode"></div>`;
 
                 // recycle bin icon container
                 galleryHtml += `<div class="op-recycle-overlay ${((tab === "#cart" && item.cart_state === "recycle") ? '' : 'op-hide-element')} op-browse-gallery-tooltip" title="${mainTitle}">`;
@@ -1900,8 +1900,24 @@ var o_browse = {
             contentAsHTML: true,
             debug: false,
             functionPosition: function(instance, helper, position){
-                // Set the tooltip postion next to the "Detail icon"
+                // Set the tooltip postion next to the "Detail" icon
                 position.target += $(`${tab} .op-thumbnail-container`).width();
+                return position
+            }
+        });
+
+        // For the tooltip of the binoculars icon on the gallery view
+        $(`${tab} .op-browse-gallery-bino-tooltip`).tooltipster({
+            maxWidth: opus.tooltipsMaxWidth,
+            theme: opus.tooltipsTheme,
+            delay: opus.tooltipsDelay,
+            contentAsHTML: true,
+            debug: false,
+            functionPosition: function(instance, helper, position){
+                // Set the tooltip postion next to the bincoulars icon, 10 is the offest
+                // to move the tooltip to the top of the binoculars icon. Without the offset,
+                // tooltip will be on the top left corner of the binoculars icon.
+                position.target -= ($(`${tab} .op-thumbnail-container`).width()/2 - 10);
                 return position
             }
         });

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -8,6 +8,7 @@
 /* globals MAX_SELECTIONS_ALLOWED */
 
 const infiniteScrollUpThreshold = 100;
+const galleryAndTableTooltipsDelay = 1000;
 
 /* jshint varstmt: false */
 var o_browse = {
@@ -1887,7 +1888,7 @@ var o_browse = {
         $(`${tab} .op-browse-gallery-tooltip`).tooltipster({
             maxWidth: opus.tooltipsMaxWidth,
             theme: opus.tooltipsTheme,
-            delay: opus.tooltipsDelay,
+            delay: galleryAndTableTooltipsDelay,
             contentAsHTML: true,
             debug: false,
         });
@@ -1928,7 +1929,7 @@ var o_browse = {
         $(`${tab} .op-browse-table-tooltip`).tooltipster({
             maxWidth: opus.tooltipsMaxWidth,
             theme: opus.tooltipsTheme,
-            delay: opus.tooltipsDelay,
+            delay: galleryAndTableTooltipsDelay,
             contentAsHTML: true,
             debug: false,
             functionBefore: function(instance, helper){

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1820,7 +1820,7 @@ var o_browse = {
                 galleryHtml += '<div class="op-modal-overlay">';
                 galleryHtml += '<p class="content-text"><i class="fas fa-binoculars fa-4x text-info" aria-hidden="true"></i></p>';
                 galleryHtml += '</div></a>';
-                galleryHtml += `<div class="op-last-modal-overlay text-success op-hide-element op-browse-gallery-bino-tooltip" title="Last viewed in slideshow mode"></div>`;
+                galleryHtml += `<div class="op-last-modal-overlay text-success op-hide-element op-browse-gallery-binocular-tooltip" title="Last viewed in slideshow mode"></div>`;
 
                 // recycle bin icon container
                 galleryHtml += `<div class="op-recycle-overlay ${((tab === "#cart" && item.cart_state === "recycle") ? '' : 'op-hide-element')} op-browse-gallery-tooltip" title="${mainTitle}">`;
@@ -1910,7 +1910,7 @@ var o_browse = {
         });
 
         // For the tooltip of the binoculars icon on the gallery view
-        $(`${tab} .op-browse-gallery-bino-tooltip`).tooltipster({
+        $(`${tab} .op-browse-gallery-binocular-tooltip`).tooltipster({
             maxWidth: opus.tooltipsMaxWidth,
             theme: opus.tooltipsTheme,
             delay: opus.tooltipsDelay,

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1900,9 +1900,11 @@ var o_browse = {
             contentAsHTML: true,
             debug: false,
             functionPosition: function(instance, helper, position){
-                // Set the tooltip postion next to the "Detail" icon
+                // Set the tooltip postion next to the "Detail" icon, 10 is the offset to move
+                // the tooltip to the upper middle of the "Detail" icon.
+                position.coord.left += 10;
                 position.target += $(`${tab} .op-thumbnail-container`).width();
-                return position
+                return position;
             }
         });
 
@@ -1918,7 +1920,7 @@ var o_browse = {
                 // to move the tooltip to the top of the binoculars icon. Without the offset,
                 // tooltip will be on the top left corner of the binoculars icon.
                 position.target -= ($(`${tab} .op-thumbnail-container`).width()/2 - 10);
-                return position
+                return position;
             }
         });
 

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -3009,16 +3009,16 @@ var o_browse = {
             let buttonInfo = o_browse.cartButtonInfo(action);
 
             // prev/next buttons - put this in op-metadata-detail-view html...
-            let html = `<div class="col"><a href="#" class="op-cart-toggle op-metadatabox-tooltip" data-id="${opusId}" title="${buttonInfo[tab].title} (or press spacebar)"><i class="${buttonInfo[tab].icon} fa-2x float-left"></i></a></div>`;
+            let html = `<div class="col"><a href="#" class="op-cart-toggle" data-id="${opusId}"><i class="${buttonInfo[tab].icon} fa-2x float-left op-metadatabox-tooltip" title="${buttonInfo[tab].title} (or press spacebar)"></i></a></div>`;
             html += `<div class="col text-center op-obs-direction">`;
             let opPrevDisabled = (nextPrevHandles.prev == "" ? "op-button-disabled" : "");
             let opNextDisabled = (nextPrevHandles.next == "" ? "op-button-disabled" : "");
-            html += `<a href="#" class="op-prev text-center ${opPrevDisabled} op-metadatabox-tooltip" data-id="${nextPrevHandles.prev}" title="Previous image: ${nextPrevHandles.prev} (left arrow key)"><i class="far fa-arrow-alt-circle-left fa-2x"></i></a>`;
-            html += `<a href="#" class="op-next ${opNextDisabled} op-metadatabox-tooltip" data-id="${nextPrevHandles.next}" title="Next image: ${nextPrevHandles.next} (right arrow key)"><i class="far fa-arrow-alt-circle-right fa-2x"></i></a>`;
+            html += `<a href="#" class="op-prev text-center ${opPrevDisabled}" data-id="${nextPrevHandles.prev}"><i class="far fa-arrow-alt-circle-left fa-2x  op-metadatabox-tooltip" title="Previous image: ${nextPrevHandles.prev} (left arrow key)"></i></a>`;
+            html += `<a href="#" class="op-next ${opNextDisabled}" data-id="${nextPrevHandles.next}"><i class="far fa-arrow-alt-circle-right fa-2x op-metadatabox-tooltip" title="Next image: ${nextPrevHandles.next} (right arrow key)"></i></a>`;
             html += `</div>`;
 
             // mini-menu like the hamburger on the observation/gallery page
-            html += `<div class="col text-start"><a href="#" class="menu pe-3 float-end text-center op-metadatabox-tooltip" role="button" data-id="${opusId}" title="More options"><i class="fas fa-bars fa-2x"></i></a></div>`;
+            html += `<div class="col text-start"><a href="#" class="menu pe-3 float-end text-center" role="button" data-id="${opusId}"><i class="fas fa-bars fa-2x op-metadatabox-tooltip" title="More options"></i></a></div>`;
             $(".op-metadata-detail-view-body .bottom").html(html);
 
             // update the binoculars here
@@ -3040,6 +3040,7 @@ var o_browse = {
                 maxWidth: opus.tooltipsMaxWidth,
                 theme: opus.tooltipsTheme,
                 delay: opus.tooltipsDelay,
+
             });
 
             $(".op-metadatabox-img-tooltip").tooltipster({

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -2989,6 +2989,7 @@ var o_browse = {
             maxWidth: opus.tooltipsMaxWidth,
             theme: opus.tooltipsTheme,
             delay: opus.tooltipsDelay,
+            side: "left",
         });
 
         // if it was last in edit mode, open in edit mode...

--- a/opus/application/static_media/js/utils.js
+++ b/opus/application/static_media/js/utils.js
@@ -141,6 +141,33 @@ var o_utils = {
         }, opus.tooltipsDelay);
     },
 
+    setTableColumnToolTipPostion: function(helper, position) {
+        let tooltipWidth = position.size.width;
+        let tooltipHeight = position.size.height;
+        let offsetToWindow = 5;
+        let arrowOffset = 15;
+        let windowWidth = helper.geo.window.size.width;
+        // make sure the tooltip is not cut off.
+        if (opus.mouseY - tooltipHeight - offsetToWindow < 0) {
+            position.side = "bottom";
+        } else {
+            position.side = "top";
+        }
+        // Make sure tooltip stay at the top border of the table row.
+        position.coord.top += 5
+
+        if (opus.mouseX + tooltipWidth + offsetToWindow > windowWidth) {
+            position.coord.left = opus.mouseX - tooltipWidth + arrowOffset;
+        } else if (opus.mouseX - tooltipWidth - offsetToWindow < 0) {
+            position.coord.left = opus.mouseX - arrowOffset;
+        } else {
+            position.coord.left = opus.mouseX - tooltipWidth/2;
+        }
+
+        position.target = opus.mouseX;
+        return position;
+    },
+
     // Set the position of the preview image tooltip
     setPreviewImageTooltipPosition: function(helper, position) {
         let tooltipWidth = position.size.width;

--- a/opus/application/static_media/js/utils.js
+++ b/opus/application/static_media/js/utils.js
@@ -145,7 +145,7 @@ var o_utils = {
                 try {
                     targetTooltipster.tooltipster("instance").reposition();
                 } catch (e) {
-                    return
+                    return;
                 }
             }
         }, opus.tooltipsDelay);

--- a/opus/application/static_media/js/utils.js
+++ b/opus/application/static_media/js/utils.js
@@ -164,7 +164,7 @@ var o_utils = {
             position.side = "top";
         }
         // Make sure tooltip stay at the top border of the table row.
-        position.coord.top += 5
+        position.coord.top += 5;
 
         if (opus.mouseX + tooltipWidth + offsetToWindow > windowWidth) {
             position.coord.left = opus.mouseX - tooltipWidth + arrowOffset;

--- a/opus/application/static_media/js/utils.js
+++ b/opus/application/static_media/js/utils.js
@@ -136,7 +136,17 @@ var o_utils = {
         opus.mouseY = e.clientY;
         opus.timer = setTimeout(function() {
             if (targetTooltipster.length) {
-                targetTooltipster.tooltipster("instance").reposition();
+                // If the table sorting (redrawing) happened right at the moment when a tooltips instance
+                // is about to reposition, an error message will complain about we try access an
+                // uninitialized element (due to table redrawing). We don't need to worry about this error
+                // because the tooltip instance will get initialized again once redrawing is done and no
+                // weird behavior with this. Instead of removing and adding this event listener again, we
+                // ignore this error when it happens.
+                try {
+                    targetTooltipster.tooltipster("instance").reposition();
+                } catch (e) {
+                    return
+                }
             }
         }, opus.tooltipsDelay);
     },


### PR DESCRIPTION
- Fixes #1265 Fixed #1273 Fixed #1274
- Were any Django, import pipeline, or table_schema files modified? N
  - If YES:
    - Database used (or new import): opus3_test_230109
    - FLAKE8 run on modified code: Y
    - All Django tests pass: Y
    - Code coverage run and still at 100%: Y
- Were any JavaScript or CSS files modified? Y
  - If YES:
    - JSHINT run on all affected files: Y
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): NA
- Was the documentation reviewed for necessary changes or additions? NA
  - About
  - Getting Started
  - FAQ
  - API Guide
  - Tooltips
  - Import/database schema

Description of changes:
- Update the position of browse table row tooltips, instead of sticking to the cursor, it will now stay at the top border of the table row. (1265, 1274)
- Update the position of the gallery "Detail" icon tooltip, it will now stay at the top of the "Detail" icon. (1273)
- Update the position of the gallery binoculars icon tooltip, it's now at the top of the binoculars icon. (1273)
- Update the position of "+" and trash icons tooltips in the edit menu of metadata detail box, now they will show up at the left of the icons (won't block the menu). (1274)
- Fixed the positions of the tooltips for cart, hamburger, prev, and next icons in metadata box, now tooltips will show up at the centered top of the icons. (1274)
- Increase the delay of tooltips on the gallery and table view, change from 0.5s to 1s. (1274)

Known problems:
- Was not able to reproduce the issue that tooltips of the table view show up at bad location when sorting is happening (1265) 
