### PR TITLE
Fixed the missing green strike-thru disappear after refreshing the page and clean up jshint warnings

### DIFF
--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -1950,6 +1950,11 @@ panel are properly separated */
     margin-bottom: 0;
 }
 
+/* Override the table row (.table > :not(caption) > * > *) color in style.css */
+.text-success td {
+    color: var(--cui-success, #2eb85c) !important;
+}
+
 .op-sort-order-container {
     display: inline-flex;
     padding-left: 0.5em;

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -1841,7 +1841,7 @@ var o_browse = {
 
                 // table row
                 let checked = item.cart_state === "cart" ? " checked" : "";
-                let recycled = (tab === "#cart" && item.cart_state === "recycle") ? "class='text-success op-recycled'" : "";
+                let recycled = (tab === "#cart" && item.cart_state === "recycle") ? "text-success op-recycled" : "";
                 let checkbox = `<input type="checkbox" name="${opusId}" value="${opusId}" class="multichoice"${checked}/>`;
                 let minimenu = `<a class="op-browse-table-tooltip" href="#" data-icon="menu" title="More options"><i class="fas fa-bars fa-xs"></i></a>`;
                 let row = `<td class="op-table-tools"><div class="op-tools mx-0 form-group op-browse-table-tooltip" title="Click to ${buttonInfo[tab].title.toLowerCase()}<br>Shift+click to start/end range" data-id="${opusId}">${checkbox} ${minimenu}</div></td>`;
@@ -1849,7 +1849,7 @@ var o_browse = {
                 let miniThumbnail = `<img class="op-browse-table-tooltip" src="${images.thumb.url}" alt="${images.thumb.alt_text}" title="${mainTitle}">`;
                 row += `<td class="op-mini-thumbnail op-mini-thumbnail-zoom"><div>${miniThumbnail}</div></td>`;
 
-                let tr = `<tr class="op-browse-table-tooltip" data-id="${opusId}" ${recycled} data-bs-target="#op-metadata-detail-view" data-obs="${item.obs_num}" title="${mainTitle}">`;
+                let tr = `<tr class="op-browse-table-tooltip ${recycled}" data-id="${opusId}" data-bs-target="#op-metadata-detail-view" data-obs="${item.obs_num}" title="${mainTitle}">`;
                 $.each(item.metadata, function(idx, cell) {
                     let slug = slugs[idx];
                     slug = o_utils.getSlugWithoutUnit(slug);

--- a/opus/application/static_media/js/cart.js
+++ b/opus/application/static_media/js/cart.js
@@ -524,9 +524,9 @@ var o_cart = {
 
         // update the panel numbers if we received them...
         if (status.product_cat_dict !== undefined) {
-            for (let pretty_name in status.product_cat_dict) {
+            for (let pretty_name of Object.keys(status.product_cat_dict)) {
                 let prod = status.product_cat_dict[pretty_name];
-                for (let ver in prod) {
+                for (let ver of Object.keys(prod)) {
                     let slugList = prod[ver];
                     for (let slugNdx = 0; slugNdx < slugList.length; slugNdx++) {
                         let slugName = slugList[slugNdx].slug_name;

--- a/opus/application/static_media/js/detail.js
+++ b/opus/application/static_media/js/detail.js
@@ -105,7 +105,7 @@ var o_detail = {
                     });
 
                     for (let idx = 0; idx < categories.length; idx++) {
-                        const currentDeferred =  arrOfDeferred[idx];
+                        const currentDeferred = arrOfDeferred[idx];
                         let tableName = categories[idx].table_name;
                         let label = categories[idx].label;
                         let html = '<h3>' + label + '</h3><div class="detail_' + tableName + '">Loading <span class="spinner">&nbsp;</span></div>';

--- a/opus/application/static_media/js/detail.js
+++ b/opus/application/static_media/js/detail.js
@@ -104,18 +104,18 @@ var o_detail = {
                         arrOfDeferred.push($.Deferred());
                     });
 
-                    for (let index in categories) {
-                        let tableName = categories[index].table_name;
-                        let label = categories[index].label;
+                    for (let idx = 0; idx < categories.length; idx++) {
+                        const currentDeferred =  arrOfDeferred[idx];
+                        let tableName = categories[idx].table_name;
+                        let label = categories[idx].label;
                         let html = '<h3>' + label + '</h3><div class="detail_' + tableName + '">Loading <span class="spinner">&nbsp;</span></div>';
                         $("#all_metadata_" + opusId).append(html);
 
                         // now send for data
                         let urlMetadata = `/opus/__api/metadata/${opusId}.html?cats=${tableName}&url_cols=${colStr}`;
-                        $("#all_metadata_" + opusId + ' .detail_' + tableName)
-                            .load(urlMetadata, function() {
+                        $("#all_metadata_" + opusId + ' .detail_' + tableName).load(urlMetadata, function() {
                                 $(this).hide().slideDown("fast");
-                                arrOfDeferred[index].resolve();
+                                currentDeferred.resolve();
                             }
                         );
 
@@ -180,7 +180,11 @@ var o_detail = {
             textArea.select();
             return new Promise((res, rej) => {
                 // here the magic happens
-                document.execCommand('copy') ? res() : rej();
+                if (document.execCommand('copy')) {
+                    res();
+                } else {
+                    rej();
+                }
                 textArea.remove();
             });
         }

--- a/opus/application/static_media/js/dictionary.js
+++ b/opus/application/static_media/js/dictionary.js
@@ -1,38 +1,48 @@
-String.replacei = String.prototype.replacei = function(rep, rby) {
-    var pos = this.toLowerCase().indexOf(rep.toLowerCase());
+/* jshint esversion: 6 */
+/* jshint bitwise: true, curly: true, freeze: true, futurehostile: true */
+/* jshint latedef: true, leanswitch: true, noarg: true, nocomma: true */
+/* jshint nonbsp: true, nonew: true */
+/* jshint varstmt: true */
+/* jshint multistr: true */
+/* globals $ */
+
+String.replacei = Object.defineProperty(String.prototype, "replacei", {
+  value: function(rep, rby) {
+    let pos = this.toLowerCase().indexOf(rep.toLowerCase());
     return pos == -1 ? this : this.substr(0, pos) + rby + this.substr(pos + rep.length);
-};
+  }
+});
 
 function removeSpecialChars(str) {
-  var html = $.parseHTML(str); //we have to double munge it to get rid of tags since we start  with escape chars
+  let html = $.parseHTML(str); //we have to double munge it to get rid of tags since we start  with escape chars
   html = $.parseHTML($(html).text());
-  var text = $(html).text();
+  let text = $(html).text();
   return text;
 }
 
 function postContents(response, searchText) {
-  var html = "";
-  definition = removeSpecialChars(response.definition);
+  let html = "";
+  let definition = removeSpecialChars(response.definition);
   if (searchText != undefined) {
     definition = definition.replacei(searchText, "<mark class='search'>"+searchText+"</mark>");
   }
-  var context = (response.context__description == undefined ? response.context: response.context__description);
+  let context = (response.context__description == undefined ? response.context: response.context__description);
   html += "<div class='context'>" + context + "</div></br>";
   html += "<div class='description'>" + definition + "</div></br>";
-  var timestamp = (response.term__timestamp == undefined ? response.timestamp: response.term__timestamp);
+  let timestamp = (response.term__timestamp == undefined ? response.timestamp: response.term__timestamp);
   html += "<div class='importDate'>" + timestamp + "</div></br>";
   return html;
 }
 
 function buildDefinitionListHTML(response, searchText) {
-  var length = response.length;
-  var html = "<div class='definitionList'>";
+  let length = response.length;
+  let html = "<div class='definitionList'>";
   if (length > 0) {
     html += "<ul>";
-    for (var index = 0; index < length; index++) {
-      var next =index + 1;
-      var term = (response[index].term__term_nice === undefined ? response[index].term : response[index].term__term_nice);
-      var term_next = (next < length && (response[next].term__term_nice === undefined ? response[next].term : response[next].term__term_nice));
+    for (let index = 0; index < length; index++) {
+      let next =index + 1;
+      let term = (response[index].term__term_nice === undefined ? response[index].term : response[index].term__term_nice);
+      let term_next = (next < length && (response[next].term__term_nice === undefined ? response[next].term : response[next].term__term_nice));
 
       html += "<li>";
       html += "<div class='term'>" + term.replace(/:/g, ": ").replace(/_/g, " ").toTitleCase() + "</div></br>";
@@ -56,17 +66,17 @@ function buildDefinitionListHTML(response, searchText) {
 }
 
 function searchDictionary(searchText, thepanel) {
-  var url = "/__dictionary/search.json?term=" + searchText;
+  let url = "/__dictionary/search.json?term=" + searchText;
   $.getJSON(url, function(response) {
-      var html = buildDefinitionListHTML(response, searchText);
+      let html = buildDefinitionListHTML(response, searchText);
       thepanel.html(html);
   });
 }
 
 $( function() {
-  var currentElement = "";
+  let currentElement = "";
   $( ".alphabetlist").click(function(event) {
-    var targetElement = 'def-'+event.currentTarget.id;
+    let targetElement = 'def-'+event.currentTarget.id;
     if (currentElement != targetElement) {
       if (currentElement != "") {
         $("#"+currentElement).hide();
@@ -75,9 +85,9 @@ $( function() {
     }
     if ($("#"+targetElement).length == 0) {
       $("#dictionaryContainer").append("<div id='"+targetElement+"' class='dictionaryContent'>Loading... please wait.</div>");
-      var url = "/__dictionary/list.json?alpha=" + event.currentTarget.id;
+      let url = "/__dictionary/list.json?alpha=" + event.currentTarget.id;
       $.getJSON(url, function(response) {
-        var html = buildDefinitionListHTML(response);
+        let html = buildDefinitionListHTML(response);
         $("#"+targetElement).html(html);
       });
     }
@@ -85,9 +95,9 @@ $( function() {
   });
   $( "#searchbox" ).submit(function(event) {
     //val searchText = $("input[name=q]").val();
-    var searchText = $("input[name=q]").val();
+    let searchText = $("input[name=q]").val();
     if (searchText != "") {
-      var thepanel = $(".cd-panel-content");
+      let thepanel = $(".cd-panel-content");
       searchDictionary(searchText, thepanel);
       $("#searchTitle").html("Searching for: '"+searchText+"'");
       $('.cd-panel').addClass('is-visible');

--- a/opus/application/static_media/js/dictionary.js
+++ b/opus/application/static_media/js/dictionary.js
@@ -12,9 +12,9 @@ function removeSpecialChars(str) {
 
 function postContents(response, searchText) {
   var html = "";
-  definition = removeSpecialChars(response.definition)
+  definition = removeSpecialChars(response.definition);
   if (searchText != undefined) {
-    definition = definition.replacei(searchText, "<mark class='search'>"+searchText+"</mark>")
+    definition = definition.replacei(searchText, "<mark class='search'>"+searchText+"</mark>");
   }
   var context = (response.context__description == undefined ? response.context: response.context__description);
   html += "<div class='context'>" + context + "</div></br>";
@@ -35,7 +35,7 @@ function buildDefinitionListHTML(response, searchText) {
       var term_next = (next < length && (response[next].term__term_nice === undefined ? response[next].term : response[next].term__term_nice));
 
       html += "<li>";
-      html += "<div class='term'>" + term.replace(/:/g, ": ").replace(/_/g, " ").toTitleCase(); + "</div></br>";
+      html += "<div class='term'>" + term.replace(/:/g, ": ").replace(/_/g, " ").toTitleCase() + "</div></br>";
       // this should actually be a while loop...term.replace(/_/g, ". ").
       if (next < length && (term == term_next)) {
         html += "<ul>";
@@ -58,7 +58,7 @@ function buildDefinitionListHTML(response, searchText) {
 function searchDictionary(searchText, thepanel) {
   var url = "/__dictionary/search.json?term=" + searchText;
   $.getJSON(url, function(response) {
-      var html = buildDefinitionListHTML(response, searchText)
+      var html = buildDefinitionListHTML(response, searchText);
       thepanel.html(html);
   });
 }
@@ -74,10 +74,10 @@ $( function() {
       currentElement = targetElement;
     }
     if ($("#"+targetElement).length == 0) {
-      $("#dictionaryContainer").append("<div id='"+targetElement+"' class='dictionaryContent'>Loading... please wait.</div>")
+      $("#dictionaryContainer").append("<div id='"+targetElement+"' class='dictionaryContent'>Loading... please wait.</div>");
       var url = "/__dictionary/list.json?alpha=" + event.currentTarget.id;
       $.getJSON(url, function(response) {
-        var html = buildDefinitionListHTML(response)
+        var html = buildDefinitionListHTML(response);
         $("#"+targetElement).html(html);
       });
     }

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -711,9 +711,11 @@ var opus = {
             let newSlugArr = normalizeURLData.new_slugs;
             let newURLHash = [];
             for (const slugObj of newSlugArr) {
+                const currentURLHash = []
                 $.each(slugObj, function(slug, value) {
-                    newURLHash.push(`${slug}=${value}`);
+                    currentURLHash.push(`${slug}=${value}`);
                 });
+                newURLHash.concat(currentURLHash);
             }
             // Encode and update new URL in browser:
             newURLHash = o_hash.encodeHashArray(newURLHash);

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -711,7 +711,7 @@ var opus = {
             let newSlugArr = normalizeURLData.new_slugs;
             let newURLHash = [];
             for (const slugObj of newSlugArr) {
-                const currentURLHash = []
+                const currentURLHash = [];
                 $.each(slugObj, function(slug, value) {
                     currentURLHash.push(`${slug}=${value}`);
                 });

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -715,7 +715,7 @@ var opus = {
                 $.each(slugObj, function(slug, value) {
                     currentURLHash.push(`${slug}=${value}`);
                 });
-                newURLHash.concat(currentURLHash);
+                newURLHash = newURLHash.concat(currentURLHash);
             }
             // Encode and update new URL in browser:
             newURLHash = o_hash.encodeHashArray(newURLHash);

--- a/opus/application/static_media/js/search.js
+++ b/opus/application/static_media/js/search.js
@@ -773,7 +773,7 @@ var o_search = {
                     preprogrammedRangesDropdown.find("a.dropdown-item").removeClass("op-hide-element");
                     $(singleRangeData).removeClass("op-hide-element");
                     o_search.removeHighlightedRangesName(singleRangeData);
-                    for (const eachCat in o_search.rangesNameMatchedCounterByCategory) {
+                    for (const eachCat of Object.keys(o_search.rangesNameMatchedCounterByCategory)) {
                         o_search.rangesNameMatchedCounterByCategory[eachCat] = 0;
                     }
                 } else if (dataName.includes(currentInputValue)) {

--- a/opus/application/static_media/js/selectMetadata.js
+++ b/opus/application/static_media/js/selectMetadata.js
@@ -346,7 +346,7 @@ var o_selectMetadata = {
             <a class="op-${slug}-units-dropdown-toggle dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">${dispUnit}</a>
             <div class="dropdown-menu op-scrollable-menu" aria-labelledby="dropdownMenuLink">`;
             let units = $(menuSelector).data("availunits");
-            for (let unit in units) {
+            for (let unit of Object.keys(units)) {
                 unitDropdown += `<a class="dropdown-item" data-defaultunit="${defaultUnit}" data-value="${unit}" data-dispvalue="${units[unit]}" data-slug="${slug}" href="#">${units[unit]}</a>`;
             }
             unitDropdown += "</div></div>)";

--- a/opus/application/static_media/js/sortMetadata.js
+++ b/opus/application/static_media/js/sortMetadata.js
@@ -66,7 +66,7 @@ let o_sortMetadata = {
                 // if there are two or less sort options, always select append
                 let append = (!inOrderList && opus.prefs.order.length <=2 ? false : true);
                 // control/shift keys overrides and always appends
-                append |= (e.ctrlKey || e.metaKey || e.shiftKey);
+                append ||= (e.ctrlKey || e.metaKey || e.shiftKey);
                 o_sortMetadata.onClickSortOrder(slug, append);
             } else {
                 $("#op-overwrite-sort-order").modal("show").data("slug", slug);

--- a/opus/application/static_media/js/sortMetadata.js
+++ b/opus/application/static_media/js/sortMetadata.js
@@ -66,7 +66,7 @@ let o_sortMetadata = {
                 // if there are two or less sort options, always select append
                 let append = (!inOrderList && opus.prefs.order.length <=2 ? false : true);
                 // control/shift keys overrides and always appends
-                append ||= (e.ctrlKey || e.metaKey || e.shiftKey);
+                append = append || (e.ctrlKey || e.metaKey || e.shiftKey);
                 o_sortMetadata.onClickSortOrder(slug, append);
             } else {
                 $("#op-overwrite-sort-order").modal("show").data("slug", slug);

--- a/opus/application/static_media/js/utils.js
+++ b/opus/application/static_media/js/utils.js
@@ -27,7 +27,7 @@ var o_utils = {
         if (Object.keys(obj1).length !== Object.keys(obj2).length) {
             return false;
         }
-        for (const key in obj1) {
+        for (const key of Object.keys(obj1)) {
             if (!(key in obj2)) {
                 return false;
             } else {

--- a/opus/application/static_media/js/widgets.js
+++ b/opus/application/static_media/js/widgets.js
@@ -1123,7 +1123,7 @@ var o_widgets = {
              } else if (form_type == 'STRING') {
                  let s_arr = [];
                  let last_qtype = '';
-                 for (let key in opus.selections[slug]) {
+                 for (let key of Object.keys(opus.selections[slug])) {
                      let value = opus.selections[slug][key];
                      let qtype;
                      try {
@@ -1159,8 +1159,7 @@ var o_widgets = {
          // this is for when you are first drawing the browse tab and there
          // multiple widgets being requested at once and we want to preserve their order
          // and avoid race conditions that will throw them out of order
-         for (let k in opus.prefs.widgets) {
-             let slug = opus.prefs.widgets[k];
+         for (let slug of opus.prefs.widgets) {
              let widget = 'widget__' + slug;
              let html = '<li id="' + widget + '" class="widget"></li>';
              $(html).appendTo('#op-search-widgets ');


### PR DESCRIPTION
- Fixes #1263 Fixed #1281 
- Were any Django, import pipeline, or table_schema files modified? N
  - If YES:
    - Database used (or new import): opus3_test_230109
    - FLAKE8 run on modified code: Y
    - All Django tests pass: Y
    - Code coverage run and still at 100%: Y
- Were any JavaScript or CSS files modified? Y
  - If YES:
    - JSHINT run on all affected files: Y
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): NA
- Was the documentation reviewed for necessary changes or additions? NA
  - About
  - Getting Started
  - FAQ
  - API Guide
  - Tooltips
  - Import/database schema

Description of changes:
- Fixed the issue of missing strike-thru lines on the cart table view after the page is reloaded.
- Clean jshint warning messages on all js files.
Known problems:
NA