### PR TITLE
Rename import file and class names

### DIFF
--- a/opus/import/config_bundle_info.py
+++ b/opus/import/config_bundle_info.py
@@ -7,27 +7,27 @@
 
 # flake8: noqa
 
-from obs_volume_cocirs_56xxx             import ObsVolumeCOCIRS56xxx
-from obs_volume_cocirs_01xxx        import ObsVolumeCOCIRS01xxx
-from obs_volume_coiss_12xxx              import ObsVolumeCOISS12xxx
-from obs_volume_corss_8xxx          import ObsVolumeCORSS8xxx
-from obs_volume_couvis_0xxx             import ObsVolumeCOUVIS0xxx
-from obs_volume_couvis_8xxx         import ObsVolumeCOUVIS8xxx
-from obs_volume_covims_0xxx             import ObsVolumeCOVIMS0xxx
-from obs_volume_covims_8xxx         import ObsVolumeCOVIMS8xxx
-from obs_volume_ebrocc_xxxx             import ObsVolumeEBROCCXxxx
-from obs_volume_gossi_0xxx              import ObsVolumeGOSSI0xxx
-from obs_volume_hstjx_xxxx             import ObsVolumeHSTJxXxxx
-from obs_volume_hstnx_xxxx          import ObsVolumeHSTNxXxxx
-from obs_volume_hstox_xxxx            import ObsVolumeHSTOxXxxx
-from obs_volume_hstix_xxxx            import ObsVolumeHSTIxXxxx
-from obs_volume_hstux_xxxx           import ObsVolumeHSTUxXxxx
-from obs_volume_nhxxlo_xxxx            import ObsVolumeNHxxLOXxxx
-from obs_volume_nhxxmv_xxxx             import ObsVolumeNHxxMVXxxx
-from obs_volume_vgiss_5678xxx              import ObsVolumeVGISS5678xxx
+from obs_volume_cocirs_56xxx       import ObsVolumeCOCIRS56xxx
+from obs_volume_cocirs_01xxx       import ObsVolumeCOCIRS01xxx
+from obs_volume_coiss_12xxx        import ObsVolumeCOISS12xxx
+from obs_volume_corss_8xxx         import ObsVolumeCORSS8xxx
+from obs_volume_couvis_0xxx        import ObsVolumeCOUVIS0xxx
+from obs_volume_couvis_8xxx        import ObsVolumeCOUVIS8xxx
+from obs_volume_covims_0xxx        import ObsVolumeCOVIMS0xxx
+from obs_volume_covims_8xxx        import ObsVolumeCOVIMS8xxx
+from obs_volume_ebrocc_xxxx        import ObsVolumeEBROCCXxxx
+from obs_volume_gossi_0xxx         import ObsVolumeGOSSI0xxx
+from obs_volume_hstjx_xxxx         import ObsVolumeHSTJxXxxx
+from obs_volume_hstnx_xxxx         import ObsVolumeHSTNxXxxx
+from obs_volume_hstox_xxxx         import ObsVolumeHSTOxXxxx
+from obs_volume_hstix_xxxx         import ObsVolumeHSTIxXxxx
+from obs_volume_hstux_xxxx         import ObsVolumeHSTUxXxxx
+from obs_volume_nhxxlo_xxxx        import ObsVolumeNHxxLOXxxx
+from obs_volume_nhxxmv_xxxx        import ObsVolumeNHxxMVXxxx
+from obs_volume_vgiss_5678xxx      import ObsVolumeVGISS5678xxx
 from obs_volume_vg28xx_vgiss       import ObsVolumeVG28xxVGISS
 from obs_volume_vg28xx_vgpps_vguvs import (ObsVolumeVG28xxVGPPS,
-                                               ObsVolumeVG28xxVGUVS)
+                                           ObsVolumeVG28xxVGUVS)
 from obs_volume_vg28xx_vgrss       import ObsVolumeVG28xxVGRSS
 
 

--- a/opus/import/config_bundle_info.py
+++ b/opus/import/config_bundle_info.py
@@ -16,7 +16,7 @@ from obs_volume_couvis_8xxx        import ObsVolumeCOUVIS8xxx
 from obs_volume_covims_0xxx        import ObsVolumeCOVIMS0xxx
 from obs_volume_covims_8xxx        import ObsVolumeCOVIMS8xxx
 from obs_volume_ebrocc_xxxx        import ObsVolumeEBROCCxxxx
-from obs_volume_go_0xxx         import ObsVolumeGO0xxx
+from obs_volume_go_0xxx            import ObsVolumeGO0xxx
 from obs_volume_hstjx_xxxx         import ObsVolumeHSTJxxxxx
 from obs_volume_hstnx_xxxx         import ObsVolumeHSTNxxxxx
 from obs_volume_hstox_xxxx         import ObsVolumeHSTOxxxxx

--- a/opus/import/config_bundle_info.py
+++ b/opus/import/config_bundle_info.py
@@ -7,28 +7,28 @@
 
 # flake8: noqa
 
-from obs_instrument_cocirs             import ObsInstrumentCOCIRS
-from obs_instrument_cocirs_cube        import ObsInstrumentCOCIRSCube
-from obs_instrument_coiss              import ObsInstrumentCOISS
-from obs_instrument_corss_occ          import ObsInstrumentCORSSOcc
-from obs_instrument_couvis             import ObsInstrumentCOUVIS
-from obs_instrument_couvis_occ         import ObsInstrumentCOUVISOcc
-from obs_instrument_covims             import ObsInstrumentCOVIMS
-from obs_instrument_covims_occ         import ObsInstrumentCOVIMSOcc
-from obs_instrument_ebrocc             import ObsInstrumentEBROCC
-from obs_instrument_gossi              import ObsInstrumentGOSSI
-from obs_instrument_hstacs             import ObsInstrumentHSTACS
-from obs_instrument_hstnicmos          import ObsInstrumentHSTNICMOS
-from obs_instrument_hststis            import ObsInstrumentHSTSTIS
-from obs_instrument_hstwfc3            import ObsInstrumentHSTWFC3
-from obs_instrument_hstwfpc2           import ObsInstrumentHSTWFPC2
-from obs_instrument_nhlorri            import ObsInstrumentNHLORRI
-from obs_instrument_nhmvic             import ObsInstrumentNHMVIC
-from obs_instrument_vgiss              import ObsInstrumentVGISS
-from obs_instrument_vg28xx_vgiss       import ObsInstrumentVG28xxVGISS
-from obs_instrument_vg28xx_vgpps_vguvs import (ObsInstrumentVG28xxVGPPS,
-                                               ObsInstrumentVG28xxVGUVS)
-from obs_instrument_vg28xx_vgrss       import ObsInstrumentVG28xxVGRSS
+from obs_volume_cocirs_56xxx             import ObsVolumeCOCIRS56xxx
+from obs_volume_cocirs_01xxx        import ObsVolumeCOCIRS01xxx
+from obs_volume_coiss_12xxx              import ObsVolumeCOISS12xxx
+from obs_volume_corss_8xxx          import ObsVolumeCORSS8xxx
+from obs_volume_couvis_0xxx             import ObsVolumeCOUVIS0xxx
+from obs_volume_couvis_8xxx         import ObsVolumeCOUVIS8xxx
+from obs_volume_covims_0xxx             import ObsVolumeCOVIMS0xxx
+from obs_volume_covims_8xxx         import ObsVolumeCOVIMS8xxx
+from obs_volume_ebrocc_xxxx             import ObsVolumeEBROCCXxxx
+from obs_volume_gossi_0xxx              import ObsVolumeGOSSI0xxx
+from obs_volume_hstjx_xxxx             import ObsVolumeHSTJxXxxx
+from obs_volume_hstnx_xxxx          import ObsVolumeHSTNxXxxx
+from obs_volume_hstox_xxxx            import ObsVolumeHSTOxXxxx
+from obs_volume_hstix_xxxx            import ObsVolumeHSTIxXxxx
+from obs_volume_hstux_xxxx           import ObsVolumeHSTUxXxxx
+from obs_volume_nhxxlo_xxxx            import ObsVolumeNHxxLOXxxx
+from obs_volume_nhxxmv_xxxx             import ObsVolumeNHxxMVXxxx
+from obs_volume_vgiss_5678xxx              import ObsVolumeVGISS5678xxx
+from obs_volume_vg28xx_vgiss       import ObsVolumeVG28xxVGISS
+from obs_volume_vg28xx_vgpps_vguvs import (ObsVolumeVG28xxVGPPS,
+                                               ObsVolumeVG28xxVGUVS)
+from obs_volume_vg28xx_vgrss       import ObsVolumeVG28xxVGRSS
 
 
 # The BUNDLE_INFO structure is used to determine the details of importing
@@ -59,47 +59,47 @@ BUNDLE_INFO = [
                            '<BUNDLE>_cube_point_index.lbl',
                            '<BUNDLE>_cube_ring_index.lbl'),
          'validate_index_rows': False,
-         'instrument_class': ObsInstrumentCOCIRSCube},
+         'instrument_class': ObsVolumeCOCIRS01xxx},
     ),
     (r'COCIRS_[56]\d\d\d',
         {'primary_index': ('OBSINDEX.LBL',),
          'validate_index_rows': False,
-         'instrument_class': ObsInstrumentCOCIRS},
+         'instrument_class': ObsVolumeCOCIRS56xxx},
     ),
     (r'COISS_[12]\d\d\d',
         {'primary_index': ('<BUNDLE>_index.lbl',),
          'validate_index_rows': False,
-         'instrument_class': ObsInstrumentCOISS},
+         'instrument_class': ObsVolumeCOISS12xxx},
     ),
     (r'CORSS_8001',
         {'primary_index': ('<BUNDLE>_index.lbl',),
          'validate_index_rows': True,
-         'instrument_class': ObsInstrumentCORSSOcc},
+         'instrument_class': ObsVolumeCORSS8xxx},
     ),
     (r'COUVIS_0\d\d\d',
         {'primary_index': ('<BUNDLE>_index.lbl',),
          'validate_index_rows': False,
-         'instrument_class': ObsInstrumentCOUVIS},
+         'instrument_class': ObsVolumeCOUVIS0xxx},
     ),
     (r'COUVIS_8001',
         {'primary_index': ('<BUNDLE>_index.lbl',),
          'validate_index_rows': True,
-         'instrument_class': ObsInstrumentCOUVISOcc},
+         'instrument_class': ObsVolumeCOUVIS8xxx},
     ),
     (r'COVIMS_0\d\d\d',
         {'primary_index': ('<BUNDLE>_index.lbl',),
          'validate_index_rows': False,
-         'instrument_class': ObsInstrumentCOVIMS},
+         'instrument_class': ObsVolumeCOVIMS0xxx},
     ),
     (r'COVIMS_8001',
         {'primary_index': ('<BUNDLE>_index.lbl',),
          'validate_index_rows': True,
-         'instrument_class': ObsInstrumentCOVIMSOcc},
+         'instrument_class': ObsVolumeCOVIMS8xxx},
     ),
     (r'EBROCC_0001',
         {'primary_index': ('<BUNDLE>_index.lbl',),
          'validate_index_rows': True,
-         'instrument_class': ObsInstrumentEBROCC},
+         'instrument_class': ObsVolumeEBROCCXxxx},
     ),
     (r'GO_0001',
         {'primary_index': None,
@@ -109,42 +109,42 @@ BUNDLE_INFO = [
     (r'GO_000[2-9]|GO_001\d|GO_002\d',
         {'primary_index': ('<BUNDLE>_index.lbl', '<BUNDLE>_sl9_index.lbl'),
          'validate_index_rows': True,
-         'instrument_class': ObsInstrumentGOSSI},
+         'instrument_class': ObsVolumeGOSSI0xxx},
     ),
     (r'HSTI\d_\d\d\d\d',
         {'primary_index': ('<BUNDLE>_index.lbl',),
          'validate_index_rows': False,
-         'instrument_class': ObsInstrumentHSTWFC3},
+         'instrument_class': ObsVolumeHSTIxXxxx},
     ),
     (r'HSTJ\d_\d\d\d\d',
         {'primary_index': ('<BUNDLE>_index.lbl',),
          'validate_index_rows': False,
-         'instrument_class': ObsInstrumentHSTACS},
+         'instrument_class': ObsVolumeHSTJxXxxx},
     ),
     (r'HSTN\d_\d\d\d\d',
         {'primary_index': ('<BUNDLE>_index.lbl',),
          'validate_index_rows': False,
-         'instrument_class': ObsInstrumentHSTNICMOS},
+         'instrument_class': ObsVolumeHSTNxXxxx},
     ),
     (r'HSTO\d_\d\d\d\d',
         {'primary_index': ('<BUNDLE>_index.lbl',),
          'validate_index_rows': False,
-         'instrument_class': ObsInstrumentHSTSTIS},
+         'instrument_class': ObsVolumeHSTOxXxxx},
     ),
     (r'HSTU\d_\d\d\d\d',
         {'primary_index': ('<BUNDLE>_index.lbl',),
          'validate_index_rows': False,
-         'instrument_class': ObsInstrumentHSTWFPC2},
+         'instrument_class': ObsVolumeHSTUxXxxx},
     ),
     (r'NH..LO_1001',
         {'primary_index': ('<BUNDLE>_index.lbl',),
          'validate_index_rows': True,
-         'instrument_class': ObsInstrumentNHLORRI},
+         'instrument_class': ObsVolumeNHxxLOXxxx},
     ),
     (r'NH..MV_1001',
         {'primary_index': ('<BUNDLE>_index.lbl',),
          'validate_index_rows': True,
-         'instrument_class': ObsInstrumentNHMVIC},
+         'instrument_class': ObsVolumeNHxxMVXxxx},
     ),
     (r'NH...._2\d\d\d',  # Ignore these volumes - we only import 1001
         {'primary_index': None,
@@ -154,26 +154,26 @@ BUNDLE_INFO = [
     (r'VGISS_[5678]\d\d\d',
         {'primary_index': ('<BUNDLE>_raw_image_index.lbl',),
          'validate_index_rows': False,
-         'instrument_class': ObsInstrumentVGISS},
+         'instrument_class': ObsVolumeVGISS5678xxx},
     ),
     (r'VG_2801',
         {'primary_index': ('<BUNDLE>_index.lbl',),
          'validate_index_rows': True,
-         'instrument_class': ObsInstrumentVG28xxVGPPS},
+         'instrument_class': ObsVolumeVG28xxVGPPS},
     ),
     (r'VG_2802',
         {'primary_index': ('<BUNDLE>_index.lbl',),
          'validate_index_rows': True,
-         'instrument_class': ObsInstrumentVG28xxVGUVS},
+         'instrument_class': ObsVolumeVG28xxVGUVS},
     ),
     (r'VG_2803',
         {'primary_index': ('<BUNDLE>_index.lbl',),
          'validate_index_rows': True,
-         'instrument_class': ObsInstrumentVG28xxVGRSS},
+         'instrument_class': ObsVolumeVG28xxVGRSS},
     ),
     (r'VG_2810',
         {'primary_index': ('<BUNDLE>_index.lbl',),
          'validate_index_rows': True,
-         'instrument_class': ObsInstrumentVG28xxVGISS},
+         'instrument_class': ObsVolumeVG28xxVGISS},
     ),
 ]

--- a/opus/import/config_bundle_info.py
+++ b/opus/import/config_bundle_info.py
@@ -15,13 +15,13 @@ from obs_volume_couvis_0xxx        import ObsVolumeCOUVIS0xxx
 from obs_volume_couvis_8xxx        import ObsVolumeCOUVIS8xxx
 from obs_volume_covims_0xxx        import ObsVolumeCOVIMS0xxx
 from obs_volume_covims_8xxx        import ObsVolumeCOVIMS8xxx
-from obs_volume_ebrocc_xxxx        import ObsVolumeEBROCCXxxx
-from obs_volume_gossi_0xxx         import ObsVolumeGOSSI0xxx
-from obs_volume_hstjx_xxxx         import ObsVolumeHSTJxXxxx
-from obs_volume_hstnx_xxxx         import ObsVolumeHSTNxXxxx
-from obs_volume_hstox_xxxx         import ObsVolumeHSTOxXxxx
-from obs_volume_hstix_xxxx         import ObsVolumeHSTIxXxxx
-from obs_volume_hstux_xxxx         import ObsVolumeHSTUxXxxx
+from obs_volume_ebrocc_xxxx        import ObsVolumeEBROCCxxxx
+from obs_volume_go_0xxx         import ObsVolumeGO0xxx
+from obs_volume_hstjx_xxxx         import ObsVolumeHSTJxxxxx
+from obs_volume_hstnx_xxxx         import ObsVolumeHSTNxxxxx
+from obs_volume_hstox_xxxx         import ObsVolumeHSTOxxxxx
+from obs_volume_hstix_xxxx         import ObsVolumeHSTIxxxxx
+from obs_volume_hstux_xxxx         import ObsVolumeHSTUxxxxx
 from obs_volume_nhxxlo_xxxx        import ObsVolumeNHxxLOXxxx
 from obs_volume_nhxxmv_xxxx        import ObsVolumeNHxxMVXxxx
 from obs_volume_vgiss_5678xxx      import ObsVolumeVGISS5678xxx
@@ -99,7 +99,7 @@ BUNDLE_INFO = [
     (r'EBROCC_0001',
         {'primary_index': ('<BUNDLE>_index.lbl',),
          'validate_index_rows': True,
-         'instrument_class': ObsVolumeEBROCCXxxx},
+         'instrument_class': ObsVolumeEBROCCxxxx},
     ),
     (r'GO_0001',
         {'primary_index': None,
@@ -109,32 +109,32 @@ BUNDLE_INFO = [
     (r'GO_000[2-9]|GO_001\d|GO_002\d',
         {'primary_index': ('<BUNDLE>_index.lbl', '<BUNDLE>_sl9_index.lbl'),
          'validate_index_rows': True,
-         'instrument_class': ObsVolumeGOSSI0xxx},
+         'instrument_class': ObsVolumeGO0xxx},
     ),
     (r'HSTI\d_\d\d\d\d',
         {'primary_index': ('<BUNDLE>_index.lbl',),
          'validate_index_rows': False,
-         'instrument_class': ObsVolumeHSTIxXxxx},
+         'instrument_class': ObsVolumeHSTIxxxxx},
     ),
     (r'HSTJ\d_\d\d\d\d',
         {'primary_index': ('<BUNDLE>_index.lbl',),
          'validate_index_rows': False,
-         'instrument_class': ObsVolumeHSTJxXxxx},
+         'instrument_class': ObsVolumeHSTJxxxxx},
     ),
     (r'HSTN\d_\d\d\d\d',
         {'primary_index': ('<BUNDLE>_index.lbl',),
          'validate_index_rows': False,
-         'instrument_class': ObsVolumeHSTNxXxxx},
+         'instrument_class': ObsVolumeHSTNxxxxx},
     ),
     (r'HSTO\d_\d\d\d\d',
         {'primary_index': ('<BUNDLE>_index.lbl',),
          'validate_index_rows': False,
-         'instrument_class': ObsVolumeHSTOxXxxx},
+         'instrument_class': ObsVolumeHSTOxxxxx},
     ),
     (r'HSTU\d_\d\d\d\d',
         {'primary_index': ('<BUNDLE>_index.lbl',),
          'validate_index_rows': False,
-         'instrument_class': ObsVolumeHSTUxXxxx},
+         'instrument_class': ObsVolumeHSTUxxxxx},
     ),
     (r'NH..LO_1001',
         {'primary_index': ('<BUNDLE>_index.lbl',),

--- a/opus/import/obs_volume_cassini_common.py
+++ b/opus/import/obs_volume_cassini_common.py
@@ -1,7 +1,7 @@
 ################################################################################
-# obs_mission_cassini.py
+# obs_volume_cassini_common.py
 #
-# Defines the ObsMissionCassini class, which encapsulates fields in the
+# Defines the ObsVolumeCassiniCommon class, which encapsulates fields in the
 # common and obs_mission_cassini tables.
 ################################################################################
 
@@ -123,7 +123,7 @@ COISS_TARGET_DESC_MAPPING = {
 }
 
 
-class ObsMissionCassini(ObsCommon):
+class ObsVolumeCassiniCommon(ObsCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/opus/import/obs_volume_cassini_occ_common.py
+++ b/opus/import/obs_volume_cassini_occ_common.py
@@ -1,17 +1,17 @@
 ################################################################################
-# obs_instrument_cassini_occ.py
+# obs_volume_cassini_occ_common.py
 #
-# Defines the ObsInstrumentCassiniOcc class, the parent for the
-# ObsInstrumentCORSSOcc, ObsInstrumentCOUVISOcc, and ObsInstrumentCOVIMSOcc
+# Defines the ObsVolumeCassiniOccCommon class, the parent for the
+# ObsVolumeCORSS8xxx, ObsVolumeCOUVIS8xxx, and ObsVolumeCOVIMS8xxx
 # classes, which encapsulate fields in the obs_instrument_corss,
 # obs_instrument_couvis, and obs_instrument_covims tables for the 8xxx
 # occultation volumes
 ################################################################################
 
-from obs_mission_cassini import ObsMissionCassini
+from obs_volume_cassini_common import ObsVolumeCassiniCommon
 
 
-class ObsInstrumentCassiniOcc(ObsMissionCassini):
+class ObsVolumeCassiniOccCommon(ObsVolumeCassiniCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/opus/import/obs_volume_cocirs_01xxx.py
+++ b/opus/import/obs_volume_cocirs_01xxx.py
@@ -1,7 +1,7 @@
 ################################################################################
-# obs_instrument_cocirs_cube.py
+# obs_volume_cocirs_01xxx.py
 #
-# Defines the ObsInstrumentCOCIRSCube class, which encapsulates fields in the
+# Defines the ObsVolumeCOCIRS01xxx class, which encapsulates fields in the
 # common, obs_mission_cassini, and obs_instrument_cocirs tables for volumes
 # COCIRS_[01]xxx.
 ################################################################################
@@ -10,12 +10,12 @@ import julian
 
 import opus_support
 
-from obs_mission_cassini import ObsMissionCassini
+from obs_volume_cassini_common import ObsVolumeCassiniCommon
 
 _EQUINOX_DATE = julian.tai_from_iso('2009-08-11T01:40:08.914')
 
 
-class ObsInstrumentCOCIRSCube(ObsMissionCassini):
+class ObsVolumeCOCIRS01xxx(ObsVolumeCassiniCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -314,9 +314,9 @@ class ObsInstrumentCOCIRSCube(ObsMissionCassini):
         return self._index_col('CSS:BODY_SPACECRAFT_RANGE_MIDDLE')
 
 
-    #######################################
-    ### OVERRIDE FROM ObsMissionCassini ###
-    #######################################
+    ############################################
+    ### OVERRIDE FROM ObsVolumeCassiniCommon ###
+    ############################################
 
     # Warning: Both the equi/point/ring index files and the supplemental index files
     # have an OBSERVATION_ID field and they're different! The index file version looks

--- a/opus/import/obs_volume_cocirs_56xxx.py
+++ b/opus/import/obs_volume_cocirs_56xxx.py
@@ -1,17 +1,17 @@
 ################################################################################
-# obs_instrument_cocirs.py
+# obs_volume_cocirs_56xxx.py
 #
-# Defines the ObsInstrumentCOCIRS class, which encapsulates fields in the
+# Defines the ObsVolumeCOCIRS56xxx class, which encapsulates fields in the
 # common, obs_mission_cassini, and obs_instrument_cocirs tables for volumes
 # COCIRS_[56]xxx.
 ################################################################################
 
 import opus_support
 
-from obs_mission_cassini import ObsMissionCassini
+from obs_volume_cassini_common import ObsVolumeCassiniCommon
 
 
-class ObsInstrumentCOCIRS(ObsMissionCassini):
+class ObsVolumeCOCIRS56xxx(ObsVolumeCassiniCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -128,9 +128,9 @@ class ObsInstrumentCOCIRS(ObsMissionCassini):
         return self._index_col('SPECTRUM_SAMPLES')
 
 
-    #######################################
-    ### OVERRIDE FROM ObsMissionCassini ###
-    #######################################
+    ############################################
+    ### OVERRIDE FROM ObsVolumeCassiniCommon ###
+    ############################################
 
     def field_obs_mission_cassini_spacecraft_clock_count1(self):
         sc = self._index_col('SPACECRAFT_CLOCK_START_COUNT')

--- a/opus/import/obs_volume_coiss_12xxx.py
+++ b/opus/import/obs_volume_coiss_12xxx.py
@@ -1,14 +1,14 @@
 ################################################################################
-# obs_instrument_coiss.py
+# obs_volume_coiss_12xxx.py
 #
-# Defines the ObsInstrumentCOISS class, which encapsulates fields in the
+# Defines the ObsVolumeCOISS12xxx class, which encapsulates fields in the
 # common, obs_mission_cassini, and obs_instrument_coiss tables for
 # COISS_[12]xxx.
 ################################################################################
 
 import opus_support
 
-from obs_mission_cassini import (ObsMissionCassini,
+from obs_volume_cassini_common import (ObsVolumeCassiniCommon,
                                  COISS_TARGET_DESC_MAPPING)
 
 
@@ -176,7 +176,7 @@ _COISS_FILTER_WAVELENGTHS = {
 # W/MT3/BL1
 
 
-class ObsInstrumentCOISS(ObsMissionCassini):
+class ObsVolumeCOISS12xxx(ObsVolumeCassiniCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -354,9 +354,9 @@ class ObsInstrumentCOISS(ObsMissionCassini):
         return self._create_mult('NONE')
 
 
-    #######################################
-    ### OVERRIDE FROM ObsMissionCassini ###
-    #######################################
+    ############################################
+    ### OVERRIDE FROM ObsVolumeCassiniCommon ###
+    ############################################
 
     def field_obs_mission_cassini_spacecraft_clock_count1(self):
         partition = self._index_col('SPACECRAFT_CLOCK_CNT_PARTITION')

--- a/opus/import/obs_volume_corss_8xxx.py
+++ b/opus/import/obs_volume_corss_8xxx.py
@@ -1,7 +1,7 @@
 ################################################################################
-# obs_instrument_corss_occ.py
+# obs_volume_corss_8xxx.py
 #
-# Defines the ObsInstrumentCORSSOcc class, which encapsulates fields for
+# Defines the ObsVolumeCORSS8xxx class, which encapsulates fields for
 # common and obs_mission_cassini for CORSS_8001 (there is no RSS instrument
 # table).
 ################################################################################
@@ -9,10 +9,10 @@
 import opus_support
 
 from config_data import DSN_NAMES
-from obs_instrument_cassini_occ import ObsInstrumentCassiniOcc
+from obs_volume_cassini_occ_common import ObsVolumeCassiniOccCommon
 
 
-class ObsInstrumentCORSSOcc(ObsInstrumentCassiniOcc):
+class ObsVolumeCORSS8xxx(ObsVolumeCassiniOccCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -129,9 +129,9 @@ class ObsInstrumentCORSSOcc(ObsInstrumentCassiniOcc):
         return self._index_col('MAXIMUM_OBSERVED_RING_ELEVATION')
 
 
-    #######################################
-    ### OVERRIDE FROM ObsMissionCassini ###
-    #######################################
+    ############################################
+    ### OVERRIDE FROM ObsVolumeCassiniCommon ###
+    ############################################
 
     def field_obs_mission_cassini_spacecraft_clock_count1(self):
         count = self._supp_index_col('SPACECRAFT_CLOCK_START_COUNT')

--- a/opus/import/obs_volume_couvis_0xxx.py
+++ b/opus/import/obs_volume_couvis_0xxx.py
@@ -1,7 +1,7 @@
 ################################################################################
-# obs_instrument_couvis.py
+# obs_volume_couvis_0xxx.py
 #
-# Defines the ObsInstrumentCOUVIS class, which encapsulates fields in the
+# Defines the ObsVolumeCOUVIS0xxx class, which encapsulates fields in the
 # common, obs_mission_cassini, and obs_instrument_couvis tables for COUVIS_0xxx.
 ################################################################################
 
@@ -9,10 +9,10 @@ import os
 
 import opus_support
 
-from obs_mission_cassini import ObsMissionCassini
+from obs_volume_cassini_common import ObsVolumeCassiniCommon
 
 
-class ObsInstrumentCOUVIS(ObsMissionCassini):
+class ObsVolumeCOUVIS0xxx(ObsVolumeCassiniCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -330,9 +330,9 @@ class ObsInstrumentCOUVIS(ObsMissionCassini):
         return (band2 - band1 + 1) // band_bin
 
 
-    #######################################
-    ### OVERRIDE FROM ObsMissionCassini ###
-    #######################################
+    ############################################
+    ### OVERRIDE FROM ObsVolumeCassiniCommon ###
+    ############################################
 
     def field_obs_mission_cassini_spacecraft_clock_count1(self):
         sc = self._index_col('SPACECRAFT_CLOCK_START_COUNT')

--- a/opus/import/obs_volume_couvis_covims_occ_common.py
+++ b/opus/import/obs_volume_couvis_covims_occ_common.py
@@ -1,14 +1,14 @@
 ################################################################################
-# obs_instrument_couvis_covims_occ.py
+# obs_volume_couvis_covims_occ_common.py
 #
-# Defines the ObsInstrumentUVISVIMSOcc class, which encapsulate fields that are
-# common to the ObsInstrumentCOUVISOcc and ObsInstrumentCOVIMSOcc classes.
+# Defines the ObsVolumeUVISVIMSOccCommon class, which encapsulate fields that are
+# common to the ObsVolumeCOUVIS8xxx and ObsVolumeCOVIMS8xxx classes.
 ################################################################################
 
-from obs_instrument_cassini_occ import ObsInstrumentCassiniOcc
+from obs_volume_cassini_occ_common import ObsVolumeCassiniOccCommon
 
 
-class ObsInstrumentUVISVIMSOcc(ObsInstrumentCassiniOcc):
+class ObsVolumeUVISVIMSOccCommon(ObsVolumeCassiniOccCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -120,9 +120,9 @@ class ObsInstrumentUVISVIMSOcc(ObsInstrumentCassiniOcc):
         return self._index_col('OBSERVED_RING_ELEVATION')
 
 
-    #######################################
-    ### OVERRIDE FROM ObsMissionCassini ###
-    #######################################
+    ############################################
+    ### OVERRIDE FROM ObsVolumeCassiniCommon ###
+    ############################################
 
     def field_obs_mission_cassini_sequence_id(self):
         return self._supp_index_col('SEQUENCE_ID')

--- a/opus/import/obs_volume_couvis_covims_occ_common.py
+++ b/opus/import/obs_volume_couvis_covims_occ_common.py
@@ -1,8 +1,8 @@
 ################################################################################
 # obs_volume_couvis_covims_occ_common.py
 #
-# Defines the ObsVolumeUVISVIMSOccCommon class, which encapsulate fields that are
-# common to the ObsVolumeCOUVIS8xxx and ObsVolumeCOVIMS8xxx classes.
+# Defines the ObsVolumeUVISVIMSOccCommon class, which encapsulate fields that
+# are common to the ObsVolumeCOUVIS8xxx and ObsVolumeCOVIMS8xxx classes.
 ################################################################################
 
 from obs_volume_cassini_occ_common import ObsVolumeCassiniOccCommon

--- a/opus/import/obs_volume_covims_0xxx.py
+++ b/opus/import/obs_volume_covims_0xxx.py
@@ -1,17 +1,17 @@
 ################################################################################
-# obs_instrument_covims.py
+# obs_volume_covims_0xxx.py
 #
-# Defines the ObsInstrumentCOVIMS class, which encapsulates fields in the
+# Defines the ObsVolumeCOVIMS0xxx class, which encapsulates fields in the
 # common, obs_mission_cassini, and obs_instrument_covims tables for COVIMS_8xxx
 # occultations.
 ################################################################################
 
 import opus_support
 
-from obs_mission_cassini import ObsMissionCassini
+from obs_volume_cassini_common import ObsVolumeCassiniCommon
 
 
-class ObsInstrumentCOVIMS(ObsMissionCassini):
+class ObsVolumeCOVIMS0xxx(ObsVolumeCassiniCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -232,9 +232,9 @@ class ObsInstrumentCOVIMS(ObsMissionCassini):
         return 96
 
 
-    #######################################
-    ### OVERRIDE FROM ObsMissionCassini ###
-    #######################################
+    ############################################
+    ### OVERRIDE FROM ObsVolumeCassiniCommon ###
+    ############################################
 
     def field_obs_mission_cassini_spacecraft_clock_count1(self):
         sc = '1/' + self._index_col('SPACECRAFT_CLOCK_START_COUNT')

--- a/opus/import/obs_volume_covims_8xxx.py
+++ b/opus/import/obs_volume_covims_8xxx.py
@@ -1,17 +1,17 @@
 ################################################################################
-# obs_instrument_couvis_occ.py
+# obs_volume_covims_8xxx.py
 #
-# Defines the ObsInstrumentCOUVISOcc class, which encapsulates fields in the
-# common, obs_mission_cassini, and obs_instrument_couvis tables for COUVIS_8001
+# Defines the ObsVolumeCOVIMS8xxx class, which encapsulates fields in the
+# common, obs_mission_cassini, and obs_instrument_covims tables for COVIMS_8001
 # occultations.
 ################################################################################
 
 import opus_support
 
-from obs_instrument_couvis_covims_occ import ObsInstrumentUVISVIMSOcc
+from obs_volume_couvis_covims_occ_common import ObsVolumeUVISVIMSOccCommon
 
 
-class ObsInstrumentCOUVISOcc(ObsInstrumentUVISVIMSOcc):
+class ObsVolumeCOVIMS8xxx(ObsVolumeUVISVIMSOccCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -22,7 +22,7 @@ class ObsInstrumentCOUVISOcc(ObsInstrumentUVISVIMSOcc):
 
     @property
     def instrument_id(self):
-        return 'COUVIS'
+        return 'COVIMS'
 
 
     ###################################
@@ -53,20 +53,24 @@ class ObsInstrumentCOUVISOcc(ObsInstrumentUVISVIMSOcc):
     ################################
 
     def field_obs_profile_temporal_sampling(self):
-        return self._supp_index_col('INTEGRATION_DURATION') / 1000 # msec -> sec
+        return self._supp_index_col('IR_EXPOSURE') / 1000 # msec -> sec
 
     def field_obs_profile_wl_band(self):
-        return self._create_mult('UV')
+        return self._create_mult('IR')
 
 
-    #######################################
-    ### OVERRIDE FROM ObsMissionCassini ###
-    #######################################
+    ############################################
+    ### OVERRIDE FROM ObsVolumeCassiniCommon ###
+    ############################################
 
     def field_obs_mission_cassini_spacecraft_clock_count1(self):
         sc = self._supp_index_col('SPACECRAFT_CLOCK_START_COUNT')
         if sc == 'UNK':
             return None
+        # COVIMS_8001 SCLKs are in some weird units where the number to the right
+        # of the decimal can be > 255, so we just round down
+        if '.' in sc:
+            sc = sc.split('.')[0] + '.000'
         try:
             sc_cvt = opus_support.parse_cassini_sclk(sc)
         except Exception as e:
@@ -78,8 +82,12 @@ class ObsInstrumentCOUVISOcc(ObsInstrumentUVISVIMSOcc):
         sc = self._supp_index_col('SPACECRAFT_CLOCK_STOP_COUNT')
         if sc == 'UNK':
             return None
+        # COVIMS_8001 SCLKs are in some weird units where the number to the right
+        # of the decimal can be > 255, so we just round up
+        if '.' in sc:
+            sc = sc.split('.')[0] + '.000'
         try:
-            sc_cvt = opus_support.parse_cassini_sclk(sc)
+            sc_cvt = opus_support.parse_cassini_sclk(sc)+1 # Round up
         except Exception as e:
             self._log_nonrepeating_error(f'Unable to parse Cassini SCLK "{sc}": {e}')
             return None
@@ -98,60 +106,50 @@ class ObsInstrumentCOUVISOcc(ObsInstrumentUVISVIMSOcc):
 
 
     ###############################################
-    ### FIELD METHODS FOR obs_instrument_couvis ###
+    ### FIELD METHODS FOR obs_instrument_covims ###
     ###############################################
 
-    def field_obs_instrument_couvis_opus_id(self):
+    def field_obs_instrument_covims_opus_id(self):
         return self.opus_id
 
-    def field_obs_instrument_couvis_bundle_id(self):
+    def field_obs_instrument_covims_bundle_id(self):
         return self.bundle
 
-    def field_obs_instrument_couvis_instrument_id(self):
+    def field_obs_instrument_covims_instrument_id(self):
         return self.instrument_id
 
-    def field_obs_instrument_couvis_observation_type(self):
-        return self._create_mult('NONE')
+    def field_obs_instrument_covims_instrument_mode_id(self):
+        return self._create_mult(self._supp_index_col('INSTRUMENT_MODE_ID'))
 
-    def field_obs_instrument_couvis_integration_duration(self):
-        return self.field_obs_profile_temporal_sampling()
+    def field_obs_instrument_covims_spectral_editing(self):
+        return self._create_mult(self._supp_index_col('SPECTRAL_EDITING'))
 
-    def field_obs_instrument_couvis_compression_type(self):
-        comp = self._supp_index_col('COMPRESSION_TYPE')
-        return self._create_mult_keep_case(comp)
+    def field_obs_instrument_covims_spectral_summing(self):
+        return self._create_mult(self._supp_index_col('SPECTRAL_SUMMING'))
 
-    def field_obs_instrument_couvis_occultation_port_state(self):
+    def field_obs_instrument_covims_star_tracking(self):
+        return self._create_mult(self._supp_index_col('STAR_TRACKING'))
+
+    def field_obs_instrument_covims_swath_width(self):
+        return self._supp_index_col('SWATH_WIDTH')
+
+    def field_obs_instrument_covims_swath_length(self):
+        return self._supp_index_col('SWATH_LENGTH')
+
+    def field_obs_instrument_covims_ir_exposure(self):
+        ir_exp = self._supp_index_col('IR_EXPOSURE')
+        if ir_exp is None:
+            return None
+        return ir_exp / 1000.
+
+    def field_obs_instrument_covims_ir_sampling_mode_id(self):
+        return self._create_mult(self._supp_index_col('IR_SAMPLING_MODE_ID'))
+
+    def field_obs_instrument_covims_vis_exposure(self):
+        return None
+
+    def field_obs_instrument_covims_vis_sampling_mode_id(self):
         return self._create_mult('N/A')
 
-    def field_obs_instrument_couvis_slit_state(self):
-        return self._create_mult('NULL')
-
-    def field_obs_instrument_couvis_test_pulse_state(self):
-        return self._create_mult(None)
-
-    def field_obs_instrument_couvis_dwell_time(self):
-        return self._create_mult(None)
-
-    def field_obs_instrument_couvis_channel(self):
-        return self._create_mult_keep_case('HSP')
-
-    def field_obs_instrument_couvis_band1(self):
-        return None
-
-    def field_obs_instrument_couvis_band2(self):
-        return None
-
-    def field_obs_instrument_couvis_band_bin(self):
-        return None
-
-    def field_obs_instrument_couvis_line1(self):
-        return None
-
-    def field_obs_instrument_couvis_line2(self):
-        return None
-
-    def field_obs_instrument_couvis_line_bin(self):
-        return None
-
-    def field_obs_instrument_couvis_samples(self):
-        return None
+    def field_obs_instrument_covims_channel(self):
+        return self._create_mult('IR')

--- a/opus/import/obs_volume_ebrocc_xxxx.py
+++ b/opus/import/obs_volume_ebrocc_xxxx.py
@@ -1,7 +1,7 @@
 ################################################################################
 # obs_volume_ebrocc_xxxx.py
 #
-# Defines the ObsVolumeEBROCCXxxx class, which encapsulates fields for
+# Defines the ObsVolumeEBROCCxxxx class, which encapsulates fields for
 # the common tables for EBROCC_0001. This class supports multiple instruments
 # in a single volume.
 ################################################################################
@@ -17,7 +17,7 @@ from obs_common import ObsCommon
 # * Emission angle and north-based emission angle = incidence angle
 # * Observer elevation = 90 - incidence angle
 
-class ObsVolumeEBROCCXxxx(ObsCommon):
+class ObsVolumeEBROCCxxxx(ObsCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/opus/import/obs_volume_ebrocc_xxxx.py
+++ b/opus/import/obs_volume_ebrocc_xxxx.py
@@ -1,7 +1,7 @@
 ################################################################################
-# obs_instrument_ebrocc.py
+# obs_volume_ebrocc_xxxx.py
 #
-# Defines the ObsInstrumentEBROCC class, which encapsulates fields for
+# Defines the ObsVolumeEBROCCXxxx class, which encapsulates fields for
 # the common tables for EBROCC_0001. This class supports multiple instruments
 # in a single volume.
 ################################################################################
@@ -17,7 +17,7 @@ from obs_common import ObsCommon
 # * Emission angle and north-based emission angle = incidence angle
 # * Observer elevation = 90 - incidence angle
 
-class ObsInstrumentEBROCC(ObsCommon):
+class ObsVolumeEBROCCXxxx(ObsCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/opus/import/obs_volume_galileo_common.py
+++ b/opus/import/obs_volume_galileo_common.py
@@ -1,14 +1,14 @@
 ################################################################################
-# obs_mission_galileo.py
+# obs_volume_galileo_common.py
 #
-# Defines the ObsMissionGalileo class, which encapsulates fields in the
+# Defines the ObsVolumeGalileoCommon class, which encapsulates fields in the
 # common and obs_mission_galileo tables.
 ################################################################################
 
 from obs_common import ObsCommon
 
 
-class ObsMissionGalileo(ObsCommon):
+class ObsVolumeGalileoCommon(ObsCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/opus/import/obs_volume_go_0xxx.py
+++ b/opus/import/obs_volume_go_0xxx.py
@@ -1,7 +1,7 @@
 ################################################################################
-# obs_volume_gossi_0xxx.py
+# obs_volume_go_0xxx.py
 #
-# Defines the ObsVolumeGOSSI0xxx class, which encapsulates fields in the
+# Defines the ObsVolumeGO0xxx class, which encapsulates fields in the
 # common, obs_mission_galileo, and obs_instrument_gossi tables for GO_0xxx.
 ################################################################################
 
@@ -47,7 +47,7 @@ _GOSSI_FILTER_WAVELENGTHS = {
 # looking to see where there is a <field> or MINIMUM/MAXIMUM_<field> in the index.
 # What a mess for only 13 observations...
 
-class ObsVolumeGOSSI0xxx(ObsVolumeGalileoCommon):
+class ObsVolumeGO0xxx(ObsVolumeGalileoCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/opus/import/obs_volume_gossi_0xxx.py
+++ b/opus/import/obs_volume_gossi_0xxx.py
@@ -1,7 +1,7 @@
 ################################################################################
-# obs_instrument_gossi.py
+# obs_volume_gossi_0xxx.py
 #
-# Defines the ObsInstrumentGOSSI class, which encapsulates fields in the
+# Defines the ObsVolumeGOSSI0xxx class, which encapsulates fields in the
 # common, obs_mission_galileo, and obs_instrument_gossi tables for GO_0xxx.
 ################################################################################
 
@@ -9,7 +9,7 @@ import numpy as np
 
 import opus_support
 
-from obs_mission_galileo import ObsMissionGalileo
+from obs_volume_galileo_common import ObsVolumeGalileoCommon
 
 
 # GOSSI is 10.16 microRad / pixel and 800x800
@@ -47,7 +47,7 @@ _GOSSI_FILTER_WAVELENGTHS = {
 # looking to see where there is a <field> or MINIMUM/MAXIMUM_<field> in the index.
 # What a mess for only 13 observations...
 
-class ObsInstrumentGOSSI(ObsMissionGalileo):
+class ObsVolumeGOSSI0xxx(ObsVolumeGalileoCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -258,9 +258,9 @@ class ObsInstrumentGOSSI(ObsMissionGalileo):
         return self.field_obs_wavelength_wave_no_res1()
 
 
-    #######################################
-    ### OVERRIDE FROM ObsMissionGalileo ###
-    #######################################
+    ############################################
+    ### OVERRIDE FROM ObsVolumeGalileoCommon ###
+    ############################################
 
     def field_obs_mission_galileo_orbit_number(self):
         orbit = self._index_col('ORBIT_NUMBER')

--- a/opus/import/obs_volume_hstix_xxxx.py
+++ b/opus/import/obs_volume_hstix_xxxx.py
@@ -1,22 +1,25 @@
 ################################################################################
-# obs_instrument_hstnicmos.py
+# obs_volume_hstix_xxxx.py
 #
-# Defines the ObsInstrumentHSTNICMOS class, which encapsulates fields in the
-# common and obs_mission_hubble tables for the HST NICMOS instrument for
-# HSTNx_xxxx. Note HST does not have separate tables for each instrument but
+# Defines the ObsVolumeHSTIxXxxx class, which encapsulates fields in the
+# common and obs_mission_hubble tables for the HST WFC3 instrument for
+# HSTIx_xxxx. Note HST does not have separate tables for each instrument but
 # combines them all together.
 ################################################################################
 
-from obs_mission_hubble import ObsMissionHubble
+from obs_volume_hubble_common import ObsVolumeHubbleCommon
 
 
-class ObsInstrumentHSTNICMOS(ObsMissionHubble):
+class ObsVolumeHSTIxXxxx(ObsVolumeHubbleCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
 
-    def _nicmos_spec_flag(self):
+    def _wfc3_spec_flag(self):
         filter1, filter2 = self._decode_filters()
+        if filter2 is not None:
+            self._log_nonrepeating_error('filter2 not None')
+            return None
         return filter1.startswith('G'), filter1, filter2
 
 
@@ -26,7 +29,7 @@ class ObsInstrumentHSTNICMOS(ObsMissionHubble):
 
     @property
     def instrument_id(self):
-        return 'HSTNICMOS'
+        return 'HSTWFC3'
 
 
     ################################
@@ -34,10 +37,9 @@ class ObsInstrumentHSTNICMOS(ObsMissionHubble):
     ################################
 
     def _observation_type(self):
-        if self._nicmos_spec_flag()[0]:
+        if self._wfc3_spec_flag()[0]:
             return 'SPI'
         return 'IMG'
-
 
     def field_obs_general_observation_type(self):
         return self._create_mult(self._observation_type())
@@ -50,7 +52,7 @@ class ObsInstrumentHSTNICMOS(ObsMissionHubble):
     def field_obs_type_image_levels(self):
         if not self._is_image():
             return None
-        return 65536 # NICMOS Inst Handbook, Sec 7.2.1
+        return 65536 # WFC3 Inst Handbook, Sec 2.2.3
 
 
     ###################################
@@ -58,49 +60,58 @@ class ObsInstrumentHSTNICMOS(ObsMissionHubble):
     ###################################
 
     def field_obs_wavelength_spec_flag(self):
-        if self._nicmos_spec_flag()[0]:
+        if self._wfc3_spec_flag()[0]:
             return self._create_mult('Y')
         return self._create_mult('N')
 
     def field_obs_wavelength_spec_size(self):
-        spec_flag, filter1, filter2 = self._nicmos_spec_flag()
-        if filter2 is not None:
-            self._log_nonrepeating_error('filter2 not None')
-            return None
+        spec_flag, filter1, filter2 = self._wfc3_spec_flag()
         if not spec_flag:
             return None
-        # For NICMOS, the entire detector is used for the spectrum, but we don't
-        # know which direction it goes in, so just be generous and give the maximum
-        # dimension of the image.
+
+        # We can't use WAVELENGTH_RESOLUTION because it's too aggressive.
+        # Instead we use the Resolving Power (lambda / d-lambda) from WFC3 Inst
+        # Handbook Table 8.1
+
+        if filter1 == 'G280':
+            wr = 300. / 70 * .001
+            bw = (450-190) * .001
+        elif filter1 == 'G102':
+            wr = 1000. / 210 * .001
+            bw = (1150-800) * .001
+        elif filter1 == 'G141':
+            wr = 1400. / 130 * .001
+            bw = (1700-1075) * .001
+        else:
+            assert False, filter1
+
+        spec_size = bw // wr
+
         lines = self._index_col('LINES')
         samples = self._index_col('LINE_SAMPLES')
-        if lines is None and samples is None:
-            return None
-        if lines is None:
-            return samples
-        if samples is None:
-            return lines
-        return max(lines, samples)
+        if lines is None or samples is None:
+            return spec_size
+
+        return min(max(lines, samples), spec_size)
 
     def field_obs_wavelength_polarization_type(self):
-        filter_name = self._index_col('FILTER_NAME')
-        if filter_name.find('POL') == -1:
-            return self._create_mult('NONE')
-        return self._create_mult('LINEAR')
+        return self._create_mult('NONE')
 
 
-    ######################################
-    ### OVERRIDE FROM ObsMissionHubble ###
-    ######################################
+    ###########################################
+    ### OVERRIDE FROM ObsVolumeHubbleCommon ###
+    ###########################################
 
     def field_obs_mission_hubble_filter_type(self):
         filter1, filter2 = self._decode_filters()
 
-        # NICMOS doesn't do filter stacking
+        # WFC3 doesn't do filter stacking
         if filter2 is not None:
             self._log_nonrepeating_error('filter2 not None')
             return self._create_mult(None)
 
+        if filter1.startswith('FR'):
+            return self._create_mult('FR')
         if filter1.startswith('G'):
             return self._create_mult('SP')
         if filter1.endswith('N'):
@@ -109,17 +120,10 @@ class ObsInstrumentHSTNICMOS(ObsMissionHubble):
             return self._create_mult('M')
         if filter1.endswith('W'):
             return self._create_mult('W')
-
-        if filter1.startswith('POL'):
-            if filter1.endswith('S'):
-                # POLxS is 0.8-1.3, about the same as wide filters
-                return self._create_mult('W')
-            elif filter1.endswith('L'):
-                # POLxL is 1.89-2.1, about the same as medium filters
-                return self._create_mult('M')
-
-        if filter1 == 'BLANK': # Opaque
-            return self._create_mult('OT')
+        if filter1.endswith('LP'):
+            return self._create_mult('LP')
+        if filter1.endswith('X'):
+            return self._create_mult('X')
 
         self._log_nonrepeating_error(f'Unknown filter "{filter1}"')
         return self._create_mult(None)

--- a/opus/import/obs_volume_hstix_xxxx.py
+++ b/opus/import/obs_volume_hstix_xxxx.py
@@ -1,7 +1,7 @@
 ################################################################################
 # obs_volume_hstix_xxxx.py
 #
-# Defines the ObsVolumeHSTIxXxxx class, which encapsulates fields in the
+# Defines the ObsVolumeHSTIxxxxx class, which encapsulates fields in the
 # common and obs_mission_hubble tables for the HST WFC3 instrument for
 # HSTIx_xxxx. Note HST does not have separate tables for each instrument but
 # combines them all together.
@@ -10,7 +10,7 @@
 from obs_volume_hubble_common import ObsVolumeHubbleCommon
 
 
-class ObsVolumeHSTIxXxxx(ObsVolumeHubbleCommon):
+class ObsVolumeHSTIxxxxx(ObsVolumeHubbleCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/opus/import/obs_volume_hstjx_xxxx.py
+++ b/opus/import/obs_volume_hstjx_xxxx.py
@@ -1,16 +1,16 @@
 ################################################################################
-# obs_instrument_hstacs.py
+# obs_volume_hstjx_xxxx.py
 #
-# Defines the ObsInstrumentHSTACS class, which encapsulates fields in the
+# Defines the ObsVolumeHSTJxXxxx class, which encapsulates fields in the
 # common and obs_mission_hubble tables for the HST ACS instrument for
 # HSTJx_xxxx. Note HST does not have separate tables for each instrument but
 # combines them all together.
 ################################################################################
 
-from obs_mission_hubble import ObsMissionHubble
+from obs_volume_hubble_common import ObsVolumeHubbleCommon
 
 
-class ObsInstrumentHSTACS(ObsMissionHubble):
+class ObsVolumeHSTJxXxxx(ObsVolumeHubbleCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -107,9 +107,9 @@ class ObsInstrumentHSTACS(ObsMissionHubble):
         return self._create_mult('NONE')
 
 
-    ######################################
-    ### OVERRIDE FROM ObsMissionHubble ###
-    ######################################
+    ###########################################
+    ### OVERRIDE FROM ObsVolumeHubbleCommon ###
+    ###########################################
 
     def field_obs_mission_hubble_filter_type(self):
         filter1, filter2 = self._decode_filters()

--- a/opus/import/obs_volume_hstjx_xxxx.py
+++ b/opus/import/obs_volume_hstjx_xxxx.py
@@ -1,7 +1,7 @@
 ################################################################################
 # obs_volume_hstjx_xxxx.py
 #
-# Defines the ObsVolumeHSTJxXxxx class, which encapsulates fields in the
+# Defines the ObsVolumeHSTJxxxxx class, which encapsulates fields in the
 # common and obs_mission_hubble tables for the HST ACS instrument for
 # HSTJx_xxxx. Note HST does not have separate tables for each instrument but
 # combines them all together.
@@ -10,7 +10,7 @@
 from obs_volume_hubble_common import ObsVolumeHubbleCommon
 
 
-class ObsVolumeHSTJxXxxx(ObsVolumeHubbleCommon):
+class ObsVolumeHSTJxxxxx(ObsVolumeHubbleCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/opus/import/obs_volume_hstnx_xxxx.py
+++ b/opus/import/obs_volume_hstnx_xxxx.py
@@ -1,7 +1,7 @@
 ################################################################################
 # obs_volume_hstnx_xxxx.py
 #
-# Defines the ObsVolumeHSTNxXxxx class, which encapsulates fields in the
+# Defines the ObsVolumeHSTNxxxxx class, which encapsulates fields in the
 # common and obs_mission_hubble tables for the HST NICMOS instrument for
 # HSTNx_xxxx. Note HST does not have separate tables for each instrument but
 # combines them all together.
@@ -10,7 +10,7 @@
 from obs_volume_hubble_common import ObsVolumeHubbleCommon
 
 
-class ObsVolumeHSTNxXxxx(ObsVolumeHubbleCommon):
+class ObsVolumeHSTNxxxxx(ObsVolumeHubbleCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/opus/import/obs_volume_hstnx_xxxx.py
+++ b/opus/import/obs_volume_hstnx_xxxx.py
@@ -1,25 +1,22 @@
 ################################################################################
-# obs_instrument_hstwfc3.py
+# obs_volume_hstnx_xxxx.py
 #
-# Defines the ObsInstrumentHSTWFC3 class, which encapsulates fields in the
-# common and obs_mission_hubble tables for the HST WFC3 instrument for
-# HSTIx_xxxx. Note HST does not have separate tables for each instrument but
+# Defines the ObsVolumeHSTNxXxxx class, which encapsulates fields in the
+# common and obs_mission_hubble tables for the HST NICMOS instrument for
+# HSTNx_xxxx. Note HST does not have separate tables for each instrument but
 # combines them all together.
 ################################################################################
 
-from obs_mission_hubble import ObsMissionHubble
+from obs_volume_hubble_common import ObsVolumeHubbleCommon
 
 
-class ObsInstrumentHSTWFC3(ObsMissionHubble):
+class ObsVolumeHSTNxXxxx(ObsVolumeHubbleCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
 
-    def _wfc3_spec_flag(self):
+    def _nicmos_spec_flag(self):
         filter1, filter2 = self._decode_filters()
-        if filter2 is not None:
-            self._log_nonrepeating_error('filter2 not None')
-            return None
         return filter1.startswith('G'), filter1, filter2
 
 
@@ -29,7 +26,7 @@ class ObsInstrumentHSTWFC3(ObsMissionHubble):
 
     @property
     def instrument_id(self):
-        return 'HSTWFC3'
+        return 'HSTNICMOS'
 
 
     ################################
@@ -37,9 +34,10 @@ class ObsInstrumentHSTWFC3(ObsMissionHubble):
     ################################
 
     def _observation_type(self):
-        if self._wfc3_spec_flag()[0]:
+        if self._nicmos_spec_flag()[0]:
             return 'SPI'
         return 'IMG'
+
 
     def field_obs_general_observation_type(self):
         return self._create_mult(self._observation_type())
@@ -52,7 +50,7 @@ class ObsInstrumentHSTWFC3(ObsMissionHubble):
     def field_obs_type_image_levels(self):
         if not self._is_image():
             return None
-        return 65536 # WFC3 Inst Handbook, Sec 2.2.3
+        return 65536 # NICMOS Inst Handbook, Sec 7.2.1
 
 
     ###################################
@@ -60,58 +58,49 @@ class ObsInstrumentHSTWFC3(ObsMissionHubble):
     ###################################
 
     def field_obs_wavelength_spec_flag(self):
-        if self._wfc3_spec_flag()[0]:
+        if self._nicmos_spec_flag()[0]:
             return self._create_mult('Y')
         return self._create_mult('N')
 
     def field_obs_wavelength_spec_size(self):
-        spec_flag, filter1, filter2 = self._wfc3_spec_flag()
+        spec_flag, filter1, filter2 = self._nicmos_spec_flag()
+        if filter2 is not None:
+            self._log_nonrepeating_error('filter2 not None')
+            return None
         if not spec_flag:
             return None
-
-        # We can't use WAVELENGTH_RESOLUTION because it's too aggressive.
-        # Instead we use the Resolving Power (lambda / d-lambda) from WFC3 Inst
-        # Handbook Table 8.1
-
-        if filter1 == 'G280':
-            wr = 300. / 70 * .001
-            bw = (450-190) * .001
-        elif filter1 == 'G102':
-            wr = 1000. / 210 * .001
-            bw = (1150-800) * .001
-        elif filter1 == 'G141':
-            wr = 1400. / 130 * .001
-            bw = (1700-1075) * .001
-        else:
-            assert False, filter1
-
-        spec_size = bw // wr
-
+        # For NICMOS, the entire detector is used for the spectrum, but we don't
+        # know which direction it goes in, so just be generous and give the maximum
+        # dimension of the image.
         lines = self._index_col('LINES')
         samples = self._index_col('LINE_SAMPLES')
-        if lines is None or samples is None:
-            return spec_size
-
-        return min(max(lines, samples), spec_size)
+        if lines is None and samples is None:
+            return None
+        if lines is None:
+            return samples
+        if samples is None:
+            return lines
+        return max(lines, samples)
 
     def field_obs_wavelength_polarization_type(self):
-        return self._create_mult('NONE')
+        filter_name = self._index_col('FILTER_NAME')
+        if filter_name.find('POL') == -1:
+            return self._create_mult('NONE')
+        return self._create_mult('LINEAR')
 
 
-    ######################################
-    ### OVERRIDE FROM ObsMissionHubble ###
-    ######################################
+    ###########################################
+    ### OVERRIDE FROM ObsVolumeHubbleCommon ###
+    ###########################################
 
     def field_obs_mission_hubble_filter_type(self):
         filter1, filter2 = self._decode_filters()
 
-        # WFC3 doesn't do filter stacking
+        # NICMOS doesn't do filter stacking
         if filter2 is not None:
             self._log_nonrepeating_error('filter2 not None')
             return self._create_mult(None)
 
-        if filter1.startswith('FR'):
-            return self._create_mult('FR')
         if filter1.startswith('G'):
             return self._create_mult('SP')
         if filter1.endswith('N'):
@@ -120,10 +109,17 @@ class ObsInstrumentHSTWFC3(ObsMissionHubble):
             return self._create_mult('M')
         if filter1.endswith('W'):
             return self._create_mult('W')
-        if filter1.endswith('LP'):
-            return self._create_mult('LP')
-        if filter1.endswith('X'):
-            return self._create_mult('X')
+
+        if filter1.startswith('POL'):
+            if filter1.endswith('S'):
+                # POLxS is 0.8-1.3, about the same as wide filters
+                return self._create_mult('W')
+            elif filter1.endswith('L'):
+                # POLxL is 1.89-2.1, about the same as medium filters
+                return self._create_mult('M')
+
+        if filter1 == 'BLANK': # Opaque
+            return self._create_mult('OT')
 
         self._log_nonrepeating_error(f'Unknown filter "{filter1}"')
         return self._create_mult(None)

--- a/opus/import/obs_volume_hstox_xxxx.py
+++ b/opus/import/obs_volume_hstox_xxxx.py
@@ -1,7 +1,7 @@
 ################################################################################
 # obs_volume_hstox_xxxx.py
 #
-# Defines the ObsVolumeHSTOxXxxx class, which encapsulates fields in the
+# Defines the ObsVolumeHSTOxxxxx class, which encapsulates fields in the
 # common and obs_mission_hubble tables for the HST STIS instrument for
 # HSTOx_xxxx. Note HST does not have separate tables for each instrument but
 # combines them all together.
@@ -10,7 +10,7 @@
 from obs_volume_hubble_common import ObsVolumeHubbleCommon
 
 
-class ObsVolumeHSTOxXxxx(ObsVolumeHubbleCommon):
+class ObsVolumeHSTOxxxxx(ObsVolumeHubbleCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/opus/import/obs_volume_hstox_xxxx.py
+++ b/opus/import/obs_volume_hstox_xxxx.py
@@ -1,16 +1,16 @@
 ################################################################################
-# obs_instrument_hststis.py
+# obs_volume_hstox_xxxx.py
 #
-# Defines the ObsInstrumentHSTSTIS class, which encapsulates fields in the
+# Defines the ObsVolumeHSTOxXxxx class, which encapsulates fields in the
 # common and obs_mission_hubble tables for the HST STIS instrument for
 # HSTOx_xxxx. Note HST does not have separate tables for each instrument but
 # combines them all together.
 ################################################################################
 
-from obs_mission_hubble import ObsMissionHubble
+from obs_volume_hubble_common import ObsVolumeHubbleCommon
 
 
-class ObsInstrumentHSTSTIS(ObsMissionHubble):
+class ObsVolumeHSTOxXxxx(ObsVolumeHubbleCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -108,9 +108,9 @@ class ObsInstrumentHSTSTIS(ObsMissionHubble):
         return self._create_mult('NONE')
 
 
-    ######################################
-    ### OVERRIDE FROM ObsMissionHubble ###
-    ######################################
+    ###########################################
+    ### OVERRIDE FROM ObsVolumeHubbleCommon ###
+    ###########################################
 
     def field_obs_mission_hubble_filter_type(self):
         filter1, filter2 = self._decode_filters()

--- a/opus/import/obs_volume_hstux_xxxx.py
+++ b/opus/import/obs_volume_hstux_xxxx.py
@@ -1,7 +1,7 @@
 ################################################################################
 # obs_volume_hstux_xxxx.py
 #
-# Defines the ObsVolumeHSTUxXxxx class, which encapsulates fields in the
+# Defines the ObsVolumeHSTUxxxxx class, which encapsulates fields in the
 # common and obs_mission_hubble tables for the HST WFPC2 instrument for
 # HSTUx_xxxx. Note HST does not have separate tables for each instrument but
 # combines them all together.
@@ -10,7 +10,7 @@
 from obs_volume_hubble_common import ObsVolumeHubbleCommon
 
 
-class ObsVolumeHSTUxXxxx(ObsVolumeHubbleCommon):
+class ObsVolumeHSTUxxxxx(ObsVolumeHubbleCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/opus/import/obs_volume_hstux_xxxx.py
+++ b/opus/import/obs_volume_hstux_xxxx.py
@@ -1,16 +1,16 @@
 ################################################################################
-# obs_instrument_hstwfpc2.py
+# obs_volume_hstux_xxxx.py
 #
-# Defines the ObsInstrumentHSTWFPC2 class, which encapsulates fields in the
+# Defines the ObsVolumeHSTUxXxxx class, which encapsulates fields in the
 # common and obs_mission_hubble tables for the HST WFPC2 instrument for
 # HSTUx_xxxx. Note HST does not have separate tables for each instrument but
 # combines them all together.
 ################################################################################
 
-from obs_mission_hubble import ObsMissionHubble
+from obs_volume_hubble_common import ObsVolumeHubbleCommon
 
 
-class ObsInstrumentHSTWFPC2(ObsMissionHubble):
+class ObsVolumeHSTUxXxxx(ObsVolumeHubbleCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -62,9 +62,9 @@ class ObsInstrumentHSTWFPC2(ObsMissionHubble):
         return self._create_mult('LINEAR')
 
 
-    ######################################
-    ### OVERRIDE FROM ObsMissionHubble ###
-    ######################################
+    ###########################################
+    ### OVERRIDE FROM ObsVolumeHubbleCommon ###
+    ###########################################
 
     def field_obs_mission_hubble_filter_type(self):
         filter1, filter2 = self._decode_filters()

--- a/opus/import/obs_volume_hubble_common.py
+++ b/opus/import/obs_volume_hubble_common.py
@@ -1,7 +1,7 @@
 ################################################################################
-# obs_mission_hubble.py
+# obs_volume_hubble_common.py
 #
-# Defines the ObsMissionHubble class, which encapsulates fields in the
+# Defines the ObsVolumeHubbleCommon class, which encapsulates fields in the
 # common and obs_mission_hubble tables. Note HST does not have separate tables
 # for each instrument but combines them all together.
 ################################################################################
@@ -9,7 +9,7 @@
 from obs_common import ObsCommon
 
 
-class ObsMissionHubble(ObsCommon):
+class ObsVolumeHubbleCommon(ObsCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/opus/import/obs_volume_new_horizons_common.py
+++ b/opus/import/obs_volume_new_horizons_common.py
@@ -1,7 +1,7 @@
 ################################################################################
-# obs_mission_new_horizons.py
+# obs_volume_new_horizons_common.py
 #
-# Defines the ObsMissionNewHorizons class, which encapsulates fields in the
+# Defines the ObsVolumeNewHorizonsCommon class, which encapsulates fields in the
 # common and obs_mission_new_horizons tables.
 ################################################################################
 
@@ -20,7 +20,7 @@ _MISSION_PHASE_NAMES = {
     'KEM1 ENCOUNTER':                 'KEM1 Encounter',
 }
 
-class ObsMissionNewHorizons(ObsCommon):
+class ObsVolumeNewHorizonsCommon(ObsCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/opus/import/obs_volume_nhxxlo_xxxx.py
+++ b/opus/import/obs_volume_nhxxlo_xxxx.py
@@ -1,15 +1,15 @@
 ################################################################################
-# obs_instrument_nhmvic.py
+# obs_volume_nhxxlo_xxxx.py
 #
-# Defines the ObsInstrumentNHMVIC class, which encapsulates fields in the
-# common, obs_mission_new_horizons, and obs_instrument_nhmvic tables for
-# NHxxMV_xxxx.
+# Defines the ObsVolumeNHxxLOXxxx class, which encapsulates fields in the
+# common, obs_mission_new_horizons, and obs_instrument_nhlorri tables for
+# NHxxLO_xxxx.
 ################################################################################
 
-from obs_mission_new_horizons import ObsMissionNewHorizons
+from obs_volume_new_horizons_common import ObsVolumeNewHorizonsCommon
 
 
-class ObsInstrumentNHMVIC(ObsMissionNewHorizons):
+class ObsVolumeNHxxLOXxxx(ObsVolumeNewHorizonsCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -20,7 +20,7 @@ class ObsInstrumentNHMVIC(ObsMissionNewHorizons):
 
     @property
     def instrument_id(self):
-        return 'NHMVIC'
+        return 'NHLORRI'
 
     @property
     def inst_host_id(self):
@@ -55,7 +55,7 @@ class ObsInstrumentNHMVIC(ObsMissionNewHorizons):
     def field_obs_general_observation_duration(self):
         return self._supp_index_col('EXPOSURE_DURATION')
 
-    # We occasionally don't bother to generate ring_geo data for NHMVIC, like during
+    # We occasionally don't bother to generate ring_geo data for NHLORRI, like during
     # cruise, so just use the given RA/DEC from the label if needed. We don't make
     # any effort to figure out the min/max values.
     def field_obs_general_right_asc1(self):
@@ -83,9 +83,7 @@ class ObsInstrumentNHMVIC(ObsMissionNewHorizons):
         return self._supp_index_col('DECLINATION')
 
     def field_obs_general_ring_obs_id(self):
-        filename = self._index_col('FILE_NAME')
-        image_num = filename[4:14]
-        camera = filename[:3].upper()
+        image_num = self._index_col('FILE_NAME')[4:14]
         start_time = self._index_col('START_TIME')
         # This is really dumb, but it's what the old OPUS did so we do it for
         # backwards compatability
@@ -93,7 +91,7 @@ class ObsInstrumentNHMVIC(ObsMissionNewHorizons):
             pl_str = 'P'
         else:
             pl_str = 'J'
-        return f'{pl_str}_IMG_NH_MVIC_{image_num}_{camera}'
+        return f'{pl_str}_IMG_NH_LORRI_{image_num}'
 
     def field_obs_general_quantity(self):
         return self._create_mult('REFLECT')
@@ -107,7 +105,7 @@ class ObsInstrumentNHMVIC(ObsMissionNewHorizons):
     ##################################
 
     def field_obs_type_image_image_type_id(self):
-        return self._create_mult('PUSH')
+        return self._create_mult('FRAM')
 
     def field_obs_type_image_duration(self):
         return self.field_obs_general_observation_duration()
@@ -116,10 +114,10 @@ class ObsInstrumentNHMVIC(ObsMissionNewHorizons):
         return 4096
 
     def field_obs_type_image_greater_pixel_size(self):
-        return 5024
+        return 1024
 
     def field_obs_type_image_lesser_pixel_size(self):
-        return 128
+        return 1024
 
 
     ###################################
@@ -127,16 +125,16 @@ class ObsInstrumentNHMVIC(ObsMissionNewHorizons):
     ###################################
 
     def field_obs_wavelength_wavelength1(self):
-        return 0.4
+        return 0.35
 
     def field_obs_wavelength_wavelength2(self):
-        return 0.975
+        return 0.85
 
     def field_obs_wavelength_wave_res1(self):
-        return 0.575
+        return 0.5
 
     def field_obs_wavelength_wave_res2(self):
-        return 0.575
+        return 0.5
 
     def field_obs_wavelength_wave_no_res1(self):
         wno1 = self.field_obs_wavelength_wave_no1()
@@ -149,19 +147,22 @@ class ObsInstrumentNHMVIC(ObsMissionNewHorizons):
         return self.field_obs_wavelength_wave_no_res1()
 
 
-    ###############################################
-    ### FIELD METHODS FOR obs_instrument_nhmvic ###
-    ###############################################
+    ################################################
+    ### FIELD METHODS FOR obs_instrument_nhlorri ###
+    ################################################
 
-    def field_obs_instrument_nhmvic_opus_id(self):
+    def field_obs_instrument_nhlorri_opus_id(self):
         return self.opus_id
 
-    def field_obs_instrument_nhmvic_bundle_id(self):
+    def field_obs_instrument_nhlorri_bundle_id(self):
         return self.bundle
 
-    def field_obs_instrument_nhmvic_instrument_id(self):
+    def field_obs_instrument_nhlorri_instrument_id(self):
         return self.instrument_id
 
-    def field_obs_instrument_nhmvic_instrument_compression_type(self):
+    def field_obs_instrument_nhlorri_instrument_compression_type(self):
         compression_type = self._supp_index_col('INSTRUMENT_COMPRESSION_TYPE')
         return self._create_mult(compression_type)
+
+    def field_obs_instrument_nhlorri_binning_mode(self):
+        return self._create_mult(self._supp_index_col('BINNING_MODE'))

--- a/opus/import/obs_volume_nhxxmv_xxxx.py
+++ b/opus/import/obs_volume_nhxxmv_xxxx.py
@@ -1,15 +1,15 @@
 ################################################################################
-# obs_instrument_nhlorri.py
+# obs_volume_nhxxmv_xxxx.py
 #
-# Defines the ObsInstrumentNHLORRI class, which encapsulates fields in the
-# common, obs_mission_new_horizons, and obs_instrument_nhlorri tables for
-# NHxxLO_xxxx.
+# Defines the ObsVolumeNHxxMVXxxx class, which encapsulates fields in the
+# common, obs_mission_new_horizons, and obs_instrument_nhmvic tables for
+# NHxxMV_xxxx.
 ################################################################################
 
-from obs_mission_new_horizons import ObsMissionNewHorizons
+from obs_volume_new_horizons_common import ObsVolumeNewHorizonsCommon
 
 
-class ObsInstrumentNHLORRI(ObsMissionNewHorizons):
+class ObsVolumeNHxxMVXxxx(ObsVolumeNewHorizonsCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -20,7 +20,7 @@ class ObsInstrumentNHLORRI(ObsMissionNewHorizons):
 
     @property
     def instrument_id(self):
-        return 'NHLORRI'
+        return 'NHMVIC'
 
     @property
     def inst_host_id(self):
@@ -55,7 +55,7 @@ class ObsInstrumentNHLORRI(ObsMissionNewHorizons):
     def field_obs_general_observation_duration(self):
         return self._supp_index_col('EXPOSURE_DURATION')
 
-    # We occasionally don't bother to generate ring_geo data for NHLORRI, like during
+    # We occasionally don't bother to generate ring_geo data for NHMVIC, like during
     # cruise, so just use the given RA/DEC from the label if needed. We don't make
     # any effort to figure out the min/max values.
     def field_obs_general_right_asc1(self):
@@ -83,7 +83,9 @@ class ObsInstrumentNHLORRI(ObsMissionNewHorizons):
         return self._supp_index_col('DECLINATION')
 
     def field_obs_general_ring_obs_id(self):
-        image_num = self._index_col('FILE_NAME')[4:14]
+        filename = self._index_col('FILE_NAME')
+        image_num = filename[4:14]
+        camera = filename[:3].upper()
         start_time = self._index_col('START_TIME')
         # This is really dumb, but it's what the old OPUS did so we do it for
         # backwards compatability
@@ -91,7 +93,7 @@ class ObsInstrumentNHLORRI(ObsMissionNewHorizons):
             pl_str = 'P'
         else:
             pl_str = 'J'
-        return f'{pl_str}_IMG_NH_LORRI_{image_num}'
+        return f'{pl_str}_IMG_NH_MVIC_{image_num}_{camera}'
 
     def field_obs_general_quantity(self):
         return self._create_mult('REFLECT')
@@ -105,7 +107,7 @@ class ObsInstrumentNHLORRI(ObsMissionNewHorizons):
     ##################################
 
     def field_obs_type_image_image_type_id(self):
-        return self._create_mult('FRAM')
+        return self._create_mult('PUSH')
 
     def field_obs_type_image_duration(self):
         return self.field_obs_general_observation_duration()
@@ -114,10 +116,10 @@ class ObsInstrumentNHLORRI(ObsMissionNewHorizons):
         return 4096
 
     def field_obs_type_image_greater_pixel_size(self):
-        return 1024
+        return 5024
 
     def field_obs_type_image_lesser_pixel_size(self):
-        return 1024
+        return 128
 
 
     ###################################
@@ -125,16 +127,16 @@ class ObsInstrumentNHLORRI(ObsMissionNewHorizons):
     ###################################
 
     def field_obs_wavelength_wavelength1(self):
-        return 0.35
+        return 0.4
 
     def field_obs_wavelength_wavelength2(self):
-        return 0.85
+        return 0.975
 
     def field_obs_wavelength_wave_res1(self):
-        return 0.5
+        return 0.575
 
     def field_obs_wavelength_wave_res2(self):
-        return 0.5
+        return 0.575
 
     def field_obs_wavelength_wave_no_res1(self):
         wno1 = self.field_obs_wavelength_wave_no1()
@@ -147,22 +149,19 @@ class ObsInstrumentNHLORRI(ObsMissionNewHorizons):
         return self.field_obs_wavelength_wave_no_res1()
 
 
-    ################################################
-    ### FIELD METHODS FOR obs_instrument_nhlorri ###
-    ################################################
+    ###############################################
+    ### FIELD METHODS FOR obs_instrument_nhmvic ###
+    ###############################################
 
-    def field_obs_instrument_nhlorri_opus_id(self):
+    def field_obs_instrument_nhmvic_opus_id(self):
         return self.opus_id
 
-    def field_obs_instrument_nhlorri_bundle_id(self):
+    def field_obs_instrument_nhmvic_bundle_id(self):
         return self.bundle
 
-    def field_obs_instrument_nhlorri_instrument_id(self):
+    def field_obs_instrument_nhmvic_instrument_id(self):
         return self.instrument_id
 
-    def field_obs_instrument_nhlorri_instrument_compression_type(self):
+    def field_obs_instrument_nhmvic_instrument_compression_type(self):
         compression_type = self._supp_index_col('INSTRUMENT_COMPRESSION_TYPE')
         return self._create_mult(compression_type)
-
-    def field_obs_instrument_nhlorri_binning_mode(self):
-        return self._create_mult(self._supp_index_col('BINNING_MODE'))

--- a/opus/import/obs_volume_vg28xx.py
+++ b/opus/import/obs_volume_vg28xx.py
@@ -1,16 +1,16 @@
 ################################################################################
-# obs_instrument_vg28xx.py
+# obs_volume_vg28xx.py
 #
-# Defines the ObsInstrumentVG28xx class, the parent for the
-# ObsInstrumentVG28xxVGISS, ObsInstrumentVG28xxVGPPS, ObsInstrumentVG28xxVGRSS,
-# and ObsInstrumentVG28xxVGUVS classes, which encapsulate
+# Defines the ObsVolumeVG28xx class, the parent for the
+# ObsVolumeVG28xxVGISS, ObsVolumeVG28xxVGPPS, ObsVolumeVG28xxVGRSS,
+# and ObsVolumeVG28xxVGUVS classes, which encapsulate
 # fields in the common, obs_mission_voyager, and (sometimes)
 # obs_instrument_vgiss tables for the VG_28XX volumes.
 ################################################################################
 
 import julian
 
-from obs_mission_voyager import ObsMissionVoyager
+from obs_volume_voyager_common import ObsVolumeVoyagerCommon
 
 
 _VG_TARGET_TO_MISSION_PHASE_MAPPING = {
@@ -49,7 +49,7 @@ THRESHOLD_START_TIME_VG_AT_NORTH = julian.tai_from_iso(
 # and VGUVS have in common in the VG_28xx reflection/occultation profile
 # volumes.
 
-class ObsInstrumentVG28xx(ObsMissionVoyager):
+class ObsVolumeVG28xx(ObsVolumeVoyagerCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -192,9 +192,9 @@ class ObsInstrumentVG28xx(ObsMissionVoyager):
                                       column='RING_EVENT_STOP_TIME')
 
 
-    #######################################
-    ### OVERRIDE FROM ObsMissionVoyager ###
-    #######################################
+    ############################################
+    ### OVERRIDE FROM ObsVolumeVoyagerCommon ###
+    ############################################
 
     def _mission_phase_name(self):
         target_name = self._index_col('TARGET_NAME').upper()

--- a/opus/import/obs_volume_vg28xx_vgiss.py
+++ b/opus/import/obs_volume_vg28xx_vgiss.py
@@ -1,15 +1,15 @@
 ################################################################################
-# obs_instrument_vg28xx_vgiss.py
+# obs_volume_vg28xx_vgiss.py
 #
 # Defines the ObsInstrumentVG28xxISS class, which encapsulates fields for the
 # common, obs_mission_voyager, and obs_instrument_vgiss tables for VG_2810
 # radial profiles.
 ################################################################################
 
-from obs_instrument_vg28xx import ObsInstrumentVG28xx
+from obs_volume_vg28xx import ObsVolumeVG28xx
 
 
-class ObsInstrumentVG28xxVGISS(ObsInstrumentVG28xx):
+class ObsVolumeVG28xxVGISS(ObsVolumeVG28xx):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/opus/import/obs_volume_vg28xx_vgpps_vguvs.py
+++ b/opus/import/obs_volume_vg28xx_vgpps_vguvs.py
@@ -1,5 +1,5 @@
 ################################################################################
-# obs_instrument_vg28xx_vgpps_vguvs.py
+# obs_volume_vg28xx_vgpps_vguvs.py
 #
 # Defines the ObsInstrumentVG28xxPPS and ObsInstrumentVG28xxUVS classes, which
 # encapsulate fields for the common and obs_mission_voyager tables for VGPPS
@@ -8,11 +8,11 @@
 # except for the instrument_id. Neither has a dedicated instrument table.
 ################################################################################
 
-from obs_instrument_vg28xx import (ObsInstrumentVG28xx,
+from obs_volume_vg28xx import (ObsVolumeVG28xx,
                                    THRESHOLD_START_TIME_VG_AT_NORTH)
 
 
-class ObsInstrumentVG28xxVGPPSUVS(ObsInstrumentVG28xx):
+class ObsVolumeVG28xxVGPPSUVS(ObsVolumeVG28xx):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -257,7 +257,7 @@ class ObsInstrumentVG28xxVGPPSUVS(ObsInstrumentVG28xx):
         return 90. - self.field_obs_ring_geometry_emission1()
 
 
-class ObsInstrumentVG28xxVGPPS(ObsInstrumentVG28xxVGPPSUVS):
+class ObsVolumeVG28xxVGPPS(ObsVolumeVG28xxVGPPSUVS):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -271,7 +271,7 @@ class ObsInstrumentVG28xxVGPPS(ObsInstrumentVG28xxVGPPSUVS):
         return 'VGPPS'
 
 
-class ObsInstrumentVG28xxVGUVS(ObsInstrumentVG28xxVGPPSUVS):
+class ObsVolumeVG28xxVGUVS(ObsVolumeVG28xxVGPPSUVS):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/opus/import/obs_volume_vg28xx_vgrss.py
+++ b/opus/import/obs_volume_vg28xx_vgrss.py
@@ -1,15 +1,15 @@
 ################################################################################
-# obs_instrument_vg28xx_vgrss.py
+# obs_volume_vg28xx_vgrss.py
 #
 # Defines the ObsInstrumentVG28xxRSS class, which encapsulates fields for the
 # common and obs_mission_voyager tables for VGRSS occultations in VG_2803.
 ################################################################################
 
 from config_data import DSN_NAMES
-from obs_instrument_vg28xx import ObsInstrumentVG28xx
+from obs_volume_vg28xx import ObsVolumeVG28xx
 
 
-class ObsInstrumentVG28xxVGRSS(ObsInstrumentVG28xx):
+class ObsVolumeVG28xxVGRSS(ObsVolumeVG28xx):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/opus/import/obs_volume_vgiss_5678xxx.py
+++ b/opus/import/obs_volume_vgiss_5678xxx.py
@@ -1,12 +1,12 @@
 ################################################################################
-# obs_instrument_vgiss.py
+# obs_volume_vgiss_5678xxx.py
 #
-# Defines the ObsInstrumentVGISS class, which encapsulates fields in the
+# Defines the ObsVolumeVGISS5678xxx class, which encapsulates fields in the
 # common, obs_mission_voyager, and obs_instrument_vgiss tables for
 # VGISS_[5678]xxx.
 ################################################################################
 
-from obs_mission_voyager import ObsMissionVoyager
+from obs_volume_voyager_common import ObsVolumeVoyagerCommon
 
 
 # Data from: https://pds-rings.seti.org/voyager/iss/inst_cat_wa1.html#inst_info
@@ -24,7 +24,7 @@ _VGISS_FILTER_WAVELENGTHS = {
 }
 
 
-class ObsInstrumentVGISS(ObsMissionVoyager):
+class ObsVolumeVGISS5678xxx(ObsVolumeVoyagerCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -166,9 +166,9 @@ class ObsInstrumentVGISS(ObsMissionVoyager):
         return self.field_obs_wavelength_wave_no_res1()
 
 
-    #######################################
-    ### OVERRIDE FROM ObsMissionVoyager ###
-    #######################################
+    ############################################
+    ### OVERRIDE FROM ObsVolumeVoyagerCommon ###
+    ############################################
 
     def _mission_phase_name(self):
         return self._index_col('MISSION_PHASE_NAME')

--- a/opus/import/obs_volume_voyager_common.py
+++ b/opus/import/obs_volume_voyager_common.py
@@ -1,7 +1,7 @@
 ################################################################################
-# obs_mission_voyager.py
+# obs_volume_voyager_common.py
 #
-# Defines the ObsMissionVoyager class, which encapsulates fields in the
+# Defines the ObsVolumeVoyagerCommon class, which encapsulates fields in the
 # common and obs_mission_voyager tables.
 ################################################################################
 
@@ -10,7 +10,7 @@ import opus_support
 from obs_common import ObsCommon
 
 
-class ObsMissionVoyager(ObsCommon):
+class ObsVolumeVoyagerCommon(ObsCommon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
- Fixes #1334 
- Were any Django, import pipeline, or table_schema files modified? Y
- Were any JavaScript or CSS files modified? N
  - If YES:
    - JSHINT run on all affected files: NA
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: NA
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): NA
- Was the documentation reviewed for necessary changes or additions? NA
  - About
  - Getting Started
  - FAQ
  - API Guide
  - Tooltips
  - Import/database schema

Description of changes:
Rename import files and classes. Here is the summary:
```
Format: Change (original) obs_instrument_{name} to (new) obs_volume_{volume/volset}, and for pds4: obs_bundle_{name}
obs_instrument_cassini_occ (ObsInstrumentCassiniOcc)            -> obs_volume_cassini_occ_common (ObsVolumeCassiniOccCommon)
obs_instrument_cocirs_cube (ObsInstrumentCOCIRSCube)            -> obs_volume_cocirs_01xxx (ObsVolumeCOCIRS01xxx)
obs_instrument_cocirs (ObsInstrumentCOCIRS)                     -> obs_volume_cocirs_56xxx (ObsVolumeCOCIRS56xxx)
obs_instrument_coiss (ObsInstrumentCOISS)                       -> obs_volume_coiss_12xxx (ObsVolumeCOISS12xxx)
obs_instrument_corss_occ (ObsInstrumentCORSSOcc)                -> obs_volume_corss_8xxx (ObsVolumeCORSS8xxx)
obs_instrument_couvis_covims_occ (ObsInstrumentUVISVIMSOcc)     -> obs_volume_couvis_covims_occ_common (ObsVolumeUVISVIMSOccCommon)
obs_instrument_couvis_occ (ObsInstrumentCOUVISOcc)              -> obs_volume_couvis_8xxx (ObsVolumeCOUVIS8xxx)
obs_instrument_couvis (ObsInstrumentCOUVIS)                     -> obs_volume_couvis_0xxx (ObsVolumeCOUVIS0xxx)
obs_instrument_covims_occ (ObsInstrumentCOVIMSOcc)              -> obs_volume_covims_8xxx (ObsVolumeCOVIMS8xxx)
obs_instrument_covims (ObsInstrumentCOVIMS)                     -> obs_volume_covims_0xxx (ObsVolumeCOVIMS0xxx)
obs_instrument_ebrocc (ObsInstrumentEBROCC)                     -> obs_volume_ebrocc_xxxx (ObsVolumeEBROCCXxxx)
obs_instrument_gossi (ObsInstrumentGOSSI)                       -> obs_volume_gossi_0xxx (ObsVolumeGOSSI0xxx)
obs_instrument_hstacs (ObsInstrumentHSTACS)                     -> obs_volume_hstjx_xxxx (ObsVolumeHSTJxXxxx)
obs_instrument_hstnicmos (ObsInstrumentHSTNICMOS)               -> obs_volume_hstnx_xxxx (ObsVolumeHSTNxXxxx)
obs_instrument_hststis (ObsInstrumentHSTSTIS)                   -> obs_volume_hstox_xxxx (ObsVolumeHSTOxXxxx)
obs_instrument_hstwfc3 (ObsInstrumentHSTWFC3)                   -> obs_volume_hstix_xxxx (ObsVolumeHSTIxXxxx)
obs_instrument_hstwfpc2 (ObsInstrumentHSTWFPC2)                 -> obs_volume_hstux_xxxx (ObsVolumeHSTUxXxxx)
obs_instrument_nhlorri (ObsInstrumentNHLORRI)                   -> obs_volume_nhxxlo_xxxx(ObsVolumeNHxxLOXxxx)
obs_instrument_nhmvic (ObsInstrumentNHMVIC)                     -> obs_volume_nhxxmv_xxxx (ObsVolumeNHxxMVXxxx)
obs_instrument_vg28xx_vgiss (ObsInstrumentVG28xxVGISS)          -> obs_volume_vg28xx_vgiss (ObsVolumeVG28xxVGISS)
obs_instrument_vg28xx_vgpps_vguvs (ObsInstrumentVG28xxVGPPS, 
                                   ObsInstrumentVG28xxVGPPSUVS, 
                                   ObsInstrumentVG28xxVGUVS)    -> obs_volume_vg28xx_vgpps_vguvs (ObsVolumeVG28xxVGPPS,          
                                                                                                  ObsVolumeVG28xxVGPPSUVS,
                                                                                                  ObsVolumeVG28xxVGUVS) 
obs_instrument_vg28xx_vgrss (ObsInstrumentVG28xxVGRSS)          -> obs_volume_vg28xx_vgrss (ObsVolumeVG28xxVGRSS)
obs_instrument_vg28xx (ObsInstrumentVG28xx)                     -> obs_volume_vg28xx (ObsVolumeVG28xx)
obs_instrument_vgiss (ObsInstrumentVGISS)                       -> obs_volume_vgiss_5678xxx (ObsVolumeVGISS5678xxx)

Format: Change (original) obs_mission_{name} to (new) obs_volume_{name}_common, and for pds4: obs_bundle_{name}_common
obs_mission_cassini (ObsMissionCassini)                         -> obs_volume_cassini_common (ObsVolumeCassiniCommon)
obs_mission_galileo (ObsMissionGalileo)                         -> obs_volume_galileo_common (ObsVolumeGalileoCommon)
obs_mission_hubble (ObsMissionHubble)                           -> obs_volume_hubble_common (ObsVolumeHubbleCommon)
obs_mission_new_horizons (ObsMissionNewHorizons)                -> obs_volume_new_horizons_common (ObsVolumeNewHorizonsCommon)
obs_mission_voyager (ObsMissionVoyager)                         -> obs_volume_voyager_common (ObsVolumeVoyagerCommon)
```
Known problems:
NA