### PR TITLE
Replace shelf_lookup with shelf_exists_if_expected in do_import.py (line

### DIFF
--- a/opus/import/do_import.py
+++ b/opus/import/do_import.py
@@ -1500,11 +1500,9 @@ def get_pdsfile_rows_for_filespec(filespec, obs_general_id, opus_id, volume_id,
                         f'Volume "{volume_id}" is missing row files under '+
                         f'shelves/index for {logical_path}')
 
-                # Check if corresponding shelves/info files exist, if not, we
-                # skip the file.
-                try:
-                    file.shelf_lookup('info')
-                except OSError:
+                # If the pdsfile is expecting the shelf file, check if corresponding
+                # shelves/info files exist, if not, we skip the file.
+                if file.shelf_exists_if_expected() is False:
                     import_util.log_nonrepeating_warning(
                         'Missing corresponding ' +
                         f'shelves/info for {file.abspath}')


### PR DESCRIPTION
- Fixes #XXX
- Were any Django, import pipeline, or table_schema files modified? Y
  - If YES:
    - Database used (or new import): re-import
    - FLAKE8 run on modified code: Y
    - All Django tests pass: Y
    - Code coverage run and still at 100%: Y
- Were any JavaScript or CSS files modified? N
  - If YES:
    - JSHINT run on all affected files: Y/NA
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y/NA
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): Y/NA
- Was the documentation reviewed for necessary changes or additions? Y/NA
  - About
  - Getting Started
  - FAQ
  - API Guide
  - Tooltips
  - Import/database schema

Description of changes:
- In do_import.py, replace `shelf_lookup` with `shelf_exists_if_expected`
- This will work with https://github.com/SETI/pds-webtools/pull/87

Known problems:
NA