### PR TITLE
Temporarily comment out PDS4 shelf usage in main_opus_import.py

### DIFF
--- a/opus/import/main_opus_import.py
+++ b/opus/import/main_opus_import.py
@@ -418,9 +418,10 @@ try: # Top-level exception handling so we always log what's going on
 
     if not impglobals.ARGUMENTS.dont_use_shelves_only:
         Pds3File.use_shelves_only()
-        Pds4File.use_shelves_only()
+        # TODO: uncomment this and line 424 when PDS4 shelves files are used
+        # Pds4File.use_shelves_only()
     Pds3File.require_shelves(True)
-    Pds4File.require_shelves(True)
+    # Pds4File.require_shelves(True)
     if impglobals.ARGUMENTS.override_pds3_data_dir:
         Pds3File.preload(impglobals.ARGUMENTS.override_pds3_data_dir)
     else:


### PR DESCRIPTION
- Disable PDS4 shelves use for now
- Is a new database import required? Y
- Were test and deploy scripts reviewed for necessary changes? NA
- Were any JavaScript or CSS files modified? N
  - If YES:
    - JSHINT run on all affected files: NA
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: NA
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): NA
- Was the documentation reviewed for necessary changes or additions? NA
  - About
  - Getting Started
  - FAQ
  - API Guide
  - Tooltips
  - Import/database schema

Description of changes:
Comment out line line 421, 424 in `main_opus_import.py`

Known problems:
NA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified PDS shelf-file handling in the OPUS import pipeline. PDS3 shelf requirements remain unchanged, while PDS4 shelf functionality adjustments have been made with plans for future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->