### PR TITLE
Fixed the issue of download error modal blocked by download pane when the screen is small

### DIFF
--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -1930,12 +1930,24 @@ is wide enough */
     display: none;
     position: absolute;
     left: 0;
-    z-index: 9999;
+    /* Make sure this value is larger than the z-index of .op-overlay and smaller than
+    the z-index of #op-download-links-error-msg-modal */
+    z-index: 9998;
     top: 2em;
     /* Fix the width of the panel so that it will increase when browser
     is wider*/
     width: 36em;
 }
+
+/* Download error modal */
+#op-download-links-error-msg-modal {
+    z-index: 9999;
+    /* Add a transparent black background as an extra backdrop to cover the download
+    panel when the screen is small */
+    background: rgba(0, 0, 0, 0.3);
+}
+
+
 
 /* Make sure "x" and download data title in header of download data
 panel are properly separated */


### PR DESCRIPTION
- Fixes #1275 
- Were any Django, import pipeline, or table_schema files modified? N
  - If YES:
    - Database used (or new import): opus3_test_230109
    - FLAKE8 run on modified code: Y
    - All Django tests pass: Y
    - Code coverage run and still at 100%: Y
- Were any JavaScript or CSS files modified? Y/N
  - If YES:
    - JSHINT run on all affected files: Y/NA
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y/NA
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): Y/NA
- Was the documentation reviewed for necessary changes or additions? Y/NA
  - About
  - Getting Started
  - FAQ
  - API Guide
  - Tooltips
  - Import/database schema

Description of changes:
Update css to make sure the download error modal is not blocked by the download pane when the screen is small.

Known problems:
NA