### PR TITLE
Use PosixPath to parse a filename rather than a regexp

### DIFF
--- a/log_analyzer/manifest.py
+++ b/log_analyzer/manifest.py
@@ -5,6 +5,7 @@ import csv
 import itertools
 import os
 import re
+from pathlib import Path, PosixPath
 from typing import NamedTuple, Sequence, Callable, Tuple, List, Dict, Any, Optional
 
 
@@ -34,10 +35,9 @@ class ManifestEntry(NamedTuple):
 
     @property
     def volume_set(self) -> str:
-        match = re.match(r'/\w+/(\w+)[/$]', self.file_path)
-        assert match
-        return match.group(1)
-
+        path = PosixPath(self.file_path)
+        assert path.is_absolute()
+        return path.parts[2]  #   ["/" "volume" volumename, .....]
 
 class Manifest(NamedTuple):
     file_name: str


### PR DESCRIPTION
FIX #1352 

- Fixes #XXX
- Were any Django, import pipeline, or table_schema files modified? B
- Were any JavaScript or CSS files modified? N
- Was the documentation reviewed for necessary changes or additions? NA
Description of changes:

Rewrite property `volume_set` to use PosixPath rather than a regexp.  Code was failing because

1.   The regexp was bogus. [/$] doesn't mean what I intended it to mean
2.   The regexp couldn't handle hyphens and periods in the directory name
