### PR TITLE
Change Equinox and Solstice to include XM and XXM

### DIFF
--- a/opus/application/test_api/responses/results_co_cirs_cube_127en_icyplu001____uv____699_f1_039e_metadata.json
+++ b/opus/application/test_api/responses/results_co_cirs_cube_127en_icyplu001____uv____699_f1_039e_metadata.json
@@ -194,7 +194,7 @@
     "Cassini Mission Constraints": {
         "CASSINIobsname": "CIRS_127EN_ICYPLU001_UVIS",
         "CASSINIactivityname": "ICYPLU",
-        "CASSINImissionphasename": "Equinox Mission",
+        "CASSINImissionphasename": "Equinox Mission (XM)",
         "CASSINItargetcode": "EN (Enceladus)",
         "CASSINItargetname": "Saturn",
         "CASSINIrevnoint": "127",

--- a/opus/application/test_api/responses/results_co_cirs_cube_127ic_dscal10066___sp____699_f4_039p_metadata.json
+++ b/opus/application/test_api/responses/results_co_cirs_cube_127ic_dscal10066___sp____699_f4_039p_metadata.json
@@ -194,7 +194,7 @@
     "Cassini Mission Constraints": {
         "CASSINIobsname": "CIRS_127IC_DSCAL10066_SP",
         "CASSINIactivityname": "DSCAL10",
-        "CASSINImissionphasename": "Equinox Mission",
+        "CASSINImissionphasename": "Equinox Mission (XM)",
         "CASSINItargetcode": "IC (Instrument calibration)",
         "CASSINItargetname": "Saturn",
         "CASSINIrevnoint": "127",

--- a/opus/application/test_api/responses/results_co_cirs_cube_128ri_lrlemp001____is____680_f3_039r_metadata.json
+++ b/opus/application/test_api/responses/results_co_cirs_cube_128ri_lrlemp001____is____680_f3_039r_metadata.json
@@ -194,7 +194,7 @@
     "Cassini Mission Constraints": {
         "CASSINIobsname": "CIRS_128RI_LRLEMP001_ISS",
         "CASSINIactivityname": "LRLEMP",
-        "CASSINImissionphasename": "Equinox Mission",
+        "CASSINImissionphasename": "Equinox Mission (XM)",
         "CASSINItargetcode": "RI (Rings - general)",
         "CASSINItargetname": "S_Rings",
         "CASSINIrevnoint": "128",

--- a/opus/application/test_api/responses/results_co_uvis_occ_2009_015_gamcas_e_metadata.json
+++ b/opus/application/test_api/responses/results_co_uvis_occ_2009_015_gamcas_e_metadata.json
@@ -144,7 +144,7 @@
     "Cassini Mission Constraints": {
         "CASSINIobsname": "UVIS_100ST_URGAMCAS001_PRIME",
         "CASSINIactivityname": "URGAMCAS",
-        "CASSINImissionphasename": "Equinox Mission",
+        "CASSINImissionphasename": "Equinox Mission (XM)",
         "CASSINItargetcode": "ST (Star)",
         "CASSINItargetname": null,
         "CASSINIrevnoint": "100",

--- a/opus/application/test_api/responses/results_co_uvis_occ_2009_062_thehya_e_metadata.json
+++ b/opus/application/test_api/responses/results_co_uvis_occ_2009_062_thehya_e_metadata.json
@@ -144,7 +144,7 @@
     "Cassini Mission Constraints": {
         "CASSINIobsname": "UVIS_104ST_URTHEHYA001_PRIME",
         "CASSINIactivityname": "URTHEHYA",
-        "CASSINImissionphasename": "Equinox Mission",
+        "CASSINImissionphasename": "Equinox Mission (XM)",
         "CASSINItargetcode": "ST (Star)",
         "CASSINItargetname": null,
         "CASSINIrevnoint": "104",

--- a/opus/application/test_api/responses/results_co_vims_occ_2014_175_l2pup_e_metadata.json
+++ b/opus/application/test_api/responses/results_co_vims_occ_2014_175_l2pup_e_metadata.json
@@ -144,7 +144,7 @@
     "Cassini Mission Constraints": {
         "CASSINIobsname": "VIMS_205RI_L2PUPOCC002_PRIME",
         "CASSINIactivityname": "L2PUPOCC",
-        "CASSINImissionphasename": "Solstice Mission",
+        "CASSINImissionphasename": "Solstice Mission (XXM)",
         "CASSINItargetcode": "RI (Rings - general)",
         "CASSINItargetname": null,
         "CASSINIrevnoint": "205",

--- a/opus/import/obs_volume_cassini_common.py
+++ b/opus/import/obs_volume_cassini_common.py
@@ -100,8 +100,8 @@ _CASSINI_PHASE_NAME_MAPPING = (
     # The descent actually happened on Jan 14
     ('Huygens Descent',           cached_tai_from_iso('2004-360T13:30:10.410'), cached_tai_from_iso('2005-015T18:28:29.451')), # '2005-001T14:28:54.449'),
     ('Tour',                      cached_tai_from_iso('2005-015T18:28:29.451'), cached_tai_from_iso('2008-183T21:04:08.998')), # '2008-183T09:17:06.323'),
-    ('Equinox Mission',           cached_tai_from_iso('2008-183T21:04:08.998'), cached_tai_from_iso('2010-285T05:22:24.745')), # '2010-283T14:14:20.741'),
-    ('Solstice Mission',          cached_tai_from_iso('2010-285T05:22:24.745'), cached_tai_from_iso('2020-001T00:00:00.000'))
+    ('Equinox Mission (XM)',      cached_tai_from_iso('2008-183T21:04:08.998'), cached_tai_from_iso('2010-285T05:22:24.745')), # '2010-283T14:14:20.741'),
+    ('Solstice Mission (XXM)',    cached_tai_from_iso('2010-285T05:22:24.745'), cached_tai_from_iso('2020-001T00:00:00.000'))
 )
 
 # These mappings are for the TARGET_DESC field to clean them up
@@ -259,10 +259,10 @@ class ObsVolumeCassiniCommon(ObsCommonPDS3):
         # These mission phase names are interchangeable, so we standardize on
         # one version
         phase = phase.upper().replace('_', ' ')
-        if phase == 'EXTENDED MISSION':
-            phase = 'EQUINOX MISSION'
-        elif phase == 'EXTENDED-EXTENDED MISSION':
-            phase = 'SOLSTICE MISSION'
+        if phase in ('EXTENDED MISSION', 'EQUINOX MISSION'):
+            phase = 'EQUINOX MISSION (XM)'
+        elif phase in ('EXTENDED-EXTENDED MISSION', 'SOLSTICE MISSION'):
+            phase = 'SOLSTICE MISSION (XXM)'
         return phase
 
     def _cassini_mission_phase_name_from_time(self):

--- a/opus/import/table_schemas/obs_mission_cassini.json
+++ b/opus/import/table_schemas/obs_mission_cassini.json
@@ -373,8 +373,8 @@
             [  11, "HUYGENS PROBE SEPARATION", "Huygens Probe Separation", "110", "Y", null, null],
             [  12, "HUYGENS DESCENT",          "Huygens Descent",          "120", "Y", null, null],
             [  13, "TOUR",                     "Tour",                     "130", "Y", null, null],
-            [  14, "EQUINOX MISSION",          "Equinox Mission",          "140", "Y", null, null],
-            [  15, "SOLSTICE MISSION",         "Solstice Mission",         "150", "Y", null, null]
+            [  14, "EQUINOX MISSION (XM)",     "Equinox Mission (XM)",     "140", "Y", null, null],
+            [  15, "SOLSTICE MISSION (XXM)",   "Solstice Mission (XXM)",   "150", "Y", null, null]
         ]
   },
     {


### PR DESCRIPTION
- Fixes #N/A
- Were any Django, import pipeline, or table_schema files modified? Y
- Were any JavaScript or CSS files modified? N
  - If YES:
    - JSHINT run on all affected files: Y/NA
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y/NA
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): Y/NA
- Was the documentation reviewed for necessary changes or additions? Y
  - About
  - Getting Started
  - FAQ
  - API Guide
  - Tooltips
  - Import/database schema

Description of changes:

Per the discussion at the group meeting on 5/28/2024, renamed "Equinox Mission" to "Equinox Mission (XM)" and renamed "Solstice Mission" to "Solstice Mission (XXM)".

Known problems:

None
