### PR TITLE
Overkill on Windows BUG

### DIFF
--- a/opus/application/test_api/api_test_helper.py
+++ b/opus/application/test_api/api_test_helper.py
@@ -7,9 +7,8 @@ import os
 import re
 import tarfile
 import zipfile
-from PIL import Image
+from PIL import Image, ImageChops
 
-import numpy as np
 import settings
 
 _RESPONSES_FILE_ROOT = 'test_api/responses/'
@@ -343,11 +342,9 @@ class ApiTestHelper:
             return
         image1 = Image.open(BytesIO(image1)).convert('RGB')
         image2 = Image.open(BytesIO(image2)).convert('RGB')
-        # Images must have the same size, and the same RGB bytes.
-        self.assertEqual(image1.size, image2.size)
-        array1, array2 = np.asarray(image1), np.asarray(image2)
-        self.assertTrue(np.array_equal(array1, array2))
+        # Must be the same size
+        self.assertEqual(image1.size, image2.size, "Image size mismatch")
 
-
-
-
+        # getbbox returns the bounds of the non-zero elements. None if all are zero.
+        difference = ImageChops.difference(image1, image2)
+        self.assertIsNone(difference.getbbox(), "Images differ")

--- a/opus/application/test_api/test_help_api.py
+++ b/opus/application/test_api/test_help_api.py
@@ -94,17 +94,10 @@ class ApiHelpTests(TestCase, ApiTestHelper):
         url = '/__help/citing.html'
         self._run_status_equal(url, 200)
 
-    if os.name == 'nt':  # pragma: no cover
-        @unittest.expectedFailure
-        def test__api_help_citing_qr(self):
-            "[test_help_api.py] /__help: citing qr"
-            url = '/__help/citing.html?searchurl=fred&stateurl=george'
-            self._run_html_equal_file(url, 'api_help_citing_qr.html')
-    else:  # pragma: no cover
-        def test__api_help_citing_qr(self):
-            "[test_help_api.py] /__help: citing qr"
-            url = '/__help/citing.html?searchurl=fred&stateurl=george'
-            self._run_html_equal_file(url, 'api_help_citing_qr.html')
+    def test__api_help_citing_qr(self):
+        "[test_help_api.py] /__help: citing qr"
+        url = '/__help/citing.html?searchurl=fred&stateurl=george'
+        self._run_html_equal_file(url, 'api_help_citing_qr.html', embedded_dynamic_image=True)
 
     def test__api_help_citing_pdf(self):
         "[test_help_api.py] /__help: citing pdf"

--- a/requirements.txt
+++ b/requirements.txt
@@ -94,7 +94,7 @@ packaging==24.2
     #   pytest
 pdfkit==1.0.0
     # via -r requirements.in
-pillow==11.2.0
+pillow==11.2.1
     # via
     #   -r requirements.in
     #   rms-pdsfile

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,9 @@
 #
 asgiref==3.8.1
     # via django
-boto3==1.37.25
+boto3==1.37.33
     # via rms-filecache
-botocore==1.37.25
+botocore==1.37.33
     # via
     #   boto3
     #   s3transfer
@@ -31,7 +31,7 @@ django==4.2.20
     #   -r requirements.in
     #   django-storages
     #   djangorestframework
-django-storages==1.14.5
+django-storages==1.14.6
     # via -r requirements.in
 djangorestframework==3.16.0
     # via -r requirements.in
@@ -58,7 +58,7 @@ google-crc32c==1.7.1
     #   google-resumable-media
 google-resumable-media==2.7.2
     # via google-cloud-storage
-googleapis-common-protos==1.69.2
+googleapis-common-protos==1.70.0
     # via google-api-core
 hurry-filesize==0.9
     # via -r requirements.in
@@ -94,7 +94,7 @@ packaging==24.2
     #   pytest
 pdfkit==1.0.0
     # via -r requirements.in
-pillow==11.2.0
+pillow==11.2.1
     # via
     #   -r requirements.in
     #   rms-pdsfile
@@ -142,7 +142,7 @@ pytz==2025.2
     # via -r requirements.in
 pyyaml==6.0.2
     # via -r requirements.in
-qrcode==8.0
+qrcode==8.1
     # via -r requirements.in
 regex==2024.11.6
     # via -r requirements.in
@@ -187,9 +187,9 @@ six==1.17.0
     # via python-dateutil
 sqlparse==0.5.3
     # via django
-typing-extensions==4.13.0
+typing-extensions==4.13.2
     # via rms-filecache
-urllib3==2.3.0
+urllib3==2.4.0
     # via
     #   botocore
     #   requests


### PR DESCRIPTION
- Fixes #1405 
- Is a new database import required? N
- Were test and deploy scripts reviewed for necessary changes? Y
- Were any JavaScript or CSS files modified? N
  - If YES:
    - JSHINT run on all affected files: Y/NA
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y/NA
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): Y/NA

Possible overkill.  If an HTML page has a dynamic PNG file embedded, we pull out the PNG bytes and compare them as images.  Perhaps a bit overkill.

I also changed PIL version directly, in order to get the tests to pass.