### PR TITLE
Fix Cassini Mission phase NULL problem

### DIFF
--- a/opus/import/import_for_tests.sh
+++ b/opus/import/import_for_tests.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 echo "*************************************************************"
 echo "***** About to import TEST PDS DATA into a new database *****"
@@ -14,45 +15,25 @@ if [ "$yn" != "YES" ]; then
     exit 1
 fi
 python main_opus_import.py --drop-permanent-tables --scorched-earth $1
-if [ $? -ne 0 ]; then exit -1; fi
 python main_opus_import.py --do-all-import COISS_2002,COISS_2008,COISS_2111 $1
-if [ $? -ne 0 ]; then exit -1; fi
 python main_opus_import.py --do-all-import COUVIS_0002 $1
-if [ $? -ne 0 ]; then exit -1; fi
 python main_opus_import.py --do-all-import COVIMS_0006 $1
-if [ $? -ne 0 ]; then exit -1; fi
 python main_opus_import.py --do-all-import COCIRS_5408 $1
-if [ $? -ne 0 ]; then exit -1; fi
 python main_opus_import.py --import-check-duplicate-id --do-all-import GO_0016,GO_0017,GO_0018 $1
-if [ $? -ne 0 ]; then exit -1; fi
 python main_opus_import.py --do-all-import VGISS_6210,VGISS_8201 $1
-if [ $? -ne 0 ]; then exit -1; fi
 python main_opus_import.py --do-all-import HSTI1_3667,HSTI1_1559,HSTJ0_9975,HSTJ1_1085,HSTN0_7181,HSTO0_7316,HSTU0_5642 $1
-if [ $? -ne 0 ]; then exit -1; fi
 python main_opus_import.py --do-all-import NHPELO_1001,NHLAMV_1001,NHJUMV_1001 $1
-if [ $? -ne 0 ]; then exit -1; fi
 python main_opus_import.py --do-all-import EBROCC_0001 $1
-if [ $? -ne 0 ]; then exit -1; fi
 python main_opus_import.py --do-all-import CORSS_8001 $1
-if [ $? -ne 0 ]; then exit -1; fi
 python main_opus_import.py --do-all-import COUVIS_8001 $1
-if [ $? -ne 0 ]; then exit -1; fi
 python main_opus_import.py --do-all-import COVIMS_8001 $1
-if [ $? -ne 0 ]; then exit -1; fi
 python main_opus_import.py --do-all-import VG_28xx $1
-if [ $? -ne 0 ]; then exit -1; fi
 python main_opus_import.py --do-all-import COCIRS_0406,COCIRS_1003 $1
-if [ $? -ne 0 ]; then exit -1; fi
 python main_opus_import.py --do-all-import uranus_occ_u0_kao_91cm $1
-if [ $? -ne 0 ]; then exit -1; fi
 python main_opus_import.py --cleanup-aux-tables
-if [ $? -ne 0 ]; then exit -1; fi
 python main_opus_import.py --import-dictionary
-if [ $? -ne 0 ]; then exit -1; fi
 (cd ../application; python manage.py migrate)
-if [ $? -ne 0 ]; then exit -1; fi
 python main_opus_import.py --validate-perm
-if [ $? -ne 0 ]; then exit -1; fi
 
 echo "ALL DONE!"
 

--- a/opus/import/obs_volume_cassini_common.py
+++ b/opus/import/obs_volume_cassini_common.py
@@ -263,6 +263,8 @@ class ObsVolumeCassiniCommon(ObsCommonPDS3):
             phase = 'EQUINOX MISSION (XM)'
         elif phase in ('EXTENDED-EXTENDED MISSION', 'SOLSTICE MISSION'):
             phase = 'SOLSTICE MISSION (XXM)'
+        if phase == 'NULL':
+            phase = self._cassini_mission_phase_name_from_time()
         return phase
 
     def _cassini_mission_phase_name_from_time(self):

--- a/opus/import/obs_volume_cocirs_01xxx.py
+++ b/opus/import/obs_volume_cocirs_01xxx.py
@@ -428,8 +428,6 @@ class ObsVolumeCOCIRS01xxx(ObsVolumeCassiniCommon):
     def field_obs_mission_cassini_mission_phase_name(self):
         mp = self._supp_index_col('MISSION_PHASE_NAME')
         mp = self._cassini_normalize_mission_phase_name(mp)
-        if mp == 'NULL':
-            return self._create_mult(None)
         return self._create_mult(mp)
 
 

--- a/opus/import/obs_volume_cocirs_56xxx.py
+++ b/opus/import/obs_volume_cocirs_56xxx.py
@@ -171,8 +171,6 @@ class ObsVolumeCOCIRS56xxx(ObsVolumeCassiniCommon):
     def field_obs_mission_cassini_mission_phase_name(self):
         mp = self._index_col('MISSION_PHASE_NAME')
         mp = self._cassini_normalize_mission_phase_name(mp)
-        if mp == 'NULL':
-            return self._create_mult(None)
         return self._create_mult(mp)
 
 

--- a/opus/import/obs_volume_coiss_12xxx.py
+++ b/opus/import/obs_volume_coiss_12xxx.py
@@ -407,8 +407,6 @@ class ObsVolumeCOISS12xxx(ObsVolumeCassiniCommon):
     def field_obs_mission_cassini_mission_phase_name(self):
         mp = self._index_col('MISSION_PHASE_NAME')
         mp = self._cassini_normalize_mission_phase_name(mp)
-        if mp == 'NULL':
-            return self._create_mult(None)
         return self._create_mult(mp)
 
     def field_obs_mission_cassini_sequence_id(self):

--- a/opus/import/obs_volume_corss_8xxx.py
+++ b/opus/import/obs_volume_corss_8xxx.py
@@ -188,6 +188,4 @@ class ObsVolumeCORSS8xxx(ObsVolumeCassiniOccCommon):
     def field_obs_mission_cassini_mission_phase_name(self):
         mp = self._supp_index_col('MISSION_PHASE_NAME')
         mp = self._cassini_normalize_mission_phase_name(mp)
-        if mp == 'NULL':
-            return self._create_mult(None)
         return self._create_mult(mp)


### PR DESCRIPTION
- Fixes #N/A
- Were any Django, import pipeline, or table_schema files modified? Y
- Were any JavaScript or CSS files modified? N
  - If YES:
    - JSHINT run on all affected files: Y/NA
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y/NA
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): Y/NA
- Was the documentation reviewed for necessary changes or additions? NA
  - About
  - Getting Started
  - FAQ
  - API Guide
  - Tooltips
  - Import/database schema

Description of changes:

Some Cassini ISS observations have a MISSION_PHASE_NAME of "NULL" and we were converting these to a mult of None, which isn't permitted. Now we infer the proper mission phase name from the observation time in these cases.

Known problems:
