### PR TITLE
Fix URL in _help file.  Clean up QR generating code

### DIFF
--- a/opus/application/apps/help/templates/help/citing.html
+++ b/opus/application/apps/help/templates/help/citing.html
@@ -27,7 +27,7 @@
     <span>
         This QR code should be used to cite OPUS as a whole.
         Note: This does not include any specific data or search results.
-        <br/><br/>(This encodes the URL <span class='op-cite-fixed-width'>https://pds-rings.seti.org/search/</span>)
+        <br/><br/>(This encodes the URL <span class='op-cite-fixed-width'>{{ basic_opus_url }}</span>)
     </span>
 </p>
 <br clear="left"/>

--- a/opus/application/apps/help/views.py
+++ b/opus/application/apps/help/views.py
@@ -217,42 +217,25 @@ def api_citing_opus(request, fmt):
     opus_search_url = request.GET.get('searchurl', None)
     opus_state_url = request.GET.get('stateurl', None)
 
-    qr = qrcode.QRCode(
-        box_size=5,
-        border=4,
-    )
-    qr.add_data(settings.PUBLIC_OPUS_URL)
-    qr.make(fit=True)
-    basic_opus_qr = qr.make_image(fill_color='black', back_color='white')
-    buffered = BytesIO()
-    basic_opus_qr.save(buffered, format='PNG')
-    basic_opus_qr_str = str(base64.b64encode(buffered.getvalue()))[2:-1]
+    def url_to_png_string(url):
+        qr = qrcode.QRCode(box_size=5, border=4)
+        qr.add_data(url)
+        qr.make(fit=True)
+        url_qr = qr.make_image(fill_color='black', back_color='white')
+        buffered = BytesIO()
+        url_qr.save(buffered, format='PNG')
+        url_qr_string = base64.b64encode(buffered.getvalue()).decode('ascii', 'strict')
+        return url_qr_string
+
+    basic_opus_qr_str = url_to_png_string(settings.PUBLIC_OPUS_URL)
 
     opus_search_qr_str = None
     if opus_search_url is not None:
-        qr = qrcode.QRCode(
-            box_size=5,
-            border=4,
-        )
-        qr.add_data(opus_search_url)
-        qr.make(fit=True)
-        opus_search_qr = qr.make_image(fill_color='black', back_color='white')
-        buffered = BytesIO()
-        opus_search_qr.save(buffered, format='PNG')
-        opus_search_qr_str = str(base64.b64encode(buffered.getvalue()))[2:-1]
+        opus_search_qr_str = url_to_png_string(opus_search_url)
 
     opus_state_qr_str = None
     if opus_state_url is not None:
-        qr = qrcode.QRCode(
-            box_size=5,
-            border=4,
-        )
-        qr.add_data(opus_state_url)
-        qr.make(fit=True)
-        opus_state_qr = qr.make_image(fill_color='black', back_color='white')
-        buffered = BytesIO()
-        opus_state_qr.save(buffered, format='PNG')
-        opus_state_qr_str = str(base64.b64encode(buffered.getvalue()))[2:-1]
+        opus_state_qr_str = url_to_png_string(opus_state_url)
 
     context = {'basic_opus_url': settings.PUBLIC_OPUS_URL,
                'basic_opus_qr': basic_opus_qr_str,
@@ -266,6 +249,9 @@ def api_citing_opus(request, fmt):
 
     exit_api_call(api_code, ret)
     return ret
+
+
+
 
 @never_cache
 def api_api_guide(request, fmt):

--- a/opus/application/apps/help/views.py
+++ b/opus/application/apps/help/views.py
@@ -251,8 +251,6 @@ def api_citing_opus(request, fmt):
     return ret
 
 
-
-
 @never_cache
 def api_api_guide(request, fmt):
     """Renders the API guide.

--- a/opus/application/test_api/responses/api_help_citing_qr.html
+++ b/opus/application/test_api/responses/api_help_citing_qr.html
@@ -18,7 +18,7 @@ a URL representing your data set. To save one of these QR codes to your computer
 <span>
 This QR code should be used to cite OPUS as a whole.
 Note: This does not include any specific data or search results.
-<br/><br/>(This encodes the URL <span class='op-cite-fixed-width'>https://pds-rings.seti.org/search/</span>)
+<br/><br/>(This encodes the URL <span class='op-cite-fixed-width'>https://opus.pds-rings.seti.org/</span>)
 </span>
 </p>
 <br clear="left"/>

--- a/requirements.txt
+++ b/requirements.txt
@@ -94,7 +94,7 @@ packaging==24.2
     #   pytest
 pdfkit==1.0.0
     # via -r requirements.in
-pillow==11.2.0
+pillow==11.2.1
     # via
     #   -r requirements.in
     #   rms-pdsfile


### PR DESCRIPTION
- Fixes #1404 
- Is a new database import required? N
- Were test and deploy scripts reviewed for necessary changes? Y
- Were any JavaScript or CSS files modified? N
  - If YES:
    - JSHINT run on all affected files: Y/NA
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y/NA
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): Y/NA
- Was the documentation reviewed for necessary changes or additions? NA

A page claimed that a QR code represented a certain URL.  It represented a different URL.  Fixed page and test