### PR TITLE
Turn off QR test on Windows

### DIFF
--- a/opus/application/test_api/test_help_api.py
+++ b/opus/application/test_api/test_help_api.py
@@ -4,6 +4,7 @@ import logging
 import os
 import platform
 import requests
+import unittest
 from unittest import TestCase
 
 from django.core.cache import cache

--- a/opus/application/test_api/test_help_api.py
+++ b/opus/application/test_api/test_help_api.py
@@ -93,9 +93,15 @@ class ApiHelpTests(TestCase, ApiTestHelper):
         url = '/__help/citing.html'
         self._run_status_equal(url, 200)
 
-    def test__api_help_citing_qr(self):
-        "[test_help_api.py] /__help: citing qr"
-        if os.name != 'nt':  # pragma: no cover
+    if os.name == 'nt':  # pragma: no cover
+        @unittest.expectedFailure
+        def test__api_help_citing_qr(self):
+            "[test_help_api.py] /__help: citing qr"
+            url = '/__help/citing.html?searchurl=fred&stateurl=george'
+            self._run_html_equal_file(url, 'api_help_citing_qr.html')
+    else:  # pragma: no cover
+        def test__api_help_citing_qr(self):
+            "[test_help_api.py] /__help: citing qr"
             url = '/__help/citing.html?searchurl=fred&stateurl=george'
             self._run_html_equal_file(url, 'api_help_citing_qr.html')
 

--- a/opus/application/test_api/test_help_api.py
+++ b/opus/application/test_api/test_help_api.py
@@ -1,6 +1,7 @@
 # opus/application/test_api/test_help_api.py
 
 import logging
+import os
 import platform
 import requests
 from unittest import TestCase
@@ -94,8 +95,9 @@ class ApiHelpTests(TestCase, ApiTestHelper):
 
     def test__api_help_citing_qr(self):
         "[test_help_api.py] /__help: citing qr"
-        url = '/__help/citing.html?searchurl=fred&stateurl=george'
-        self._run_html_equal_file(url, 'api_help_citing_qr.html')
+        if os.name != 'nt':  # pragma: no cover
+            url = '/__help/citing.html?searchurl=fred&stateurl=george'
+            self._run_html_equal_file(url, 'api_help_citing_qr.html')
 
     def test__api_help_citing_pdf(self):
         "[test_help_api.py] /__help: citing pdf"


### PR DESCRIPTION
- Fixes #N/A
- Is a new database import required? N
- Were test and deploy scripts reviewed for necessary changes? Y
- Were any JavaScript or CSS files modified? N
  - If YES:
    - JSHINT run on all affected files: Y/NA
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y/NA
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): Y/NA
- Was the documentation reviewed for necessary changes or additions? Y
  - About
  - Getting Started
  - FAQ
  - API Guide
  - Tooltips
  - Import/database schema

Description of changes:

- Because Windows seems to be producing slightly different binary for otherwise-identical QR codes (see #1405), the tests fail on Windows. Until we can figure out what's going on, I have disabled the single QR code test when running on Windows.

Known problems:
